### PR TITLE
fix header typo

### DIFF
--- a/courses/min201/de.md
+++ b/courses/min201/de.md
@@ -1,3 +1,4 @@
+---
 name: Einführung in das Bitcoin-Mining
 goal: Das Funktionieren der Mining-Branche durch praktische Übungen zur Wiederverwendung von ASICs verstehen.
 objectives:
@@ -5,6 +6,7 @@ objectives:
   - Die Mining-Branche verstehen
   - Einen S9-Miner in eine Heizung umwandeln
   - Den ersten Satoshi minen
+---
 
 # Ihre ersten Schritte im Mining!
 

--- a/courses/min201/de.md
+++ b/courses/min201/de.md
@@ -1,6 +1,6 @@
 name: Einführung in das Bitcoin-Mining
 goal: Das Funktionieren der Mining-Branche durch praktische Übungen zur Wiederverwendung von ASICs verstehen.
-Objectives:
+objectives:
   - Die Theorie des Minings verstehen
   - Die Mining-Branche verstehen
   - Einen S9-Miner in eine Heizung umwandeln

--- a/courses/min201/en.md
+++ b/courses/min201/en.md
@@ -1,6 +1,6 @@
 name: Introduction to Bitcoin Mining
 goal: Understand the functioning of the mining industry through a practical exercise of reusing ASICs.
-Objectives:
+objectives:
   - Understand the theory behind mining
   - Understand the mining industry
   - Transform an S9 into a heater

--- a/courses/min201/en.md
+++ b/courses/min201/en.md
@@ -1,3 +1,4 @@
+---
 name: Introduction to Bitcoin Mining
 goal: Understand the functioning of the mining industry through a practical exercise of reusing ASICs.
 objectives:
@@ -5,6 +6,7 @@ objectives:
   - Understand the mining industry
   - Transform an S9 into a heater
   - Mine your first satoshi
+---
 
 # Your first steps in mining!
 

--- a/courses/min201/es.md
+++ b/courses/min201/es.md
@@ -1,3 +1,4 @@
+---
 name: Introducción a la Minería de Bitcoin
 goal: Comprender el funcionamiento de la industria minera a través de un ejercicio práctico de reutilización de ASICs.
 objectives:
@@ -5,6 +6,7 @@ objectives:
   - Comprender la industria minera
   - Convertir un S9 en calefacción
   - Minar el primer satoshi
+---
 
 # ¡Tus primeros pasos en la minería!
 

--- a/courses/min201/es.md
+++ b/courses/min201/es.md
@@ -1,6 +1,6 @@
 name: Introducción a la Minería de Bitcoin
 goal: Comprender el funcionamiento de la industria minera a través de un ejercicio práctico de reutilización de ASICs.
-Objectives:
+objectives:
   - Comprender la teoría sobre la minería
   - Comprender la industria minera
   - Convertir un S9 en calefacción

--- a/courses/min201/fr.md
+++ b/courses/min201/fr.md
@@ -1,7 +1,7 @@
 ---
 name: Introduction au Minage de Bitcoin
 goal: Comprendre le fonctionnement de l'industrie du minage à travers un exercice pratique de réutilisation d'ASICs.
-Objectives:
+objectives:
   - Comprendre la théorie sur le minage
   - Comprendre l'industrie du minage
   - Transformer un S9 en chauffage

--- a/courses/min201/it.md
+++ b/courses/min201/it.md
@@ -1,6 +1,6 @@
 name: Introduzione al Mining di Bitcoin
 goal: Comprendere il funzionamento dell'industria del mining attraverso un esercizio pratico di riutilizzo degli ASIC.
-Objectives:
+objectives:
   - Comprendere la teoria del mining
   - Comprendere l'industria del mining
   - Trasformare un S9 in un riscaldamento

--- a/courses/min201/it.md
+++ b/courses/min201/it.md
@@ -1,3 +1,4 @@
+---
 name: Introduzione al Mining di Bitcoin
 goal: Comprendere il funzionamento dell'industria del mining attraverso un esercizio pratico di riutilizzo degli ASIC.
 objectives:
@@ -5,6 +6,7 @@ objectives:
   - Comprendere l'industria del mining
   - Trasformare un S9 in un riscaldamento
   - Estrarre il primo satoshi
+--- 
 
 # I tuoi primi passi nel mining!
 

--- a/courses/min201/pt.md
+++ b/courses/min201/pt.md
@@ -1,3 +1,4 @@
+---
 name: Introdução à Mineração de Bitcoin
 goal: Compreender o funcionamento da indústria de mineração através de um exercício prático de reutilização de ASICs.
 objectives:
@@ -5,6 +6,7 @@ objectives:
   - Compreender a indústria de mineração
   - Transformar um S9 em aquecedor
   - Minerar o primeiro satoshi
+---
 
 # Seus primeiros passos na mineração!
 

--- a/courses/min201/pt.md
+++ b/courses/min201/pt.md
@@ -1,6 +1,6 @@
 name: Introdução à Mineração de Bitcoin
 goal: Compreender o funcionamento da indústria de mineração através de um exercício prático de reutilização de ASICs.
-Objectives:
+objectives:
   - Compreender a teoria da mineração
   - Compreender a indústria de mineração
   - Transformar um S9 em aquecedor


### PR DESCRIPTION
Find out that there was initially a typo in the course header: the `objectives` property was written with capital "O". I've therefore corrected it.

Also, the LLM-Translator used for the batch translation tends to forget about the header delimiters, so I've added them. 