### PR TITLE
Correction: coinjoin 7x7 to 8x8 in Boltzmann tutorial

### DIFF
--- a/tutorials/privacy/boltzmann-entropy/de.md
+++ b/tutorials/privacy/boltzmann-entropy/de.md
@@ -35,7 +35,7 @@ Der erste Indikator, den die Software berechnet, ist die Gesamtzahl der möglich
 
 Unter Berücksichtigung der Werte der in der Transaktion beteiligten UTXOs berechnet dieser Indikator die Anzahl der Wege, auf denen die Eingaben den Ausgaben zugeordnet werden können. Mit anderen Worten, er bestimmt die Anzahl der plausiblen Interpretationen, die eine Transaktion aus der Perspektive eines externen Beobachters, der sie analysiert, hervorrufen kann.
 Zum Beispiel präsentiert ein Coinjoin, strukturiert nach dem Whirlpool 5x5-Modell, `1.496` mögliche Kombinationen: ![KYCP](assets/4.webp)
-Ein Whirlpool Surge Cycle 7x7-Coinjoin bietet andererseits `9.934.563` mögliche Interpretationen: ![KYCP](assets/5.webp)
+Ein Whirlpool Surge Cycle 8x8-Coinjoin bietet andererseits `9.934.563` mögliche Interpretationen: ![KYCP](assets/5.webp)
 Im Gegensatz dazu wird eine traditionellere Transaktion mit 1 Eingabe und 2 Ausgaben nur eine einzige Interpretation präsentieren: ![KYCP](assets/6.webp)
 
 ### Entropie:
@@ -65,7 +65,7 @@ E = log2(1.496)
 E = 10,5469 Bits
 ```
 Somit zeigt diese Coinjoin-Transaktion eine Entropie von `10,5469 Bits`, was als sehr zufriedenstellend betrachtet wird. Je höher dieser Wert, desto mehr unterschiedliche Interpretationen lässt die Transaktion zu, wodurch ihr Datenschutzniveau gestärkt wird.
-Für eine 7x7-Coinjoin-Transaktion, die `9.934.563` Interpretationen bietet, wäre die Entropie:
+Für eine 8x8-Coinjoin-Transaktion, die `9.934.563` Interpretationen bietet, wäre die Entropie:
 ```
 C = 9.934.563
 E = log2(9.934.563)
@@ -128,11 +128,11 @@ E = 10.5469
 ED = 10.5469 / 10 = 1.054 Bits
 ```
 
-Berechnen wir auch die Entropiedichte für einen Whirlpool 7x7 Coinjoin:
+Berechnen wir auch die Entropiedichte für einen Whirlpool 8x8 Coinjoin:
 ```
-T = 7 + 7 = 14
+T = 8 + 8 = 16
 E = 23.244
-ED = 23.244 / 14 = 1.66 Bits
+ED = 23.244 / 16 = 1.453 bits
 ```
 
 ### Boltzmann-Score:
@@ -158,7 +158,7 @@ Gesamtinterpretationen = 1496
 Score = 512 / 1496 = 34%
 ```
 
-Nehmen wir das Beispiel eines Whirlpool 7x7 Coinjoin (Surge-Zyklus), würde die Boltzmann-Tabelle so aussehen:
+Nehmen wir das Beispiel eines Whirlpool 8x8 Coinjoin (Surge-Zyklus), würde die Boltzmann-Tabelle so aussehen:
 
 |       | OUT.0 | OUT.1 | OUT.2 | OUT.3 | OUT.4 | OUT.5 | OUT.6 | OUT.7 |
 |-------|-------|-------|-------|-------|-------|-------|-------|-------|

--- a/tutorials/privacy/boltzmann-entropy/en.md
+++ b/tutorials/privacy/boltzmann-entropy/en.md
@@ -35,7 +35,7 @@ The first indicator that the software calculates is the total number of possible
 
 Taking into account the values of the UTXOs involved in the transaction, this indicator calculates the number of ways in which the inputs can be associated with the outputs. In other words, it determines the number of plausible interpretations that a transaction can elicit from the perspective of an external observer analyzing it.
 For example, a coinjoin structured according to the Whirlpool 5x5 model presents `1,496` possible combinations: ![KYCP](assets/4.webp)
-A Whirlpool Surge Cycle 7x7 coinjoin, on the other hand, presents `9,934,563` possible interpretations: ![KYCP](assets/5.webp)
+A Whirlpool Surge Cycle 8x8 coinjoin, on the other hand, presents `9,934,563` possible interpretations: ![KYCP](assets/5.webp)
 In contrast, a more traditional transaction with 1 input and 2 outputs will only present a single interpretation: ![KYCP](assets/6.webp)
 
 ### Entropy:
@@ -66,7 +66,7 @@ E = log2(1,496)
 E = 10.5469 bits
 ```
 Thus, this coinjoin transaction displays an entropy of `10.5469 bits`, which is considered very satisfactory. The higher this value, the more different interpretations the transaction admits, thereby strengthening its level of privacy.
-For a 7x7 coinjoin transaction presenting `9,934,563` interpretations, the entropy would be:
+For a 8x8 coinjoin transaction presenting `9,934,563` interpretations, the entropy would be:
 ```
 C = 9,934,563
 E = log2(9,934,563)
@@ -131,11 +131,11 @@ E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
-Let's also calculate the entropy density for a Whirlpool 7x7 coinjoin:
+Let's also calculate the entropy density for a Whirlpool 8x8 coinjoin:
 ```
-T = 7 + 7 = 14
+T = 8 + 8 = 16
 E = 23.244
-ED = 23.244 / 14 = 1.66 bits
+ED = 23.244 / 16 = 1.453 bits
 ```
 
 ### Boltzmann Score:
@@ -161,7 +161,7 @@ Total Interpretations = 1496
 Score = 512 / 1496 = 34%
 ```
 
-Taking the example of a Whirlpool 7x7 coinjoin (surge cycle), the Boltzmann table would look like this:
+Taking the example of a Whirlpool 8x8 coinjoin (surge cycle), the Boltzmann table would look like this:
 
 |       | OUT.0 | OUT.1 | OUT.2 | OUT.3 | OUT.4 | OUT.5 | OUT.6 | OUT.7 |
 |-------|-------|-------|-------|-------|-------|-------|-------|-------|

--- a/tutorials/privacy/boltzmann-entropy/es.md
+++ b/tutorials/privacy/boltzmann-entropy/es.md
@@ -35,7 +35,7 @@ El primer indicador que calcula el software es el número total de combinaciones
 
 Teniendo en cuenta los valores de los UTXOs involucrados en la transacción, este indicador calcula el número de formas en que las entradas pueden asociarse con las salidas. En otras palabras, determina el número de interpretaciones plausibles que una transacción puede suscitar desde la perspectiva de un observador externo que la analiza.
 Por ejemplo, un coinjoin estructurado según el modelo Whirlpool 5x5 presenta `1,496` combinaciones posibles: ![KYCP](assets/4.webp)
-Un coinjoin de Ciclo de Aumento Whirlpool 7x7, por otro lado, presenta `9,934,563` interpretaciones posibles: ![KYCP](assets/5.webp)
+Un coinjoin de Ciclo de Aumento Whirlpool 8x8, por otro lado, presenta `9,934,563` interpretaciones posibles: ![KYCP](assets/5.webp)
 En contraste, una transacción más tradicional con 1 entrada y 2 salidas solo presentará una única interpretación: ![KYCP](assets/6.webp)
 
 ### Entropía:
@@ -65,7 +65,7 @@ E = log2(1,496)
 E = 10.5469 bits
 ```
 Así, esta transacción coinjoin muestra una entropía de `10.5469 bits`, lo cual se considera muy satisfactorio. Cuanto mayor sea este valor, más interpretaciones diferentes admite la transacción, fortaleciendo así su nivel de privacidad.
-Para una transacción coinjoin 7x7 que presenta `9,934,563` interpretaciones, la entropía sería:
+Para una transacción coinjoin 8x8 que presenta `9,934,563` interpretaciones, la entropía sería:
 ```
 C = 9,934,563
 E = log2(9,934,563)
@@ -128,11 +128,11 @@ E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
-Calculemos también la densidad de entropía para un coinjoin Whirlpool 7x7:
+Calculemos también la densidad de entropía para un coinjoin Whirlpool 8x8:
 ```
-T = 7 + 7 = 14
+T = 8 + 8 = 16
 E = 23.244
-ED = 23.244 / 14 = 1.66 bits
+ED = 23.244 / 16 = 1.453 bits
 ```
 
 ### Puntuación Boltzmann:
@@ -158,7 +158,7 @@ Interpretaciones Totales = 1496
 Puntaje = 512 / 1496 = 34%
 ```
 
-Tomando el ejemplo de un coinjoin Whirlpool 7x7 (ciclo de aumento), la tabla de Boltzmann se vería así:
+Tomando el ejemplo de un coinjoin Whirlpool 8x8 (ciclo de aumento), la tabla de Boltzmann se vería así:
 
 |       | OUT.0 | OUT.1 | OUT.2 | OUT.3 | OUT.4 | OUT.5 | OUT.6 | OUT.7 |
 |-------|-------|-------|-------|-------|-------|-------|-------|-------|

--- a/tutorials/privacy/boltzmann-entropy/fr.md
+++ b/tutorials/privacy/boltzmann-entropy/fr.md
@@ -37,7 +37,7 @@ En prenant en compte les valeurs des UTXO impliqués dans la transaction, cet in
 
 À titre d'exemple, un coinjoin structuré selon le modèle Whirlpool 5x5 présente `1 496` combinaisons possibles :
 ![KYCP](assets/4.webp)
-Un coinjoin Whirlpool Surge Cycle 7x7 présente lui `9 934 563` interprétations possibles :
+Un coinjoin Whirlpool Surge Cycle 8x8 présente lui `9 934 563` interprétations possibles :
 ![KYCP](assets/5.webp)
 En revanche, une transaction plus classique avec 1 input et 2 outputs présentera seulement une seule interprétation :
 ![KYCP](assets/6.webp)
@@ -72,7 +72,7 @@ E = 10.5469 bits
 
 Ainsi, cette transaction coinjoin affiche une entropie de `10.5469 bits`, ce qui est considéré comme très satisfaisant. Plus cette valeur est élevée, plus la transaction admet d'interprétations différentes, renforçant par conséquent son niveau de confidentialité.
 
-Pour une transaction coinjoin 7x7 présentant `9 934 563` interprétations, l'entropie serait :
+Pour une transaction coinjoin 8x8 présentant `9 934 563` interprétations, l'entropie serait :
 ```
 C = 9 934 563
 E = log2(9 934 563)
@@ -139,11 +139,11 @@ E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
-Calculons également la densité de l'entropie pour un coinjoin Whirlpool 7x7 :
+Calculons également la densité de l'entropie pour un coinjoin Whirlpool 8x8 :
 ```
-T = 7 + 7 = 14
+T = 8 + 8 = 16
 E = 23.244
-ED = 23.244 / 14 = 1.66 bits
+ED = 23.244 / 16 = 1.453 bits
 ```
 
 ### Score de Boltzmann :
@@ -171,7 +171,7 @@ Interprétations totales = 1496
 Score = 512 / 1496 = 34 %
 ```
 
-Si l'on reprend l'exemple d'un coinjoin Whirlpool 7x7 (surge cycle), le tableau de Boltzmann ressemblerait à cela :
+Si l'on reprend l'exemple d'un coinjoin Whirlpool 8x8 (surge cycle), le tableau de Boltzmann ressemblerait à cela :
 
 |       | OUT.0 | OUT.1 | OUT.2 | OUT.3 | OUT.4 | OUT.5 | OUT.6 | OUT.7 |
 |-------|-------|-------|-------|-------|-------|-------|-------|-------|

--- a/tutorials/privacy/boltzmann-entropy/it.md
+++ b/tutorials/privacy/boltzmann-entropy/it.md
@@ -35,7 +35,7 @@ Il primo indicatore che il software calcola è il numero totale di combinazioni 
 
 Tenendo conto dei valori degli UTXO coinvolti nella transazione, questo indicatore calcola il numero di modi in cui gli input possono essere associati agli output. In altre parole, determina il numero di interpretazioni plausibili che una transazione può suscitare dal punto di vista di un osservatore esterno che la analizza.
 Ad esempio, un coinjoin strutturato secondo il modello Whirlpool 5x5 presenta `1.496` combinazioni possibili: ![KYCP](assets/4.webp)
-Un coinjoin Whirlpool Surge Cycle 7x7, d'altra parte, presenta `9.934.563` interpretazioni possibili: ![KYCP](assets/5.webp)
+Un coinjoin Whirlpool Surge Cycle 8x8, d'altra parte, presenta `9.934.563` interpretazioni possibili: ![KYCP](assets/5.webp)
 Al contrario, una transazione più tradizionale con 1 input e 2 output presenterà una sola interpretazione: ![KYCP](assets/6.webp)
 
 ### Entropia:
@@ -65,7 +65,7 @@ E = log2(1,496)
 E = 10.5469 bit
 ```
 Quindi, questa transazione coinjoin mostra un'entropia di `10.5469 bit`, che è considerata molto soddisfacente. Più alto è questo valore, più diverse interpretazioni ammette la transazione, rafforzando così il suo livello di privacy.
-Per una transazione coinjoin 7x7 che presenta `9,934,563` interpretazioni, l'entropia sarebbe:
+Per una transazione coinjoin 8x8 che presenta `9,934,563` interpretazioni, l'entropia sarebbe:
 ```
 C = 9,934,563
 E = log2(9,934,563)
@@ -128,11 +128,11 @@ E = 10.5469
 ED = 10.5469 / 10 = 1.054 bit
 ```
 
-Calcoliamo anche la densità di entropia per un coinjoin Whirlpool 7x7:
+Calcoliamo anche la densità di entropia per un coinjoin Whirlpool 8x8:
 ```
-T = 7 + 7 = 14
+T = 8 + 8 = 16
 E = 23.244
-ED = 23.244 / 14 = 1.66 bit
+ED = 23.244 / 16 = 1.453 bits
 ```
 
 ### Punteggio di Boltzmann:
@@ -154,7 +154,7 @@ Interpretazioni Totali = 1496
 Punteggio = 512 / 1496 = 34%
 ```
 
-Prendendo l'esempio di un coinjoin Whirlpool 7x7 (ciclo di surge), la tabella di Boltzmann sarebbe così:
+Prendendo l'esempio di un coinjoin Whirlpool 8x8 (ciclo di surge), la tabella di Boltzmann sarebbe così:
 
 |       | OUT.0 | OUT.1 | OUT.2 | OUT.3 | OUT.4 | OUT.5 | OUT.6 | OUT.7 |
 |-------|-------|-------|-------|-------|-------|-------|-------|-------|

--- a/tutorials/privacy/boltzmann-entropy/pt.md
+++ b/tutorials/privacy/boltzmann-entropy/pt.md
@@ -35,7 +35,7 @@ O primeiro indicador que o software calcula é o número total de combinações 
 
 Levando em conta os valores dos UTXOs envolvidos na transação, este indicador calcula o número de maneiras pelas quais as entradas podem ser associadas às saídas. Em outras palavras, determina o número de interpretações plausíveis que uma transação pode suscitar do ponto de vista de um observador externo analisando-a.
 Por exemplo, um coinjoin estruturado de acordo com o modelo Whirlpool 5x5 apresenta `1,496` combinações possíveis: ![KYCP](assets/4.webp)
-Um coinjoin Whirlpool Surge Cycle 7x7, por outro lado, apresenta `9,934,563` interpretações possíveis: ![KYCP](assets/5.webp)
+Um coinjoin Whirlpool Surge Cycle 8x8, por outro lado, apresenta `9,934,563` interpretações possíveis: ![KYCP](assets/5.webp)
 Em contraste, uma transação mais tradicional com 1 entrada e 2 saídas apresentará apenas uma única interpretação: ![KYCP](assets/6.webp)
 
 ### Entropia:
@@ -64,7 +64,7 @@ E = log2(1,496)
 E = 10.5469 bits
 ```
 Assim, esta transação coinjoin exibe uma entropia de `10.5469 bits`, o que é considerado muito satisfatório. Quanto maior esse valor, mais diferentes interpretações a transação admite, fortalecendo assim seu nível de privacidade.
-Para uma transação coinjoin 7x7 apresentando `9,934,563` interpretações, a entropia seria:
+Para uma transação coinjoin 8x8 apresentando `9,934,563` interpretações, a entropia seria:
 ```
 C = 9,934,563
 E = log2(9,934,563)
@@ -127,11 +127,11 @@ E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
-Vamos também calcular a densidade de entropia para um coinjoin Whirlpool 7x7:
+Vamos também calcular a densidade de entropia para um coinjoin Whirlpool 8x8:
 ```
-T = 7 + 7 = 14
+T = 8 + 8 = 16
 E = 23.244
-ED = 23.244 / 14 = 1.66 bits
+ED = 23.244 / 16 = 1.453 bits
 ```
 
 ### Pontuação Boltzmann:
@@ -153,7 +153,7 @@ Total de Interpretações = 1496
 Pontuação = 512 / 1496 = 34%
 ```
 
-Tomando o exemplo de um Whirlpool 7x7 coinjoin (ciclo de aumento), a tabela Boltzmann ficaria assim:
+Tomando o exemplo de um Whirlpool 8x8 coinjoin (ciclo de aumento), a tabela Boltzmann ficaria assim:
 
 |       | OUT.0 | OUT.1 | OUT.2 | OUT.3 | OUT.4 | OUT.5 | OUT.6 | OUT.7 |
 |-------|-------|-------|-------|-------|-------|-------|-------|-------|


### PR DESCRIPTION
Correction d'une erreur dans mon tuto. J'ai utilisé tout le long un exemple de coinjoin 7x7, alors qu'il s'agissait en réalité d'un coinjoin 8x8 (j'ai oublié l'input n°0 ^^). Dans cette PR, j'ai ajusté les références, modifié les formules concernées et recalculé les données dans les 6 langues.