### PR TITLE
re-index chapter for some secu101 quizzes

### DIFF
--- a/quizzes/questions/831/question.yml
+++ b/quizzes/questions/831/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: easy
 duration: 15
 author: DecouvreBitcoin

--- a/quizzes/questions/832/question.yml
+++ b/quizzes/questions/832/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: easy
 duration: 15
 author: DecouvreBitcoin

--- a/quizzes/questions/833/question.yml
+++ b/quizzes/questions/833/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: intermediate
 duration: 30
 author: DecouvreBitcoin

--- a/quizzes/questions/834/question.yml
+++ b/quizzes/questions/834/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: intermediate
 duration: 30
 author: DecouvreBitcoin

--- a/quizzes/questions/835/question.yml
+++ b/quizzes/questions/835/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: intermediate
 duration: 30
 author: DecouvreBitcoin

--- a/quizzes/questions/836/question.yml
+++ b/quizzes/questions/836/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: hard
 duration: 45
 author: DecouvreBitcoin

--- a/quizzes/questions/837/question.yml
+++ b/quizzes/questions/837/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: hard
 duration: 45
 author: DecouvreBitcoin

--- a/quizzes/questions/838/question.yml
+++ b/quizzes/questions/838/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: hard
 duration: 45
 author: DecouvreBitcoin

--- a/quizzes/questions/850/question.yml
+++ b/quizzes/questions/850/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: easy
 duration: 15
 author: DecouvreBitcoin

--- a/quizzes/questions/851/question.yml
+++ b/quizzes/questions/851/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: hard
 duration: 45
 author: DecouvreBitcoin

--- a/quizzes/questions/852/question.yml
+++ b/quizzes/questions/852/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: intermediate
 duration: 30
 author: DecouvreBitcoin

--- a/quizzes/questions/855/question.yml
+++ b/quizzes/questions/855/question.yml
@@ -1,6 +1,6 @@
 course: secu101
 part: 4
-chapter: 4
+chapter: 3
 difficulty: intermediate
 duration: 30
 author: DecouvreBitcoin


### PR DESCRIPTION
Due to the addition of the second part, the chapter 4 of part 2 was removed but the corresponding quizzes were not updated. Here's the fix. 