### PR TITLE
resources/builders/wallet-of-satoshi - description fix

### DIFF
--- a/resources/builders/wallet-of-satoshi/builder.yml
+++ b/resources/builders/wallet-of-satoshi/builder.yml
@@ -4,8 +4,8 @@ links:
   website: https://www.walletofsatoshi.com/
   twitter: https://twitter.com/walletofsatoshi
 tags:
-  - marchand
-  - bitcoi only
+  - custodial
+  - bitcoin-only
   - LN wallet
 
 category: Wallet

--- a/resources/builders/wallet-of-satoshi/de.yml
+++ b/resources/builders/wallet-of-satoshi/de.yml
@@ -1,5 +1,5 @@
 description: |
-  Das einfachste Bitcoin Lightning Wallet der Welt.
+  Das verwahrbrieftasche einfachste Bitcoin Lightning Wallet der Welt.
   
 contributors:
   - rabbit-hole

--- a/resources/builders/wallet-of-satoshi/en.yml
+++ b/resources/builders/wallet-of-satoshi/en.yml
@@ -1,5 +1,5 @@
 description: |
-  The world's simplest Bitcoin Lightning wallet.
+  The world's simplest custodial Bitcoin Lightning wallet.
   
 contributors:
   - rabbit-hole

--- a/resources/builders/wallet-of-satoshi/es.yml
+++ b/resources/builders/wallet-of-satoshi/es.yml
@@ -1,4 +1,4 @@
 description: |
-  La cartera de Bitcoin Lightning más simple del mundo.
+  La custodio cartera de Bitcoin Lightning más simple del mundo.
 contributors:
   - rabbit-hole

--- a/resources/builders/wallet-of-satoshi/fr.yml
+++ b/resources/builders/wallet-of-satoshi/fr.yml
@@ -1,5 +1,5 @@
 description: |
-  Le portefeuille Bitcoin Lightning le plus simple au monde.
+  Le de garde portefeuille Bitcoin Lightning le plus simple au monde.
   
 contributors:
   - rabbit-hole

--- a/resources/builders/wallet-of-satoshi/it.yml
+++ b/resources/builders/wallet-of-satoshi/it.yml
@@ -1,5 +1,5 @@
 description: |
-  Il portafoglio Bitcoin Lightning più semplice al mondo.
+  Il custodiale portafoglio Bitcoin Lightning più semplice al mondo.
   
 contributors:
   - rabbit-hole

--- a/resources/builders/wallet-of-satoshi/pt.yml
+++ b/resources/builders/wallet-of-satoshi/pt.yml
@@ -1,5 +1,5 @@
 description: |
-  A carteira Bitcoin Lightning mais simples do mundo.
+  A carteira custodial Bitcoin Lightning mais simples do mundo.
   
 contributors:
   - rabbit-hole

--- a/tutorials/wallet/wasabi/tutorial.yml
+++ b/tutorials/wallet/wasabi/tutorial.yml
@@ -2,7 +2,7 @@ builder: Wasabi Wallet
 
 level: advanced
 
-category: mobile
+category: desktop
 
 tags:
   - open-source


### PR DESCRIPTION
This PR:
-  fix description of Wallet of Satoshi in resources/builders path.
Just adding word "custodial" to a description to all languages.
I consider it to be important.

- typo fix of resources/builders/wallet-of-satoshi/builder.yml file.

- fix wasabi wallet category to desktop