### PR TITLE
Fixed broken link on Ronin V1 tutorial

### DIFF
--- a/tutorials/node/ronin-dojo/de.md
+++ b/tutorials/node/ronin-dojo/de.md
@@ -3,7 +3,7 @@ name: RoninDojo
 
 description: Installieren und nutzen Sie Ihren eigenen Bitcoin RoninDojo-Knoten.
 ---
-**ACHTUNG: Obwohl dieses Tutorial für die Installation von RoninDojo v1 noch funktioniert, ermöglicht es nicht, Ihren Knoten auf RoninDojo v2 zu aktualisieren. Obwohl diese Version noch funktioniert, wird sie nicht mehr aktualisiert. Um von den neuesten Verbesserungen und Funktionen zu profitieren, empfehle ich Ihnen dringend, unser spezielles Tutorial für die direkte Installation von RoninDojo v2 auf Ihrem Raspberry Pi zu konsultieren:** [https://planb.network/tutorials/privacy/ronin-dojo-v2](https://planb.network/tutorials/privacy/ronin-dojo-v2)
+**ACHTUNG: Obwohl dieses Tutorial für die Installation von RoninDojo v1 noch funktioniert, ermöglicht es nicht, Ihren Knoten auf RoninDojo v2 zu aktualisieren. Obwohl diese Version noch funktioniert, wird sie nicht mehr aktualisiert. Um von den neuesten Verbesserungen und Funktionen zu profitieren, empfehle ich Ihnen dringend, unser spezielles Tutorial für die direkte Installation von RoninDojo v2 auf Ihrem Raspberry Pi zu konsultieren:** [https://planb.network/tutorials/node/ronin-dojo-v2](https://planb.network/tutorials/node/ronin-dojo-v2)
 
 ---
 

--- a/tutorials/node/ronin-dojo/en.md
+++ b/tutorials/node/ronin-dojo/en.md
@@ -3,7 +3,7 @@ name: RoninDojo
 
 description: Installing and using your RoninDojo Bitcoin node.
 ---
-**WARNING: Although this tutorial remains operational for installing RoninDojo v1, it will not allow you to upgrade your node to RoninDojo v2. Thus, while this version remains functional, it is no longer updated. To benefit from the latest improvements and features, I strongly recommend consulting our dedicated tutorial for the direct installation of RoninDojo v2 on your Raspberry Pi:** [https://planb.network/tutorials/privacy/ronin-dojo-v2](https://planb.network/tutorials/privacy/ronin-dojo-v2)
+**WARNING: Although this tutorial remains operational for installing RoninDojo v1, it will not allow you to upgrade your node to RoninDojo v2. Thus, while this version remains functional, it is no longer updated. To benefit from the latest improvements and features, I strongly recommend consulting our dedicated tutorial for the direct installation of RoninDojo v2 on your Raspberry Pi:** [https://planb.network/tutorials/node/ronin-dojo-v2](https://planb.network/tutorials/node/ronin-dojo-v2)
 
 ---
 

--- a/tutorials/node/ronin-dojo/es.md
+++ b/tutorials/node/ronin-dojo/es.md
@@ -3,7 +3,7 @@ name: RoninDojo
 
 description: Instalar y utilizar su propio nodo Bitcoin RoninDojo.
 ---
-**ADVERTENCIA: Aunque este tutorial sigue siendo operativo para la instalación de RoninDojo v1, no te permitirá actualizar tu nodo a RoninDojo v2. Por lo tanto, aunque esta versión sigue siendo funcional, ya no se actualiza. Para beneficiarte de las últimas mejoras y características, te recomiendo encarecidamente que consultes nuestro tutorial dedicado a la instalación directa de RoninDojo v2 en tu Raspberry Pi:** [https://planb.network/tutorials/privacy/ronin-dojo-v2](https://planb.network/tutorials/privacy/ronin-dojo-v2)
+**ADVERTENCIA: Aunque este tutorial sigue siendo operativo para la instalación de RoninDojo v1, no te permitirá actualizar tu nodo a RoninDojo v2. Por lo tanto, aunque esta versión sigue siendo funcional, ya no se actualiza. Para beneficiarte de las últimas mejoras y características, te recomiendo encarecidamente que consultes nuestro tutorial dedicado a la instalación directa de RoninDojo v2 en tu Raspberry Pi:** [https://planb.network/tutorials/node/ronin-dojo-v2](https://planb.network/tutorials/node/ronin-dojo-v2)
 
 ---
 

--- a/tutorials/node/ronin-dojo/fr.md
+++ b/tutorials/node/ronin-dojo/fr.md
@@ -3,7 +3,7 @@ name: RoninDojo
 
 description: Installer et utiliser son nœud Bitcoin RoninDojo.
 ---
-**ATTENTION : Bien que ce tutoriel reste opérationnel pour l'installation de RoninDojo v1, il ne vous permettra pas de mettre à niveau votre nœud vers RoninDojo v2. Ainsi, bien que cette version demeure fonctionnelle, elle n'est plus tenue à jour. Pour bénéficier des dernières améliorations et fonctionnalités, je vous recommande fortement de consulter notre tutoriel dédié à l'installation directe de RoninDojo v2 sur votre Raspberry Pi :** https://planb.network/tutorials/privacy/ronin-dojo-v2
+**ATTENTION : Bien que ce tutoriel reste opérationnel pour l'installation de RoninDojo v1, il ne vous permettra pas de mettre à niveau votre nœud vers RoninDojo v2. Ainsi, bien que cette version demeure fonctionnelle, elle n'est plus tenue à jour. Pour bénéficier des dernières améliorations et fonctionnalités, je vous recommande fortement de consulter notre tutoriel dédié à l'installation directe de RoninDojo v2 sur votre Raspberry Pi :** [https://planb.network/tutorials/node/ronin-dojo-v2](https://planb.network/tutorials/node/ronin-dojo-v2)
 
 ---
 

--- a/tutorials/node/ronin-dojo/it.md
+++ b/tutorials/node/ronin-dojo/it.md
@@ -3,7 +3,7 @@ name: RoninDojo
 
 description: Installare e utilizzare il proprio nodo Bitcoin RoninDojo.
 ---
-**ATTENZIONE: Anche se questa guida rimane operativa per l'installazione di RoninDojo v1, non Le permetterà di aggiornare il Suo nodo a RoninDojo v2. Pertanto, anche se questa versione rimane funzionale, non è più aggiornata. Per beneficiare degli ultimi miglioramenti e funzionalità, Le raccomando vivamente di consultare la nostra guida dedicata all'installazione diretta di RoninDojo v2 sul Suo Raspberry Pi:** [https://planb.network/tutorials/privacy/ronin-dojo-v2](https://planb.network/tutorials/privacy/ronin-dojo-v2)
+**ATTENZIONE: Anche se questa guida rimane operativa per l'installazione di RoninDojo v1, non Le permetterà di aggiornare il Suo nodo a RoninDojo v2. Pertanto, anche se questa versione rimane funzionale, non è più aggiornata. Per beneficiare degli ultimi miglioramenti e funzionalità, Le raccomando vivamente di consultare la nostra guida dedicata all'installazione diretta di RoninDojo v2 sul Suo Raspberry Pi:** [https://planb.network/tutorials/node/ronin-dojo-v2](https://planb.network/tutorials/node/ronin-dojo-v2)
 
 ---
 

--- a/tutorials/node/ronin-dojo/pt.md
+++ b/tutorials/node/ronin-dojo/pt.md
@@ -3,7 +3,7 @@ name: RoninDojo
 
 description: Instalar e usar seu próprio nó Bitcoin RoninDojo.
 ---
-**ATENÇÃO: Embora este tutorial permaneça operacional para a instalação do RoninDojo v1, ele não permitirá que você atualize seu nó para o RoninDojo v2. Assim, embora esta versão continue funcional, ela não é mais atualizada. Para se beneficiar das últimas melhorias e funcionalidades, recomendo fortemente que consulte o nosso tutorial dedicado à instalação direta do RoninDojo v2 no seu Raspberry Pi:** [https://planb.network/tutorials/privacy/ronin-dojo-v2](https://planb.network/tutorials/privacy/ronin-dojo-v2)
+**ATENÇÃO: Embora este tutorial permaneça operacional para a instalação do RoninDojo v1, ele não permitirá que você atualize seu nó para o RoninDojo v2. Assim, embora esta versão continue funcional, ela não é mais atualizada. Para se beneficiar das últimas melhorias e funcionalidades, recomendo fortemente que consulte o nosso tutorial dedicado à instalação direta do RoninDojo v2 no seu Raspberry Pi:** [https://planb.network/tutorials/node/ronin-dojo-v2](https://planb.network/tutorials/node/ronin-dojo-v2)
 
 ---
 


### PR DESCRIPTION
Juste une petite erreur dans l'URL qui redirige depuis Ronin V1 vers Ronin V2.