### PR TITLE
RoninDojo v2 tutorial update: veth* fix

### DIFF
--- a/tutorials/node/ronin-dojo-v2/de.md
+++ b/tutorials/node/ronin-dojo-v2/de.md
@@ -233,6 +233,34 @@ Sie werden aufgefordert, Ihr Benutzerpasswort zu bestätigen. Geben Sie es ein u
 Herzlichen Glückwunsch! Ihr RoninDojo v2 Node ist jetzt konfiguriert und einsatzbereit. Er wird mit dem IBD (*Initial Block Download*) beginnen, um die Bitcoin-Blockchain vom Genesis-Block an herunterzuladen und zu verifizieren. Dieser Schritt umfasst das Abrufen aller seit dem 3. Januar 2009 getätigten Bitcoin-Transaktionen und nimmt einige Zeit in Anspruch. Sobald die Blockchain vollständig heruntergeladen ist, wird der Indexer fortfahren, die Datenbank zu komprimieren. Die Dauer des IBD kann erheblich variieren. Ihr RoninDojo Node wird voll funktionsfähig sein, sobald dieser Prozess abgeschlossen ist.
 **Wenn Sie von einem alten RoninDojo v1 Node** auf diese neue Version mit diesem Tutorial migrieren und dabei die gleiche SSD behalten, sollte Ihr Node automatisch die vorhandenen Daten auf der Festplatte erkennen und wiederverwenden, sodass Sie den IBD nicht erneut durchführen müssen. In diesem Fall müssen Sie nur darauf warten, dass Ihr Node mit den neuesten Blöcken resynchronisiert wird.
 
+### Schritt 8: "veth* fix"
+Wenn Sie auf Ihrem RoninDojo v2 auf Raspberry Pi auf einen Fehler stoßen, bei dem Ihr Knoten nach einer problemlosen Installation plötzlich über SSH nicht mehr erreichbar ist, sich aber nach einem einfachen Neustart wieder erholt, dann müssen Sie diesen Schritt 8 befolgen. Dieser häufige Fehler kann leicht mit einer von der Gemeinschaft entwickelten Lösung behoben werden: dem "_veth fix_". Diese kleine Korrektur behebt dauerhaft die plötzlichen Verbindungsabbrüche. Hier erfahren Sie, wie Sie sie anwenden.
+
+Öffnen Sie ein neues Terminal auf Ihrem persönlichen Computer und stellen Sie eine SSH-Verbindung zu Ihrem Knoten her, indem Sie den folgenden Befehl verwenden: 
+`SSH ronindojo@[IP]`
+
+Wenn beispielsweise die IP-Adresse Ihres Knotens `192.168.1.40` ist, wäre der passende Befehl: 
+`SSH ronindojo@192.168.1.40`
+
+Es wird Sie aufgefordert, das Benutzerpasswort einzugeben. Geben Sie es ein und drücken Sie `Enter`, um zu bestätigen. Sie gelangen dann zur RoninCLI-Schnittstelle. Verwenden Sie die Pfeiltasten Ihrer Tastatur, um zur Option `Exit RoninDojo` zu navigieren und drücken Sie `Enter`, um sie auszuwählen.
+
+An diesem Punkt befinden Sie sich im Terminal Ihres Knotens, mit einem Befehlsprompt ähnlich wie: `ronindojo@RoninDojo:~ $`. Um den veth* fix anzuwenden, geben Sie den folgenden Befehl ein und drücken Sie `Enter`: 
+`sudo nano /etc/dhcpcd.conf`
+
+Bestätigen Sie Ihr Passwort erneut und drücken Sie `Enter`.
+
+Sie gelangen zur Datei `dhcpcd.conf`. Sie müssen den folgenden Text kopieren, dabei das Sternchen einschließen, und ihn am Ende der Datei hinzufügen: 
+`denyinterfaces veth*`
+
+Um dies zu tun, bewegen Sie sich mit der Abwärtspfeil-Taste Ihrer Tastatur zum Ende der Datei und verwenden Sie dann die rechte Maustaste Ihrer Maus, um den Text auf einer unabhängigen Zeile einzufügen.
+
+Nachdem Sie den Text hinzugefügt haben, drücken Sie `ctrl X`, um den Vorgang zu starten, gefolgt von `ctrl Y`, um das Speichern der Änderungen zu bestätigen, und drücken Sie `Enter`, um den Vorgang abzuschließen und zum Befehlsprompt zurückzukehren. Um sicherzustellen, dass die Änderung korrekt angewendet wurde, öffnen Sie die Datei `dhcpcd.conf` erneut mit dem entsprechenden Befehl.
+
+Um die Anwendung der Korrektur abzuschließen, starten Sie Ihren Knoten neu, indem Sie ausführen: 
+`sudo reboot now`
+
+An diesem Punkt können Sie Ihr Terminal schließen. Lassen Sie dem RoninDojo genügend Zeit zum Neustarten, nach dem Sie sich über die grafische Benutzeroberfläche Ihres Browsers erneut verbinden sollten. Dieser Prozess sollte den aufgetretenen Fehler beheben.
+
 ## Wie verwenden Sie Ihren RoninDojo v2 Node?
 
 ### Verbinden Ihrer Wallet-Software mit Electrs

--- a/tutorials/node/ronin-dojo-v2/en.md
+++ b/tutorials/node/ronin-dojo-v2/en.md
@@ -242,6 +242,34 @@ Congratulations! Your RoninDojo v2 node is now configured and ready to use. It w
 
 **If you are migrating from an old RoninDojo v1 node** to this new version with this tutorial while keeping the same SSD, your node should automatically detect and reuse the existing data on the disk, sparing you the necessity of performing the IBD again. In this case, you will just need to wait for your node to resynchronize with the latest blocks.
 
+### Step 8: "veth* fix"
+If you encounter a bug with your RoninDojo v2 on Raspberry Pi, where after a hassle-free installation, your node suddenly becomes unreachable via SSH but recovers after a simple restart, then you need to follow this step 8. This common bug can be easily fixed with a solution developed by the community: the "_veth fix_". This minor correction permanently remedies the abrupt disconnections. Here's how to apply it.
+
+Open a new terminal on your personal computer and establish an SSH connection with your node using the following command: 
+`SSH ronindojo@[IP]`
+
+If, for example, your node's IP address is `192.168.1.40`, the appropriate command would be: 
+`SSH ronindojo@192.168.1.40`
+
+You will be prompted to enter the user password. Enter it and press `enter` to validate. You will then access the RoninCLI interface. Use your keyboard's arrows to navigate to the `Exit RoninDojo` option and press `enter` to select it.
+
+At this point, you are on your node's terminal, with a command prompt similar to: `ronindojo@RoninDojo:~ $`. To apply the veth* fix, type the following command and press `enter`: 
+`sudo nano /etc/dhcpcd.conf`
+
+Confirm your password again and press `enter`.
+
+You will arrive at the `dhcpcd.conf` file. You need to copy the following text, ensuring to include the asterisk, and add it to the bottom of the file: 
+`denyinterfaces veth*`
+
+To do this, move to the bottom of the file using the down arrow on your keyboard, then use the right click of your mouse to paste the text on an independent line.
+
+After adding the text, press `ctrl X` to start exiting, followed by `ctrl Y` to confirm saving the changes, and press `enter` to finalize and return to the command prompt. To ensure that the modification has been correctly applied, reopen the `dhcpcd.conf` file using the appropriate command.
+
+To complete the application of the fix, restart your node by executing: 
+`sudo reboot now`
+
+At this point, you can close your terminal. Allow the necessary time for your RoninDojo to restart, after which you should be able to reconnect via your browser's graphical interface. This process should fix the encountered bug.
+
 ## How to use your RoninDojo v2 node?
 
 ### Connecting your wallet software to Electrs

--- a/tutorials/node/ronin-dojo-v2/es.md
+++ b/tutorials/node/ronin-dojo-v2/es.md
@@ -233,6 +233,34 @@ Se te pedirá que confirmes tu contraseña de usuario. Ingrésala y valida presi
 ¡Felicidades! Tu nodo RoninDojo v2 ya está configurado y listo para usar. Comenzará su IBD (*Initial Block Download*, Descarga Inicial de Bloques), procediendo a descargar y verificar la blockchain de Bitcoin desde el bloque Génesis. Este paso implica recuperar todas las transacciones de Bitcoin realizadas desde el 3 de enero de 2009 y toma algo de tiempo. Una vez que la blockchain esté completamente descargada, el indexador procederá a comprimir la base de datos. La duración del IBD puede variar considerablemente. Tu nodo RoninDojo estará completamente operativo una vez que este proceso se haya completado.
 **Si estás migrando de un antiguo nodo RoninDojo v1** a esta nueva versión con este tutorial mientras mantienes el mismo SSD, tu nodo debería detectar automáticamente y reutilizar los datos existentes en el disco, ahorrándote la necesidad de realizar el IBD nuevamente. En este caso, solo necesitarás esperar a que tu nodo se resincronice con los últimos bloques.
 
+### Paso 8: "veth* fix"
+Si encuentras un error con tu RoninDojo v2 en Raspberry Pi, donde después de una instalación sin problemas, tu nodo de repente se vuelve inalcanzable vía SSH pero se recupera después de un simple reinicio, entonces necesitas seguir este paso 8. Este error común puede ser fácilmente solucionado con una solución desarrollada por la comunidad: el "_veth fix_". Esta pequeña corrección soluciona definitivamente las desconexiones abruptas. Aquí te explicamos cómo aplicarla.
+
+Abre un nuevo terminal en tu computadora personal y establece una conexión SSH con tu nodo utilizando el siguiente comando: 
+`SSH ronindojo@[IP]`
+
+Si, por ejemplo, la dirección IP de tu nodo es `192.168.1.40`, el comando apropiado sería: 
+`SSH ronindojo@192.168.1.40`
+
+Se te pedirá que introduzcas la contraseña del usuario. Ingrésala y presiona `enter` para validar. Luego accederás a la interfaz RoninCLI. Usa las flechas de tu teclado para navegar hasta la opción `Exit RoninDojo` y presiona `enter` para seleccionarla.
+
+En este punto, estás en el terminal de tu nodo, con un prompt similar a: `ronindojo@RoninDojo:~ $`. Para aplicar el veth* fix, escribe el siguiente comando y presiona `enter`: 
+`sudo nano /etc/dhcpcd.conf`
+
+Confirma tu contraseña nuevamente y presiona `enter`.
+
+Llegarás al archivo `dhcpcd.conf`. Necesitas copiar el texto siguiente, asegurándote de incluir el asterisco, y añadirlo al final del archivo: 
+`denyinterfaces veth*`
+
+Para hacerlo, muévete hasta el final del archivo usando la flecha hacia abajo de tu teclado, luego usa el clic derecho de tu ratón para pegar el texto en una línea independiente.
+
+Después de añadir el texto, presiona `ctrl X` para comenzar a salir, seguido de `ctrl Y` para confirmar el guardado de los cambios, y presiona `enter` para finalizar y volver al prompt de comandos. Para asegurarte de que la modificación ha sido aplicada correctamente, reabre el archivo `dhcpcd.conf` utilizando el comando apropiado.
+
+Para completar la aplicación de la corrección, reinicia tu nodo ejecutando: 
+`sudo reboot now`
+
+En este punto, puedes cerrar tu terminal. Deja el tiempo necesario para que tu RoninDojo se reinicie, tras lo cual deberías ser capaz de reconectarte a través de la interfaz gráfica de tu navegador. Este proceso debería solucionar el error encontrado.
+
 ## ¿Cómo usar tu nodo RoninDojo v2?
 
 ### Conectando tu software de billetera a Electrs

--- a/tutorials/node/ronin-dojo-v2/fr.md
+++ b/tutorials/node/ronin-dojo-v2/fr.md
@@ -253,6 +253,34 @@ Félicitations ! Votre nœud RoninDojo v2 est désormais configuré et prêt à 
 
 **Si vous procédez à la migration d'un ancien nœud RoninDojo v1** vers cette nouvelle version avec ce tutoriel tout en conservant le même SSD, votre nœud devrait automatiquement détecter et réutiliser les données existantes sur le disque, vous épargnant ainsi la nécessité de réaliser de nouveau l'IBD. Dans ce cas, il suffira d'attendre que votre nœud se resynchronise avec les derniers blocs.
 
+### Étape 8 : « veth* fix »
+Si vous rencontrez un bug avec votre RoninDojo v2 sur Raspberry Pi, où après une installation sans soucis, votre nœud devient subitement injoignable via SSH, mais se rétablit après un simple redémarrage, alors vous devez suivre cette étape 8. Ce bug fréquent peut être facilement corrigé grâce à une solution mise au point par la communauté : le « _veth fix_ ». Cette petite correction permet de remédier définitivement aux déconnexion intempestives. Voici comment l'appliquer.
+
+Ouvrez un nouveau terminal sur votre ordinateur personnel et établissez une connexion SSH avec votre nœud en utilisant la commande suivante :
+`SSH ronindojo@[IP]`
+
+Si, par exemple, l'adresse IP de votre nœud est `192.168.1.40`, la commande adéquate sera :
+`SSH ronindojo@192.168.1.40`
+
+Il vous sera demandé de saisir le mot de passe utilisateur. Entrez-le puis appuyez sur `entrer` pour valider. Vous accéderez alors à l'interface RoninCLI. Utilisez les flèches de votre clavier pour naviguer jusqu'à l'option `Exit RoninDojo` et appuyez sur `entrer` pour la sélectionner.
+
+À ce stade, vous vous trouvez sur le terminal de votre nœud, avec une invite de commande semblable à : `ronindojo@RoninDojo:~ $`. Pour appliquer le veth* fix, saisissez la commande suivante et appuyez sur `entrer` :
+`sudo nano /etc/dhcpcd.conf`
+
+Confirmez une nouvelle fois votre mot de passe et appuyez sur `entrer`.
+
+Vous arriverez sur le fichier `dhcpcd.conf`. Vous devez copier le texte suivant, en veillant à inclure l'astérisque, et l'ajouter tout en bas du fichier :
+`denyinterfaces veth*`
+
+Pour ce faire, déplacez-vous jusqu'au bas du fichier à l'aide de la flèche du bas de votre clavier, puis utilisez le clic droit de votre souris pour coller le texte sur une ligne indépendante.
+
+Après avoir ajouté le texte, pressez `ctrl X` pour commencer à quitter, suivi de `ctrl Y` pour confirmer l'enregistrement des modifications, et appuyez sur `entrer` pour finaliser et retourner à l'invite de commande. Pour vous assurer que la modification a été correctement appliquée, ouvrez à nouveau le fichier `dhcpcd.conf` en utilisant la commande appropriée.
+
+Pour terminer l'application du correctif, redémarrez votre nœud en exécutant :
+`sudo reboot now`
+
+À ce stade, vous pouvez fermer votre terminal. Laissez le temps nécessaire au redémarrage de votre RoninDojo, après quoi vous devriez être capable de vous reconnecter via l'interface graphique de votre navigateur. Ce processus devrait corriger le bug rencontré.
+
 ## Comment utiliser son nœud RoninDojo v2 ?
 
 ### Connecter ses logiciels de portefeuilles à Electrs

--- a/tutorials/node/ronin-dojo-v2/it.md
+++ b/tutorials/node/ronin-dojo-v2/it.md
@@ -233,6 +233,34 @@ Ti verrà chiesto di confermare la password dell'utente. Inseriscila e convalida
 Congratulazioni! Il tuo nodo RoninDojo v2 è ora configurato e pronto all'uso. Inizierà il suo IBD (*Initial Block Download*), procedendo con il download e la verifica della blockchain di Bitcoin a partire dal blocco Genesis. Questo passaggio comporta il recupero di tutte le transazioni Bitcoin effettuate dal 3 gennaio 2009 e richiede del tempo. Una volta che la blockchain è completamente scaricata, l'indicizzatore procederà a comprimere il database. La durata dell'IBD può variare notevolmente. Il tuo nodo RoninDojo sarà completamente operativo una volta completato questo processo.
 **Se stai migrando da un vecchio nodo RoninDojo v1** a questa nuova versione seguendo questa guida e mantenendo lo stesso SSD, il tuo nodo dovrebbe automaticamente rilevare e riutilizzare i dati esistenti sul disco, risparmiandoti la necessità di eseguire nuovamente l'IBD. In questo caso, dovrai solo attendere che il tuo nodo si risincronizzi con gli ultimi blocchi.
 
+### Passo 8: "veth* fix"
+Se incontri un bug con il tuo RoninDojo v2 su Raspberry Pi, dove dopo un'installazione senza problemi, il tuo nodo diventa improvvisamente irraggiungibile via SSH ma si riprende dopo un semplice riavvio, allora devi seguire questo passo 8. Questo bug comune può essere facilmente risolto con una soluzione sviluppata dalla comunità: il "_veth fix_". Questa piccola correzione rimedia definitivamente alle disconnessioni improvvise. Ecco come applicarla.
+
+Apri un nuovo terminale sul tuo computer personale e stabilisci una connessione SSH con il tuo nodo utilizzando il seguente comando:
+`SSH ronindojo@[IP]`
+
+Se, ad esempio, l'indirizzo IP del tuo nodo è `192.168.1.40`, il comando appropriato sarebbe: 
+`SSH ronindojo@192.168.1.40`
+
+Ti verrà chiesto di inserire la password utente. Inseriscila e premi `invio` per convalidare. Accederai quindi all'interfaccia RoninCLI. Usa le frecce della tua tastiera per navigare fino all'opzione `Exit RoninDojo` e premi `invio` per selezionarla.
+
+A questo punto, ti trovi sul terminale del tuo nodo, con un prompt dei comandi simile a: `ronindojo@RoninDojo:~ $`. Per applicare il veth* fix, digita il seguente comando e premi `invio`: 
+`sudo nano /etc/dhcpcd.conf`
+
+Conferma nuovamente la tua password e premi `invio`.
+
+Arriverai al file `dhcpcd.conf`. Devi copiare il seguente testo, assicurandoti di includere l'asterisco, e aggiungerlo in fondo al file: 
+`denyinterfaces veth*`
+
+Per farlo, spostati in fondo al file usando la freccia verso il basso sulla tua tastiera, poi usa il clic destro del tuo mouse per incollare il testo su una linea indipendente.
+
+Dopo aver aggiunto il testo, premi `ctrl X` per iniziare ad uscire, seguito da `ctrl Y` per confermare il salvataggio delle modifiche, e premi `invio` per finalizzare e ritornare al prompt dei comandi. Per assicurarti che la modifica sia stata applicata correttamente, riapri il file `dhcpcd.conf` utilizzando il comando appropriato.
+
+Per completare l'applicazione della correzione, riavvia il tuo nodo eseguendo: 
+`sudo reboot now`
+
+A questo punto, puoi chiudere il tuo terminale. Lascia il tempo necessario per il riavvio del tuo RoninDojo, dopo di che dovresti essere in grado di riconnetterti tramite l'interfaccia grafica del tuo browser. Questo processo dovrebbe risolvere il bug incontrato.
+
 ## Come usare il tuo nodo RoninDojo v2?
 
 ### Collegare il tuo software wallet a Electrs

--- a/tutorials/node/ronin-dojo-v2/pt.md
+++ b/tutorials/node/ronin-dojo-v2/pt.md
@@ -74,7 +74,7 @@ Finalmente, instale seu Raspberry Pi em seu gabinete. Esteja ciente, um passo po
 
 ## Como instalar o RoninDojo v2 em um Raspberry Pi 4?
 
-### Passo 1: Prepare o micro SD inicializável
+### Etapa 1: Prepare o micro SD inicializável
 Após montar seu hardware, o próximo passo é instalar o RoninDojo. Para isso, vamos preparar um cartão micro SD inicializável a partir do seu computador, gravando a imagem de disco apropriada nele.
 Você precisará usar o software _**Raspberry Pi Imager**_, projetado para facilitar o download, a configuração e a gravação de sistemas operacionais em um cartão micro SD para uso com um Raspberry Pi. Comece instalando este software no seu PC pessoal:
 - Para Ubuntu/Debian: https://downloads.raspberrypi.org/imager/imager_latest_amd64.deb
@@ -141,14 +141,14 @@ Quando a mensagem indicando o fim do processo aparecer, você pode remover o car
 
 ![writing micro SD completed](assets/pt/23.webp)
 
-### Passo 2: Complete a Montagem do Nó
+### Etapa 2: Complete a Montagem do Nó
 Agora você pode inserir o cartão micro SD na porta apropriada do seu Raspberry Pi.
 
 ![micro SD](assets/pt/24.webp)
 
 Em seguida, conecte o seu Raspberry Pi ao seu roteador usando o cabo Ethernet. Finalmente, ligue o seu nó conectando o cabo de energia e pressionando o botão de energia (se o seu setup incluir um).
 
-### Passo 3: Estabeleça uma Conexão SSH com o Nó
+### Etapa 3: Estabeleça uma Conexão SSH com o Nó
 Primeiro, é necessário encontrar o endereço IP do seu nó. Você tem a opção de usar uma ferramenta como _[Advanced IP Scanner](https://www.advanced-ip-scanner.com/)_ ou _[Angry IP Scanner](https://angryip.org/)_, ou verificar a interface de administração do seu roteador. O endereço IP deve estar no formato `192.168.1.??`. **Para todos os comandos seguintes, substitua `[IP]` pelo endereço IP real do seu nó**, (removendo os colchetes).
 
 Abra um terminal.
@@ -214,7 +214,7 @@ O próximo passo envolve a criação de uma senha de usuário, que será usada t
 Uma vez que estas ações estejam completas, aguarde a inicialização do seu nó. Você então acessará a interface web do RoninUI. Você está quase no final do processo, apenas alguns pequenos passos restantes!
 ![Ronin UI](assets/pt/29.webp)
 
-### Passo 7: Remover Credenciais Temporárias
+### Etapa 7: Remover Credenciais Temporárias
 Abra um novo terminal no seu computador pessoal e estabeleça uma conexão SSH com seu nó usando o seguinte comando:
 `SSH ronindojo@[IP]`
 
@@ -232,6 +232,34 @@ Neste ponto, você está no terminal do seu nó, com um prompt de comando simila
 Será solicitado que você confirme sua senha de usuário. Insira-a e valide pressionando `enter`. Aguarde a conclusão da operação, depois use o comando `exit` para sair do terminal.
 Parabéns! Seu nó RoninDojo v2 está agora configurado e pronto para uso. Ele iniciará seu IBD (*Initial Block Download*), procedendo para baixar e verificar a blockchain do Bitcoin desde o bloco Gênesis. Esta etapa envolve recuperar todas as transações de Bitcoin feitas desde 3 de janeiro de 2009 e leva algum tempo. Uma vez que a blockchain esteja totalmente baixada, o indexador prosseguirá para comprimir o banco de dados. A duração do IBD pode variar consideravelmente. Seu nó RoninDojo estará totalmente operacional uma vez que este processo seja concluído.
 **Se você está migrando de um antigo nó RoninDojo v1** para esta nova versão com este tutorial enquanto mantém o mesmo SSD, seu nó deve detectar automaticamente e reutilizar os dados existentes no disco, poupando-lhe a necessidade de realizar o IBD novamente. Neste caso, você só precisará esperar que seu nó ressincronize com os blocos mais recentes.
+
+### Etapa 8: "veth* fix"
+Se você encontrar um bug com seu RoninDojo v2 no Raspberry Pi, onde após uma instalação sem problemas, seu nó de repente se torna inacessível via SSH, mas se recupera após um simples reinício, então você precisa seguir esta etapa 8. Esse bug comum pode ser facilmente corrigido com uma solução desenvolvida pela comunidade: o "_veth fix_". Essa pequena correção resolve definitivamente as desconexões abruptas. Aqui está como aplicá-la.
+
+Abra um novo terminal no seu computador pessoal e estabeleça uma conexão SSH com seu nó usando o seguinte comando: 
+`SSH ronindojo@[IP]`
+
+Se, por exemplo, o endereço IP do seu nó for `192.168.1.40`, o comando apropriado seria: 
+`SSH ronindojo@192.168.1.40`
+
+Será solicitado que você insira a senha do usuário. Digite-a e pressione `enter` para validar. Você então acessará a interface RoninCLI. Use as setas do seu teclado para navegar até a opção `Exit RoninDojo` e pressione `enter` para selecioná-la.
+
+Neste ponto, você está no terminal do seu nó, com um prompt de comando semelhante a: `ronindojo@RoninDojo:~ $`. Para aplicar o veth* fix, digite o seguinte comando e pressione `enter`: 
+`sudo nano /etc/dhcpcd.conf`
+
+Confirme sua senha novamente e pressione `enter`.
+
+Você chegará ao arquivo `dhcpcd.conf`. Você precisa copiar o texto seguinte, garantindo incluir o asterisco, e adicioná-lo no final do arquivo: 
+`denyinterfaces veth*`
+
+Para fazer isso, mova-se para o final do arquivo usando a seta para baixo do seu teclado, em seguida, use o clique direito do seu mouse para colar o texto em uma linha independente.
+
+Após adicionar o texto, pressione `ctrl X` para começar a sair, seguido por `ctrl Y` para confirmar a gravação das modificações, e pressione `enter` para finalizar e retornar ao prompt de comando. Para garantir que a modificação foi aplicada corretamente, reabra o arquivo `dhcpcd.conf` usando o comando apropriado.
+
+Para completar a aplicação da correção, reinicie seu nó executando: 
+`sudo reboot now`
+
+Neste ponto, você pode fechar seu terminal. Permita o tempo necessário para o reinício do seu RoninDojo, após o qual você deve ser capaz de se reconectar via interface gráfica do seu navegador. Este processo deve corrigir o bug encontrado.
 
 ## Como usar seu nó RoninDojo v2?
 


### PR DESCRIPTION
Cette PR ajoute une partie supplémentaire au tutoriel déjà merge sur RoninDojo v2. La partie décrit comment résoudre un bug très fréquemment rencontré avec le « _veth* fix_ ».

Partie traduite dans les 6 langues.