### PR TITLE
fix invalid property values

### DIFF
--- a/quizzes/questions/491/en.yml
+++ b/quizzes/questions/491/en.yml
@@ -1,8 +1,8 @@
 question: Is it recommended to memorize a passphrase or mnemonic phrase for a Bitcoin
   wallet?
-answer: false
+answer: This is false
 wrong_answers:
-  - true
+  - This is true
   - It depends on the length of the passphrase or mnemonic phrase
   - It depends on the complexity of the passphrase or mnemonic phrase
 explanation: |

--- a/quizzes/questions/530/en.yml
+++ b/quizzes/questions/530/en.yml
@@ -1,8 +1,8 @@
 question: Is it possible to reverse from a Bitcoin address to the public key, or from
   the public key to the private key?
-answer: false
+answer: This is false
 wrong_answers:
-  - true
+  - This is true
   - Only from the public key to the private key
   - Only from the address to the public key
 explanation: |

--- a/quizzes/questions/535/en.yml
+++ b/quizzes/questions/535/en.yml
@@ -1,7 +1,7 @@
 question: Does using a Bitcoin address save space in the blocks?
-answer: false
+answer: This is false
 wrong_answers:
-  - true
+  - This is true
   - Only if the address is compressed
   - Only if the address is hashed
 explanation: |

--- a/quizzes/questions/641/en.yml
+++ b/quizzes/questions/641/en.yml
@@ -1,10 +1,10 @@
 question: Does the capacity of a Lightning payment channel limit the total number
   of transactions or the total volume of Bitcoin that can be transmitted through the
   channel?
-answer: false
+answer: This is false
 wrong_answers:
-  - true
-  - Only in some cases
+  - This is true
+  - This is only true in some cases
   - It depends on the Bitcoin network
 explanation: |
   Although the capacity of a Lightning payment channel is fixed, this does

--- a/quizzes/questions/794/es.yml
+++ b/quizzes/questions/794/es.yml
@@ -5,5 +5,7 @@ wrong_answers:
   - Permite a los usuarios bloquear anuncios en línea.
   - Permite a los usuarios acceder a Internet sin utilizar datos.
 explanation: |
-  
+  El protocolo HTTPS se utiliza para cifrar datos en sitios web, garantizando que
+  los datos intercambiados entre el usuario y el sitio web son seguros. Esto ayuda a proteger
+  de que terceros intercepten los datos.  
 reviewed: false

--- a/quizzes/questions/804/de.yml
+++ b/quizzes/questions/804/de.yml
@@ -5,5 +5,7 @@ wrong_answers:
   - Die Software wird keine neuen Funktionen haben.
   - Die Software wird mehr Systemressourcen verbrauchen.
 explanation: |
-  
+  Geknackte Software, die nicht aktualisiert werden kann, stellt eine doppelte potenzielle
+  Bedrohung dar. Sie kann einen Virus einschleppen, wenn sie illegal von einer verdächtigen Website heruntergeladen wird
+  und sie kann gegen neue Angriffsformen unsicher sein.
 reviewed: false

--- a/quizzes/questions/804/fr.yml
+++ b/quizzes/questions/804/fr.yml
@@ -5,5 +5,7 @@ wrong_answers:
   - Le logiciel n'aura pas de nouvelles fonctionnalités.
   - Le logiciel consommera plus de ressources système.
 explanation: |
-  
+  Les logiciels défectueux qui ne peuvent pas être mis à jour représentent une double menace potentielle.
+  menace potentielle. Il peut apporter un virus lors de son téléchargement illégal à partir d'un site web suspect
+  et il peut ne pas être sécurisé contre les nouvelles formes d'attaque.
 reviewed: false

--- a/quizzes/questions/809/en.yml
+++ b/quizzes/questions/809/en.yml
@@ -1,7 +1,7 @@
 question: Do Linux and Mac often need antivirus?
-answer: false
+answer: This is false
 wrong_answers:
-  - true
+  - This is true
   - Only Linux needs antivirus.
   - Only Mac needs antivirus.
 explanation: |

--- a/quizzes/questions/809/it.yml
+++ b/quizzes/questions/809/it.yml
@@ -1,7 +1,7 @@
 question: Linux e Mac hanno spesso bisogno di antivirus?
-answer: false
+answer: È falso
 wrong_answers:
-  - true
+  - È vero
   - Solo Linux ha bisogno di antivirus.
   - Solo Mac ha bisogno di antivirus.
 explanation: |


### PR DESCRIPTION
I've updated some question files in order to remove invalid values. 
These invalid values were misused of `false` and `true` in `answer` and `wrong_answers` properties, and empty values for `explanation` property. 