### PR TITLE
Specifying "bash" for code blocks

### DIFF
--- a/tutorials/privacy/boltzmann-entropy/de.md
+++ b/tutorials/privacy/boltzmann-entropy/de.md
@@ -49,7 +49,7 @@ Wenn eine Transaktion eine hohe Anzahl möglicher Kombinationen aufweist, ist es
 In der Praxis zeigt die Entropie, ob aus der Perspektive eines externen Beobachters eine Transaktion mehrere mögliche Interpretationen zulässt, basierend allein auf den Beträgen von Eingängen und Ausgängen, ohne andere externe oder interne Muster und Heuristiken zu berücksichtigen. Eine hohe Entropie ist dann gleichbedeutend mit besserer Vertraulichkeit für die Transaktion.
 
 Entropie wird als der binäre Logarithmus der Anzahl möglicher Kombinationen definiert. Hier ist die verwendete Formel:
-```
+```bash
 E: die Entropie der Transaktion
 C: die Anzahl möglicher Kombinationen für die Transaktion
 
@@ -59,21 +59,21 @@ E = log2(C)
 In der Mathematik entspricht der binäre Logarithmus (Basis-2-Logarithmus) der inversen Operation des Potenzierens von 2. Mit anderen Worten, der binäre Logarithmus von `x` ist der Exponent, zu dem `2` erhoben werden muss, um `x` zu erhalten. Dieser Indikator wird somit in Bits ausgedrückt.
 
 Nehmen wir das Beispiel der Berechnung der Entropie für eine Coinjoin-Transaktion, die nach dem Whirlpool 5x5-Modell strukturiert ist, das, wie zuvor erwähnt, eine Anzahl möglicher Kombinationen von `1.496` bietet:
-```
+```bash
 C = 1.496
 E = log2(1.496)
 E = 10,5469 Bits
 ```
 Somit zeigt diese Coinjoin-Transaktion eine Entropie von `10,5469 Bits`, was als sehr zufriedenstellend betrachtet wird. Je höher dieser Wert, desto mehr unterschiedliche Interpretationen lässt die Transaktion zu, wodurch ihr Datenschutzniveau gestärkt wird.
 Für eine 8x8-Coinjoin-Transaktion, die `9.934.563` Interpretationen bietet, wäre die Entropie:
-```
+```bash
 C = 9.934.563
 E = log2(9.934.563)
 E = 23,244 Bits
 ```
 
 Nehmen wir ein weiteres Beispiel mit einer konventionelleren Transaktion, die einen Eingang und zwei Ausgänge aufweist: [1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce](https://mempool.space/tx/1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce) Im Fall dieser Transaktion ist die einzige mögliche Interpretation: `(In.0) > (Out.0 ; Out.1)`. Folglich wird ihre Entropie auf `0` festgelegt:
-```
+```bash
 C = 1
 E = log2(1)
 E = 0 Bits
@@ -83,7 +83,7 @@ E = 0 Bits
 Der dritte Indikator, der vom Boltzmann-Rechner bereitgestellt wird, heißt `Wallet Efficiency`. Dieser Indikator bewertet die Effizienz der Transaktion, indem er sie mit der optimalen Transaktion vergleicht, die in einer identischen Konfiguration denkbar ist.
 Dies führt uns zur Diskussion des Konzepts der maximalen Entropie, die der höchsten Entropie entspricht, die eine spezifische Transaktionsstruktur theoretisch erreichen könnte. Die Effizienz der Transaktion wird dann berechnet, indem diese maximale Entropie mit der tatsächlichen Entropie der analysierten Transaktion konfrontiert wird.
 Die verwendete Formel lautet wie folgt:
-```
+```bash
 ER: die tatsächliche Entropie der Transaktion ausgedrückt in Bits
 EM: die maximal mögliche Entropie für eine gegebene Transaktionsstruktur ausgedrückt in Bits
 Ef: die Effizienz der Transaktion in Bits
@@ -92,14 +92,14 @@ Ef = ER - EM
 ```
 
 Zum Beispiel, für eine Whirlpool 5x5 Typ Coinjoin-Struktur, wird die maximale Entropie auf `10.5469` festgelegt:
-```
+```bash
 ER = 10.5469
 EM = 10.5469
 Ef = 10.5469 - 10.5469 = 0 Bits
 ```
 
 Dieser Indikator wird auch als Prozentsatz ausgedrückt, seine Formel lautet dann:
-```
+```bash
 CR: die tatsächliche Anzahl möglicher Kombinationen
 CM: die maximale Anzahl möglicher Kombinationen mit derselben Struktur
 Ef: die Effizienz ausgedrückt als Prozentsatz
@@ -113,7 +113,7 @@ Eine Effizienz von `100%` zeigt also an, dass die Transaktion ihr Potenzial für
 
 ### Entropiedichte:
 Der vierte Indikator ist die Entropiedichte, notiert im Werkzeug `Entropiedichte`. Sie bietet eine Perspektive auf die Entropie in Bezug auf jeden Input oder Output der Transaktion. Dieser Indikator erweist sich als nützlich für die Bewertung und den Vergleich der Effizienz von Transaktionen unterschiedlicher Größe. Um sie zu berechnen, teilt man einfach die Gesamtentropie der Transaktion durch die Gesamtzahl der beteiligten Inputs und Outputs:
-```
+```bash
 ED: die Entropiedichte ausgedrückt in Bits
 E: die Entropie der Transaktion ausgedrückt in Bits
 T: die Gesamtzahl der Inputs und Outputs in der Transaktion
@@ -122,14 +122,14 @@ ED = E / T
 ```
 
 Nehmen wir das Beispiel eines Whirlpool 5x5 Coinjoin:
-```
+```bash
 T = 5 + 5 = 10
 E = 10.5469
 ED = 10.5469 / 10 = 1.054 Bits
 ```
 
 Berechnen wir auch die Entropiedichte für einen Whirlpool 8x8 Coinjoin:
-```
+```bash
 T = 8 + 8 = 16
 E = 23.244
 ED = 23.244 / 16 = 1.453 bits
@@ -152,7 +152,7 @@ Nehmen wir wieder das Beispiel eines Whirlpool-Coinjoin, würde die Tabelle der 
 
 Hier können wir deutlich sehen, dass jede Eingabe die gleiche Chance hat, mit jedem Ausgang assoziiert zu werden, was die Vertraulichkeit der Transaktion erhöht.
 Die Berechnung des Boltzmann-Scores erfolgt durch Division der Anzahl der Interpretationen, in denen ein bestimmtes Ereignis auftritt, durch die Gesamtzahl der verfügbaren Interpretationen. Um also den Score zu bestimmen, der Eingabe Nr. 0 mit Ausgang Nr. 3 (`512` Interpretationen) verbindet, wird folgendes Verfahren verwendet:
-```
+```bash
 Interpretationen (IN.0 > OUT.3) = 512
 Gesamtinterpretationen = 1496
 Score = 512 / 1496 = 34%

--- a/tutorials/privacy/boltzmann-entropy/en.md
+++ b/tutorials/privacy/boltzmann-entropy/en.md
@@ -50,7 +50,7 @@ When a transaction presents a high number of possible combinations, it is often 
 In practice, entropy reveals whether, from the perspective of an external observer, a transaction presents multiple possible interpretations, based solely on the amounts of inputs and outputs, without considering other external or internal patterns and heuristics. High entropy is then synonymous with better confidentiality for the transaction.
 
 Entropy is defined as the binary logarithm of the number of possible combinations. Here is the formula used:
-```
+```bash
 E: the entropy of the transaction
 C: the number of possible combinations for the transaction
 
@@ -60,21 +60,21 @@ E = log2(C)
 In mathematics, the binary logarithm (base-2 logarithm) corresponds to the inverse operation of exponentiating 2. In other words, the binary logarithm of `x` is the exponent to which `2` must be raised to obtain `x`. This indicator is thus expressed in bits.
 
 Let's take the example of calculating the entropy for a coinjoin transaction structured according to the Whirlpool 5x5 model, which, as mentioned earlier, offers a number of possible combinations of `1,496`:
-```
+```bash
 C = 1,496
 E = log2(1,496)
 E = 10.5469 bits
 ```
 Thus, this coinjoin transaction displays an entropy of `10.5469 bits`, which is considered very satisfactory. The higher this value, the more different interpretations the transaction admits, thereby strengthening its level of privacy.
 For a 8x8 coinjoin transaction presenting `9,934,563` interpretations, the entropy would be:
-```
+```bash
 C = 9,934,563
 E = log2(9,934,563)
 E = 23.244 bits
 ```
 
 Let's take another example with a more conventional transaction, featuring one input and two outputs: [1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce](https://mempool.space/tx/1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce) In the case of this transaction, the only possible interpretation is: `(In.0) > (Out.0 ; Out.1)`. Consequently, its entropy is established at `0`:
-```
+```bash
 C = 1
 E = log2(1)
 E = 0 bits
@@ -86,7 +86,7 @@ The third indicator provided by the Boltzmann Calculator is named `Wallet Effici
 This leads us to discuss the concept of maximum entropy, which corresponds to the highest entropy a specific transaction structure could theoretically achieve. The transaction's efficiency is then calculated by confronting this maximum entropy with the actual entropy of the analyzed transaction.
 
 The formula used is as follows:
-```
+```bash
 ER: the actual entropy of the transaction expressed in bits
 EM: the maximum possible entropy for a given transaction structure expressed in bits
 Ef: the efficiency of the transaction in bits
@@ -95,14 +95,14 @@ Ef = ER - EM
 ```
 
 For example, for a Whirlpool 5x5 type coinjoin structure, the maximum entropy is set at `10.5469`:
-```
+```bash
 ER = 10.5469
 EM = 10.5469
 Ef = 10.5469 - 10.5469 = 0 bits
 ```
 
 This indicator is also expressed as a percentage, its formula is then:
-```
+```bash
 CR: the actual number of possible combinations
 CM: the maximum number of possible combinations with the same structure
 Ef: the efficiency expressed as a percentage
@@ -116,7 +116,7 @@ An efficiency of `100%` thus indicates that the transaction maximizes its potent
 
 ### Entropy Density:
 The fourth indicator is the entropy density, noted on the tool `Entropy Density`. It provides a perspective on the entropy relative to each input or output of the transaction. This indicator proves useful for evaluating and comparing the efficiency of transactions of different sizes. To calculate it, simply divide the total entropy of the transaction by the total number of inputs and outputs involved:
-```
+```bash
 ED: the entropy density expressed in bits
 E: the entropy of the transaction expressed in bits
 T: the total number of inputs and outputs in the transaction
@@ -125,14 +125,14 @@ ED = E / T
 ```
 
 Let's take the example of a Whirlpool 5x5 coinjoin:
-```
+```bash
 T = 5 + 5 = 10
 E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
 Let's also calculate the entropy density for a Whirlpool 8x8 coinjoin:
-```
+```bash
 T = 8 + 8 = 16
 E = 23.244
 ED = 23.244 / 16 = 1.453 bits
@@ -155,7 +155,7 @@ Taking the example of a Whirlpool coinjoin again, the table of conditional proba
 
 Here, we can clearly see that each input has an equal chance of being associated with any output, which enhances the confidentiality of the transaction.
 Calculating the Boltzmann score involves dividing the number of interpretations in which a certain event occurs by the total number of available interpretations. Thus, to determine the score associating input No. 0 with output No. 3 (`512` interpretations), the following procedure is used:
-```
+```bash
 Interpretations (IN.0 > OUT.3) = 512
 Total Interpretations = 1496
 Score = 512 / 1496 = 34%

--- a/tutorials/privacy/boltzmann-entropy/es.md
+++ b/tutorials/privacy/boltzmann-entropy/es.md
@@ -49,7 +49,7 @@ Cuando una transacción presenta un alto número de combinaciones posibles, a me
 En la práctica, la entropía revela si, desde la perspectiva de un observador externo, una transacción presenta múltiples interpretaciones posibles, basándose únicamente en las cantidades de entradas y salidas, sin considerar otros patrones y heurísticas externos o internos. Una alta entropía es entonces sinónimo de mejor confidencialidad para la transacción.
 
 La entropía se define como el logaritmo binario del número de combinaciones posibles. Aquí está la fórmula utilizada:
-```
+```bash
 E: la entropía de la transacción
 C: el número de combinaciones posibles para la transacción
 
@@ -59,21 +59,21 @@ E = log2(C)
 En matemáticas, el logaritmo binario (logaritmo base-2) corresponde a la operación inversa de elevar 2. En otras palabras, el logaritmo binario de `x` es el exponente al que se debe elevar `2` para obtener `x`. Este indicador se expresa así en bits.
 
 Tomemos el ejemplo de calcular la entropía para una transacción coinjoin estructurada según el modelo Whirlpool 5x5, que, como se mencionó anteriormente, ofrece un número de combinaciones posibles de `1,496`:
-```
+```bash
 C = 1,496
 E = log2(1,496)
 E = 10.5469 bits
 ```
 Así, esta transacción coinjoin muestra una entropía de `10.5469 bits`, lo cual se considera muy satisfactorio. Cuanto mayor sea este valor, más interpretaciones diferentes admite la transacción, fortaleciendo así su nivel de privacidad.
 Para una transacción coinjoin 8x8 que presenta `9,934,563` interpretaciones, la entropía sería:
-```
+```bash
 C = 9,934,563
 E = log2(9,934,563)
 E = 23.244 bits
 ```
 
 Tomemos otro ejemplo con una transacción más convencional, con una entrada y dos salidas: [1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce](https://mempool.space/tx/1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce) En el caso de esta transacción, la única interpretación posible es: `(In.0) > (Out.0 ; Out.1)`. En consecuencia, su entropía se establece en `0`:
-```
+```bash
 C = 1
 E = log2(1)
 E = 0 bits
@@ -83,7 +83,7 @@ E = 0 bits
 El tercer indicador proporcionado por el Calculador Boltzmann se denomina `Eficiencia de la Cartera`. Este indicador evalúa la eficiencia de la transacción comparándola con la transacción óptima concebible en una configuración idéntica.
 Esto nos lleva a discutir el concepto de entropía máxima, que corresponde a la mayor entropía que una estructura de transacción específica podría teóricamente alcanzar. La eficiencia de la transacción se calcula entonces confrontando esta entropía máxima con la entropía real de la transacción analizada.
 La fórmula utilizada es la siguiente:
-```
+```bash
 ER: la entropía real de la transacción expresada en bits
 EM: la entropía máxima posible para una estructura de transacción dada expresada en bits
 Ef: la eficiencia de la transacción en bits
@@ -92,14 +92,14 @@ Ef = ER - EM
 ```
 
 Por ejemplo, para una estructura de coinjoin tipo Whirlpool 5x5, la entropía máxima se establece en `10.5469`:
-```
+```bash
 ER = 10.5469
 EM = 10.5469
 Ef = 10.5469 - 10.5469 = 0 bits
 ```
 
 Este indicador también se expresa como un porcentaje, su fórmula es entonces:
-```
+```bash
 CR: el número real de combinaciones posibles
 CM: el número máximo de combinaciones posibles con la misma estructura
 Ef: la eficiencia expresada como un porcentaje
@@ -113,7 +113,7 @@ Una eficiencia del `100%` indica así que la transacción maximiza su potencial 
 
 ### Densidad de Entropía:
 El cuarto indicador es la densidad de entropía, anotada en la herramienta como `Densidad de Entropía`. Proporciona una perspectiva sobre la entropía relativa a cada entrada o salida de la transacción. Este indicador resulta útil para evaluar y comparar la eficiencia de transacciones de diferentes tamaños. Para calcularlo, simplemente se divide la entropía total de la transacción por el número total de entradas y salidas involucradas:
-```
+```bash
 ED: la densidad de entropía expresada en bits
 E: la entropía de la transacción expresada en bits
 T: el número total de entradas y salidas en la transacción
@@ -122,14 +122,14 @@ ED = E / T
 ```
 
 Tomemos el ejemplo de un coinjoin Whirlpool 5x5:
-```
+```bash
 T = 5 + 5 = 10
 E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
 Calculemos también la densidad de entropía para un coinjoin Whirlpool 8x8:
-```
+```bash
 T = 8 + 8 = 16
 E = 23.244
 ED = 23.244 / 16 = 1.453 bits
@@ -152,7 +152,7 @@ Tomando el ejemplo de un coinjoin Whirlpool nuevamente, la tabla de probabilidad
 
 Aquí, podemos ver claramente que cada entrada tiene la misma probabilidad de estar asociada con cualquier salida, lo que mejora la confidencialidad de la transacción.
 Calcular el puntaje de Boltzmann implica dividir el número de interpretaciones en las que ocurre un cierto evento por el número total de interpretaciones disponibles. Así, para determinar el puntaje que asocia la entrada N.º 0 con la salida N.º 3 (`512` interpretaciones), se utiliza el siguiente procedimiento:
-```
+```bash
 Interpretaciones (IN.0 > OUT.3) = 512
 Interpretaciones Totales = 1496
 Puntaje = 512 / 1496 = 34%

--- a/tutorials/privacy/boltzmann-entropy/fr.md
+++ b/tutorials/privacy/boltzmann-entropy/fr.md
@@ -54,7 +54,7 @@ Lorsqu'une transaction présente un nombre élevé de combinaisons possibles, il
 En pratique, l'entropie révèle si, du regard d'un observateur externe, une transaction présente de multiples interprétations possibles, basées uniquement sur les montants des entrées et sorties, sans prendre en compte d'autres paternes et heuristiques externes ou internes. Une grande entropie est alors synonyme d'une meilleure confidentialité pour la transaction.
 
 L'entropie est définie comme le logarithme binaire du nombre de combinaisons possibles. Voici la formule utilisée :
-```
+```bash
 E : l'entropie de la transaction
 C : le nombre de combinaisons possibles pour la transaction
 
@@ -64,7 +64,7 @@ E = log2(C)
 En mathématiques, le logarithme binaire (logarithme de base 2) correspond à l'opération inverse de l'exponentiation de 2. Autrement dit, le logarithme binaire de `x` est l'exposant auquel `2` doit être élevé pour obtenir `x`. Cet indicateur s'exprime donc en bits. 
 
 Prenons l'exemple du calcul de l'entropie pour une transaction coinjoin structurée selon le modèle Whirlpool 5x5, qui, comme mentionné précédemment, offre un nombre de combinaisons possibles de `1 496` :
-```
+```bash
 C = 1 496
 E = log2(1 496)
 E = 10.5469 bits
@@ -73,14 +73,14 @@ E = 10.5469 bits
 Ainsi, cette transaction coinjoin affiche une entropie de `10.5469 bits`, ce qui est considéré comme très satisfaisant. Plus cette valeur est élevée, plus la transaction admet d'interprétations différentes, renforçant par conséquent son niveau de confidentialité.
 
 Pour une transaction coinjoin 8x8 présentant `9 934 563` interprétations, l'entropie serait :
-```
+```bash
 C = 9 934 563
 E = log2(9 934 563)
 E = 23.244 bits
 ```
 
 Prenons un exemple supplémentaire avec une transaction plus conventionnelle, comportant un input et deux outputs : [1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce](https://mempool.space/tx/1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce) Dans le cas de cette transaction, l'unique interprétation possible est : `(In.0) > (Out.0 ; Out.1)`. Par conséquent, son entropie s'établit à `0` :
-```
+```bash
 C = 1
 E = log2(1)
 E = 0 bits
@@ -92,7 +92,7 @@ Le troisième indicateur fourni par le Calculateur Boltzmann est dénommé `Wall
 Cela nous amène à aborder le concept d'entropie maximale, qui correspond à l'entropie la plus élevée qu'une structure de transaction spécifique puisse théoriquement atteindre. L'efficacité de la transaction est alors calculée en confrontant cette entropie maximale à l'entropie réelle de la transaction analysée. 
 
 La formule utilisée est la suivante :
-```
+```bash
 ER : l'entropie réelle de la transaction exprimée en bits
 EM : l'entropie maximale possible pour une structure de transaction donnée exprimée en bits
 Ef : l'efficacité de la transaction en bits
@@ -101,14 +101,14 @@ Ef = ER - EM
 ```
 
 Par exemple, pour une structure de coinjoin de type Whirlpool 5x5, l'entropie maximale est fixée à `10.5469` :
-```
+```bash
 ER = 10.5469
 EM = 10.5469
 Ef = 10.5469 - 10.5469 = 0 bits
 ```
 
 Cet indicateur est également exprimé en pourcentage, sa formule est alors :
-```
+```bash
 CR : le nombre de combinaisons possibles réelles
 CM : le nombre de combinaisons possibles au maximum avec la même structure
 Ef : l'efficacité exprimée en pourcentage
@@ -124,7 +124,7 @@ Une efficacité de `100 %` indique donc que la transaction exploite au maximum s
 Le quatrième indicateur est la densité de l'entropie noté sur l'outil `Entropy Density`. Il offre une perspective sur l'entropie relative à chaque entrée ou sortie de la transaction. Cet indicateur s'avère utile pour évaluer et comparer l'efficacité de transactions de différentes tailles. 
 
 Pour le calculer, on divise simplement l'entropie totale de la transaction par le nombre total d'entrées et de sorties impliquées :
-```
+```bash
 ED : la densité de l'entropie exprimée en bits
 E : l'entropie de la transaction exprimée en bits
 T : le nombre total d'inputs et d'outputs dans la transaction
@@ -133,14 +133,14 @@ ED = E / T
 ```
 
 Prenons l'exemple d'un coinjoin de type Whirlpool 5x5 :
-```
+```bash
 T = 5 + 5 = 10
 E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
 Calculons également la densité de l'entropie pour un coinjoin Whirlpool 8x8 :
-```
+```bash
 T = 8 + 8 = 16
 E = 23.244
 ED = 23.244 / 16 = 1.453 bits
@@ -165,7 +165,7 @@ En reprenant l'exemple d'un coinjoin Whirlpool, le tableau des probabilités con
 On voit bien ici que chaque entrée présente une chance égale d'être associée à n'importe quelle sortie, ce qui renforce la confidentialité de la transaction. 
 
 Le calcul du score de Boltzmann consiste à diviser le nombre d'interprétations dans lesquelles un certain événement se manifeste par le nombre total d'interprétations disponibles. Ainsi, pour déterminer le score associant l'entrée n°0 à la sortie n°3 (`512` interprétations), on procède de la manière suivante :
-```
+```bash
 Interprétations (IN.0 > OUT.3) = 512
 Interprétations totales = 1496
 Score = 512 / 1496 = 34 %

--- a/tutorials/privacy/boltzmann-entropy/it.md
+++ b/tutorials/privacy/boltzmann-entropy/it.md
@@ -49,7 +49,7 @@ Quando una transazione presenta un alto numero di combinazioni possibili, è spe
 In pratica, l'entropia rivela se, dal punto di vista di un osservatore esterno, una transazione presenta molteplici interpretazioni possibili, basandosi unicamente sulle quantità di input e output, senza considerare altri schemi e euristiche esterni o interni. Un'alta entropia è quindi sinonimo di maggiore riservatezza per la transazione.
 
 L'entropia è definita come il logaritmo binario del numero di combinazioni possibili. Ecco la formula utilizzata:
-```
+```bash
 E: l'entropia della transazione
 C: il numero di combinazioni possibili per la transazione
 
@@ -59,21 +59,21 @@ E = log2(C)
 In matematica, il logaritmo binario (logaritmo in base 2) corrisponde all'operazione inversa dell'elevamento a potenza di 2. In altre parole, il logaritmo binario di `x` è l'esponente al quale `2` deve essere elevato per ottenere `x`. Questo indicatore è quindi espresso in bit.
 
 Prendiamo l'esempio del calcolo dell'entropia per una transazione coinjoin strutturata secondo il modello Whirlpool 5x5, che, come accennato in precedenza, offre un numero di combinazioni possibili di `1,496`:
-```
+```bash
 C = 1,496
 E = log2(1,496)
 E = 10.5469 bit
 ```
 Quindi, questa transazione coinjoin mostra un'entropia di `10.5469 bit`, che è considerata molto soddisfacente. Più alto è questo valore, più diverse interpretazioni ammette la transazione, rafforzando così il suo livello di privacy.
 Per una transazione coinjoin 8x8 che presenta `9,934,563` interpretazioni, l'entropia sarebbe:
-```
+```bash
 C = 9,934,563
 E = log2(9,934,563)
 E = 23.244 bit
 ```
 
 Prendiamo un altro esempio con una transazione più convenzionale, con un input e due output: [1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce](https://mempool.space/tx/1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce) Nel caso di questa transazione, l'unica interpretazione possibile è: `(In.0) > (Out.0 ; Out.1)`. Di conseguenza, la sua entropia è stabilita a `0`:
-```
+```bash
 C = 1
 E = log2(1)
 E = 0 bit
@@ -83,7 +83,7 @@ E = 0 bit
 Il terzo indicatore fornito dal Calcolatore Boltzmann è denominato `Efficienza del Portafoglio`. Questo indicatore valuta l'efficienza della transazione confrontandola con la transazione ottimale concepibile in una configurazione identica.
 Questo ci porta a discutere il concetto di entropia massima, che corrisponde all'entropia più alta che una specifica struttura di transazione potrebbe teoricamente raggiungere. L'efficienza della transazione viene quindi calcolata confrontando questa entropia massima con l'entropia effettiva della transazione analizzata.
 La formula utilizzata è la seguente:
-```
+```bash
 ER: l'entropia effettiva della transazione espressa in bit
 EM: l'entropia massima possibile per una data struttura di transazione espressa in bit
 Ef: l'efficienza della transazione in bit
@@ -92,14 +92,14 @@ Ef = ER - EM
 ```
 
 Per esempio, per una struttura di coinjoin di tipo Whirlpool 5x5, l'entropia massima è impostata a `10.5469`:
-```
+```bash
 ER = 10.5469
 EM = 10.5469
 Ef = 10.5469 - 10.5469 = 0 bit
 ```
 
 Questo indicatore è espresso anche in percentuale, la cui formula è quindi:
-```
+```bash
 CR: il numero effettivo di combinazioni possibili
 CM: il numero massimo di combinazioni possibili con la stessa struttura
 Ef: l'efficienza espressa in percentuale
@@ -113,7 +113,7 @@ Un'efficienza del `100%` indica quindi che la transazione massimizza il suo pote
 
 ### Densità di Entropia:
 Il quarto indicatore è la densità di entropia, indicata nello strumento come `Densità di Entropia`. Fornisce una prospettiva sull'entropia relativa a ciascun input o output della transazione. Questo indicatore si rivela utile per valutare e confrontare l'efficienza di transazioni di dimensioni diverse. Per calcolarlo, basta dividere l'entropia totale della transazione per il numero totale di input e output coinvolti:
-```
+```bash
 ED: la densità di entropia espressa in bit
 E: l'entropia della transazione espressa in bit
 T: il numero totale di input e output nella transazione
@@ -122,14 +122,14 @@ ED = E / T
 ```
 
 Prendiamo l'esempio di un coinjoin Whirlpool 5x5:
-```
+```bash
 T = 5 + 5 = 10
 E = 10.5469
 ED = 10.5469 / 10 = 1.054 bit
 ```
 
 Calcoliamo anche la densità di entropia per un coinjoin Whirlpool 8x8:
-```
+```bash
 T = 8 + 8 = 16
 E = 23.244
 ED = 23.244 / 16 = 1.453 bits
@@ -148,7 +148,7 @@ Prendendo di nuovo l'esempio di un coinjoin Whirlpool, la tabella delle probabil
 | Input 1 | 34%      | 34%      | 34%      | 34%      | 34%      |
 Qui, possiamo chiaramente vedere che ogni input ha la stessa probabilità di essere associato a qualsiasi output, il che aumenta la confidenzialità della transazione.
 Il calcolo del punteggio di Boltzmann prevede la divisione del numero di interpretazioni in cui si verifica un certo evento per il numero totale di interpretazioni disponibili. Pertanto, per determinare il punteggio che associa l'input numero 0 all'output numero 3 (`512` interpretazioni), si utilizza la seguente procedura:
-```
+```bash
 Interpretazioni (IN.0 > OUT.3) = 512
 Interpretazioni Totali = 1496
 Punteggio = 512 / 1496 = 34%

--- a/tutorials/privacy/boltzmann-entropy/pt.md
+++ b/tutorials/privacy/boltzmann-entropy/pt.md
@@ -48,7 +48,7 @@ Quando uma transação apresenta um alto número de combinações possíveis, é
 Na prática, a entropia revela se, do ponto de vista de um observador externo, uma transação apresenta múltiplas interpretações possíveis, baseando-se apenas nas quantidades de entradas e saídas, sem considerar outros padrões e heurísticas externos ou internos. Alta entropia é então sinônimo de melhor confidencialidade para a transação.
 
 A entropia é definida como o logaritmo binário do número de combinações possíveis. Aqui está a fórmula usada:
-```
+```bash
 E: a entropia da transação
 C: o número de combinações possíveis para a transação
 
@@ -58,21 +58,21 @@ E = log2(C)
 Em matemática, o logaritmo binário (logaritmo de base-2) corresponde à operação inversa de elevar 2. Em outras palavras, o logaritmo binário de `x` é o expoente ao qual `2` deve ser elevado para obter `x`. Este indicador é, portanto, expresso em bits.
 
 Vamos tomar o exemplo do cálculo da entropia para uma transação coinjoin estruturada de acordo com o modelo Whirlpool 5x5, que, como mencionado anteriormente, oferece um número de combinações possíveis de `1,496`:
-```
+```bash
 C = 1,496
 E = log2(1,496)
 E = 10.5469 bits
 ```
 Assim, esta transação coinjoin exibe uma entropia de `10.5469 bits`, o que é considerado muito satisfatório. Quanto maior esse valor, mais diferentes interpretações a transação admite, fortalecendo assim seu nível de privacidade.
 Para uma transação coinjoin 8x8 apresentando `9,934,563` interpretações, a entropia seria:
-```
+```bash
 C = 9,934,563
 E = log2(9,934,563)
 E = 23.244 bits
 ```
 
 Vamos tomar outro exemplo com uma transação mais convencional, apresentando uma entrada e duas saídas: [1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce](https://mempool.space/tx/1b1b0c3f0883a99f1161c64da19471841ed12a1f78e77fab128c69a5f578ccce) No caso desta transação, a única interpretação possível é: `(In.0) > (Out.0 ; Out.1)`. Consequentemente, sua entropia é estabelecida em `0`:
-```
+```bash
 C = 1
 E = log2(1)
 E = 0 bits
@@ -82,7 +82,7 @@ E = 0 bits
 O terceiro indicador fornecido pelo Calculador Boltzmann é denominado `Eficiência da Carteira`. Este indicador avalia a eficiência da transação comparando-a com a transação ótima concebível em uma configuração idêntica.
 Isso nos leva a discutir o conceito de entropia máxima, que corresponde à maior entropia que uma estrutura de transação específica poderia teoricamente alcançar. A eficiência da transação é então calculada confrontando essa entropia máxima com a entropia real da transação analisada.
 A fórmula utilizada é a seguinte:
-```
+```bash
 ER: a entropia real da transação expressa em bits
 EM: a entropia máxima possível para uma dada estrutura de transação expressa em bits
 Ef: a eficiência da transação em bits
@@ -91,14 +91,14 @@ Ef = ER - EM
 ```
 
 Por exemplo, para uma estrutura de coinjoin do tipo Whirlpool 5x5, a entropia máxima é definida em `10.5469`:
-```
+```bash
 ER = 10.5469
 EM = 10.5469
 Ef = 10.5469 - 10.5469 = 0 bits
 ```
 
 Este indicador também é expresso como uma porcentagem, sua fórmula é então:
-```
+```bash
 CR: o número real de combinações possíveis
 CM: o número máximo de combinações possíveis com a mesma estrutura
 Ef: a eficiência expressa como uma porcentagem
@@ -112,7 +112,7 @@ Uma eficiência de `100%` indica, portanto, que a transação maximiza seu poten
 
 ### Densidade de Entropia:
 O quarto indicador é a densidade de entropia, notada na ferramenta como `Densidade de Entropia`. Ela oferece uma perspectiva sobre a entropia relativa a cada entrada ou saída da transação. Este indicador é útil para avaliar e comparar a eficiência de transações de diferentes tamanhos. Para calculá-lo, basta dividir a entropia total da transação pelo número total de entradas e saídas envolvidas:
-```
+```bash
 ED: a densidade de entropia expressa em bits
 E: a entropia da transação expressa em bits
 T: o número total de entradas e saídas na transação
@@ -121,14 +121,14 @@ ED = E / T
 ```
 
 Vamos tomar o exemplo de um coinjoin Whirlpool 5x5:
-```
+```bash
 T = 5 + 5 = 10
 E = 10.5469
 ED = 10.5469 / 10 = 1.054 bits
 ```
 
 Vamos também calcular a densidade de entropia para um coinjoin Whirlpool 8x8:
-```
+```bash
 T = 8 + 8 = 16
 E = 23.244
 ED = 23.244 / 16 = 1.453 bits
@@ -147,7 +147,7 @@ Tomando o exemplo de um coinjoin Whirlpool novamente, a tabela de probabilidades
 | Entrada 1 | 34%      | 34%      | 34%      | 34%      | 34%      |
 Aqui, podemos ver claramente que cada entrada tem uma chance igual de ser associada a qualquer saída, o que aumenta a confidencialidade da transação.
 Calcular a pontuação de Boltzmann envolve dividir o número de interpretações nas quais um certo evento ocorre pelo número total de interpretações disponíveis. Assim, para determinar a pontuação associando a entrada Nº 0 com a saída Nº 3 (`512` interpretações), o seguinte procedimento é usado:
-```
+```bash
 Interpretações (IN.0 > OUT.3) = 512
 Total de Interpretações = 1496
 Pontuação = 512 / 1496 = 34%

--- a/tutorials/privacy/coinjoin-samourai-wallet/de.md
+++ b/tutorials/privacy/coinjoin-samourai-wallet/de.md
@@ -195,7 +195,7 @@ Es wird Ihnen angeboten, Ihren PayNym Bot zu erhalten. Sie können ihn anfordern
 
 ![samourai](assets/de/15.webp)
 Bevor Sie fortfahren, um Bitcoins auf dieses neue Wallet zu erhalten, wird dringend empfohlen, die Gültigkeit Ihrer Wallet-Backups (das Passwort und die Wiederherstellungsphrase) erneut zu überprüfen. Um das Passwort zu überprüfen, können Sie das Symbol Ihres PayNym Bots oben links auf dem Bildschirm auswählen und dann folgenden Pfad verfolgen:
-```
+```bash
 Einstellungen > Fehlerbehebung > Passwort/Backup-Test
 ```
 
@@ -208,7 +208,7 @@ Samourai wird bestätigen, ob es gültig ist.
 ![samourai](assets/de/17.webp)
 
 Um Ihr Backup der Wiederherstellungsphrase zu überprüfen, greifen Sie auf das Symbol Ihres PayNym Bots zu, das sich oben links auf dem Bildschirm befindet, und folgen Sie diesem Pfad:
-```
+```bash
 Einstellungen > Wallet > 12-Wörter-Wiederherstellungsphrase anzeigen
 ```
 

--- a/tutorials/privacy/coinjoin-samourai-wallet/en.md
+++ b/tutorials/privacy/coinjoin-samourai-wallet/en.md
@@ -205,7 +205,7 @@ You are offered to obtain your PayNym Bot. You can request it if you wish, altho
 
 ![samourai](assets/en/15.webp)
 Before proceeding to receive bitcoins on this new wallet, it is strongly recommended to recheck the validity of your wallet backups (the passphrase and the recovery phrase). To verify the passphrase, you can select the icon of your PayNym Bot located at the top left of the screen, then follow the path:
-```
+```bash
 Settings > Troubleshooting > Passphrase/backup test
 ```
 
@@ -218,7 +218,7 @@ Samourai will confirm if it is valid.
 ![samourai](assets/en/17.webp)
 
 To verify your backup of the recovery phrase, access the icon of your PayNym Bot, located at the top left of the screen, and follow this path:
-```
+```bash
 Settings > Wallet > Show 12-word recovery phrase
 ```
 

--- a/tutorials/privacy/coinjoin-samourai-wallet/es.md
+++ b/tutorials/privacy/coinjoin-samourai-wallet/es.md
@@ -195,7 +195,7 @@ Se te ofrecerá obtener tu PayNym Bot. Puedes solicitarlo si lo deseas, aunque n
 
 ![samourai](assets/es/15.webp)
 Antes de proceder a recibir bitcoins en esta nueva billetera, se recomienda encarecidamente volver a verificar la validez de las copias de seguridad de tu billetera (la frase de paso y la frase de recuperación). Para verificar la frase de paso, puedes seleccionar el icono de tu PayNym Bot ubicado en la parte superior izquierda de la pantalla, luego seguir el camino:
-```
+```bash
 Settings > Troubleshooting > Passphrase/backup test
 ```
 
@@ -208,7 +208,7 @@ Samourai confirmará si es válida.
 ![samourai](assets/es/17.webp)
 
 Para verificar tu copia de seguridad de la frase de recuperación, accede al icono de tu PayNym Bot, ubicado en la parte superior izquierda de la pantalla, y sigue este camino:
-```
+```bash
 Settings > Wallet > Show 12-word recovery phrase
 ```
 

--- a/tutorials/privacy/coinjoin-samourai-wallet/fr.md
+++ b/tutorials/privacy/coinjoin-samourai-wallet/fr.md
@@ -221,7 +221,7 @@ Il vous est proposé d'obtenir votre PayNym Bot. Vous pouvez le demander si vous
 ![samourai](assets/fr/15.webp)
 
 Avant de procéder à la réception de bitcoins sur ce nouveau portefeuille, il est fortement recommandé de vérifier de nouveau la validité des sauvegardes de votre portefeuille (la passphrase et la phrase de récupération). Pour vérifier la passphrase, vous pouvez sélectionner l'icône de votre PayNym Bot située en haut à gauche de l'écran, puis en suivre le chemin :
-```
+```bash
 Paramètres > Dépannage > Passphrase/test sauvegarde 
 ```
 
@@ -234,7 +234,7 @@ Samourai vous confirmera si celle-ci est valide.
 ![samourai](assets/fr/17.webp)
 
 Pour vérifier votre sauvegarde de la phrase de récupération, accédez à l'icône de votre PayNym Bot, située en haut à gauche de l'écran, et suivez ce chemin :
-```
+```bash
 Paramètres > Portefeuille > Afficher la phrase de récupération de 12 mots
 ```
 

--- a/tutorials/privacy/coinjoin-samourai-wallet/it.md
+++ b/tutorials/privacy/coinjoin-samourai-wallet/it.md
@@ -188,7 +188,7 @@ Dopo aver effettuato queste copie di sicurezza, sarai indirizzato all'interfacci
 Ti viene offerto di ottenere il tuo PayNym Bot. Puoi richiederlo se lo desideri, anche se non è essenziale per il nostro tutorial.
 
 Prima di procedere a ricevere bitcoin su questo nuovo portafoglio, è fortemente consigliato ricontrollare la validità delle copie di sicurezza del tuo portafoglio (la passphrase e la frase di recupero). Per verificare la passphrase, puoi selezionare l'icona del tuo PayNym Bot situata in alto a sinistra dello schermo, poi seguire il percorso:
-```
+```bash
 Impostazioni > Risoluzione problemi > Test passphrase/backup
 ```
 
@@ -197,7 +197,7 @@ Inserisci la tua passphrase per eseguire la verifica.
 Samourai confermerà se è valida.
 
 Per verificare il tuo backup della frase di recupero, accedi all'icona del tuo PayNym Bot, situata in alto a sinistra dello schermo, e segui questo percorso:
-```
+```bash
 Impostazioni > Portafoglio > Mostra frase di recupero da 12 parole
 ```
 

--- a/tutorials/privacy/coinjoin-samourai-wallet/pt.md
+++ b/tutorials/privacy/coinjoin-samourai-wallet/pt.md
@@ -195,7 +195,7 @@ Após fazer esses backups, você será direcionado para a interface da sua nova 
 
 ![samourai](assets/pt/15.webp)
 Antes de proceder para receber bitcoins nesta nova carteira, é altamente recomendado verificar novamente a validade dos backups da sua carteira (a passphrase e a frase de recuperação). Para verificar a passphrase, você pode selecionar o ícone do seu PayNym Bot localizado no canto superior esquerdo da tela, e seguir o caminho:
-```
+```bash
 Settings > Troubleshooting > Passphrase/backup test
 ```
 
@@ -208,7 +208,7 @@ Samourai confirmará se é válida.
 ![samourai](assets/pt/17.webp)
 
 Para verificar seu backup da frase de recuperação, acesse o ícone do seu PayNym Bot, localizado no canto superior esquerdo da tela, e siga este caminho:
-```
+```bash
 Settings > Wallet > Show 12-word recovery phrase
 ```
 

--- a/tutorials/privacy/coinjoin-sparrow-wallet/de.md
+++ b/tutorials/privacy/coinjoin-sparrow-wallet/de.md
@@ -187,7 +187,7 @@ Stellen Sie die Gültigkeit Ihrer Sicherungskopie der Wiederherstellungsphrase s
 ![sparrow](assets/de/13.webp)
 
 Lassen Sie den vorgeschlagenen Ableitungspfad als Standard und drücken Sie `Keystore importieren`. In meinem Beispiel weicht der Ableitungspfad leicht ab, da ich das Testnet für dieses Tutorial verwende. Der Ableitungspfad, der für Sie erscheinen sollte, ist wie folgt:
-```
+```bash
 m/84'/0'/0'
 ```
 

--- a/tutorials/privacy/coinjoin-sparrow-wallet/en.md
+++ b/tutorials/privacy/coinjoin-sparrow-wallet/en.md
@@ -196,7 +196,7 @@ Ensure the validity of your recovery phrase backup before clicking on `Confirm B
 ![sparrow](assets/en/13.webp)
 
 Leave the suggested derivation path as default and press `Import Keystore`. In my example, the derivation path differs slightly since I am using the Testnet for this tutorial. The derivation path that should appear for you is as follows:
-```
+```bash
 m/84'/0'/0'
 ```
 

--- a/tutorials/privacy/coinjoin-sparrow-wallet/es.md
+++ b/tutorials/privacy/coinjoin-sparrow-wallet/es.md
@@ -187,7 +187,7 @@ Asegura la validez de tu copia de seguridad de la frase de recuperación antes d
 ![sparrow](assets/es/13.webp)
 
 Deja la ruta de derivación sugerida como predeterminada y presiona `Import Keystore`. En mi ejemplo, la ruta de derivación difiere ligeramente ya que estoy usando el Testnet para este tutorial. La ruta de derivación que debería aparecer para ti es la siguiente:
-```
+```bash
 m/84'/0'/0'
 ```
 

--- a/tutorials/privacy/coinjoin-sparrow-wallet/fr.md
+++ b/tutorials/privacy/coinjoin-sparrow-wallet/fr.md
@@ -205,7 +205,7 @@ Assurez-vous de la validité de votre sauvegarde de la phrase de récupération 
 ![sparrow](assets/fr/13.webp)
 
 Laissez le chemin de dérivation proposé par défaut et appuyez sur `Import Keystore`. Dans mon exemple, le chemin de dérivation diffère légèrement étant donné que j'utilise le Testnet pour faire ce tutoriel. Le chemin de dérivation qui devrait s'afficher pour vous est le suivant :
-```
+```bash
 m/84'/0'/0'
 ```
 

--- a/tutorials/privacy/coinjoin-sparrow-wallet/it.md
+++ b/tutorials/privacy/coinjoin-sparrow-wallet/it.md
@@ -187,7 +187,7 @@ Assicurati della validità del tuo backup della frase di recupero prima di clicc
 ![sparrow](assets/it/13.webp)
 
 Lascia il percorso di derivazione suggerito come predefinito e premi `Importa Keystore`. Nel mio esempio, il percorso di derivazione differisce leggermente poiché sto usando il Testnet per questo tutorial. Il percorso di derivazione che dovrebbe apparire per te è il seguente:
-```
+```bash
 m/84'/0'/0'
 ```
 

--- a/tutorials/privacy/coinjoin-sparrow-wallet/pt.md
+++ b/tutorials/privacy/coinjoin-sparrow-wallet/pt.md
@@ -187,7 +187,7 @@ Certifique-se da validade do backup da sua frase de recuperação antes de clica
 ![sparrow](assets/pt/13.webp)
 
 Deixe o caminho de derivação sugerido como padrão e pressione `Import Keystore`. No meu exemplo, o caminho de derivação difere ligeiramente, pois estou usando o Testnet para este tutorial. O caminho de derivação que deve aparecer para você é o seguinte:
-```
+```bash
 m/84'/0'/0'
 ```
 

--- a/tutorials/privacy/wst-anonsets/de.md
+++ b/tutorials/privacy/wst-anonsets/de.md
@@ -55,7 +55,7 @@ Wenn Sie Ihr UTXO am Ausgang der Zyklen kennen, bestimmt das retrospektive Anons
 Um diese Indikatoren für Ihre eigenen Münzen, die durch Coinjoin-Zyklen gegangen sind, selbst zu berechnen, können Sie ein speziell von Samourai Wallet entwickeltes Tool verwenden: *Whirlpool Stats Tools*.
 Wenn Sie ein RoninDojo besitzen, ist WST bereits auf Ihrem Knoten vorinstalliert. Sie können daher die Installationsschritte überspringen und direkt mit den Nutzungsschritten fortfahren. Für diejenigen, die keinen RoninDojo-Knoten haben, sehen wir uns an, wie man mit der Installation dieses Tools auf einem Computer vorgeht.
 Sie benötigen: Tor Browser (oder Tor), Python 3.4.4 oder höher, git und pip. Öffnen Sie ein Terminal. Um die Anwesenheit und Version dieser Software auf Ihrem System zu überprüfen, geben Sie die folgenden Befehle ein:
-```
+```bash
 python --version
 git --version
 pip --version
@@ -66,22 +66,22 @@ Falls nötig, können Sie sie von ihren jeweiligen Websites herunterladen:
 - https://www.torproject.org/download/;
 - https://git-scm.com/downloads.
 Sobald all diese Software installiert ist, klonen Sie das WST-Repository von einem Terminal aus:
-```
+```bash
 git clone https://code.samourai.io/whirlpool/whirlpool_stats.git
 ```
 ![WST](assets/8.webp)
 Navigieren Sie zum WST-Verzeichnis:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Installieren Sie die Abhängigkeiten:
-```
+```bash
 pip3 install -r ./requirements.txt
 ```
 ![WST](assets/9.webp)
 Sie können sie auch manuell installieren (optional):
-```
+```bash
 pip install PySocks
 pip install requests[socks]
 pip install plotly
@@ -91,12 +91,12 @@ pip install python-bitcoinrpc
 ```
 
 Navigieren Sie zum Unterordner `/whirlpool_stats`:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Starten Sie WST:
-```
+```bash
 python3 wst.py
 ```
 ![WST](assets/10.webp)
@@ -105,26 +105,26 @@ Starten Sie Tor oder den Tor Browser im Hintergrund.
 **-> Für RoninDojo-Benutzer können Sie das Tutorial direkt hier fortsetzen.**
 
 Stellen Sie den Proxy auf Tor (RoninDojo) ein,
-```
+```bash
 socks5 127.0.0.1:9050
 ```
 
 oder auf den Tor Browser, je nachdem, was Sie verwenden:
-```
+```bash
 socks5 127.0.0.1:9150
 ```
 
 Diese Manipulation ermöglicht es Ihnen, Daten über OXT via Tor herunterzuladen, um keine Informationen über Ihre Transaktionen preiszugeben. Wenn Sie ein Anfänger sind und dieser Schritt komplex erscheint, wissen Sie, dass es einfach darum geht, Ihren Internetverkehr durch Tor zu leiten. Die einfachste Methode besteht darin, den Tor Browser im Hintergrund auf Ihrem Computer zu starten und dann nur den zweiten Befehl auszuführen, um sich über diesen Browser zu verbinden (`socks5 127.0.0.1:9150`).
 ![WST](assets/11.webp)
 Navigieren Sie anschließend zum Arbeitsverzeichnis, von dem aus Sie die WST-Daten herunterladen möchten, indem Sie den Befehl `workdir` verwenden. Dieser Ordner dient dazu, die Transaktionsdaten zu speichern, die Sie von OXT in Form von `.csv`-Dateien abrufen werden. Diese Informationen sind wesentlich für die Berechnung der Indikatoren, die Sie erhalten möchten. Sie können den Standort dieses Verzeichnisses frei wählen. Es könnte klug sein, einen Ordner speziell für WST-Daten zu erstellen. Als Beispiel wählen wir den Downloads-Ordner. Wenn Sie RoninDojo verwenden, ist dieser Schritt nicht notwendig:
-```
+```bash
 workdir path/to/your/directory
 ```
 
 Das Befehlsfenster sollte sich dann geändert haben, um Ihr Arbeitsverzeichnis anzuzeigen.
 ![WST](assets/12.webp)
 Laden Sie dann die Daten aus dem Pool herunter, der Ihre Transaktion enthält. Zum Beispiel, wenn ich im `100,000 sats` Pool bin, lautet der Befehl:
-```
+```bash
 download 0001
 ```
 ![WST](assets/13.webp)
@@ -134,14 +134,14 @@ Die Stückelungscodes auf WST sind wie folgt:
 - Pool 0,01 Bitcoins: `001`
 - Pool 0,001 Bitcoins: `0001`
 Sobald die Daten heruntergeladen sind, laden Sie diese. Zum Beispiel, wenn ich im Pool von `100.000 Sats` bin, lautet der Befehl:
-```
+```bash
 load 0001
 ```
 
 Dieser Schritt dauert je nach Computer einige Minuten. Jetzt ist ein guter Zeitpunkt, um sich einen Kaffee zu machen! :)
 ![WST](assets/14.webp)
 Nachdem die Daten geladen wurden, geben Sie den Befehl `score` gefolgt von Ihrem TXID (Transaktionsidentifikator) ein, um dessen Anonsets zu erhalten:
-```
+```bash
 score TXID
 ```
 

--- a/tutorials/privacy/wst-anonsets/en.md
+++ b/tutorials/privacy/wst-anonsets/en.md
@@ -58,7 +58,7 @@ To calculate these indicators on your own coins that have gone through coinjoin 
 If you have a RoninDojo, WST is preinstalled on your node. You can therefore skip the installation steps and directly follow the usage steps. For those who do not have a RoninDojo node, let's see how to proceed with the installation of this tool on a computer.
 
 You will need: Tor Browser (or Tor), Python 3.4.4 or higher, git, and pip. Open a terminal. To check the presence and version of these software on your system, enter the following commands:
-```
+```bash
 python --version
 git --version
 pip --version
@@ -69,22 +69,22 @@ If needed, you can download them from their respective websites:
 - https://www.torproject.org/download/;
 - https://git-scm.com/downloads.
 Once all these software are installed, from a terminal, clone the WST repository:
-```
+```bash
 git clone https://code.samourai.io/whirlpool/whirlpool_stats.git
 ```
 ![WST](assets/8.webp)
 Navigate to the WST directory:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Install the dependencies:
-```
+```bash
 pip3 install -r ./requirements.txt
 ```
 ![WST](assets/9.webp)
 You may also install them manually (optional):
-```
+```bash
 pip install PySocks
 pip install requests[socks]
 pip install plotly
@@ -94,12 +94,12 @@ pip install python-bitcoinrpc
 ```
 
 Navigate to the `/whirlpool_stats` subfolder:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Start WST:
-```
+```bash
 python3 wst.py
 ```
 ![WST](assets/10.webp)
@@ -108,26 +108,26 @@ Launch Tor or Tor Browser in the background.
 **-> For RoninDojo users, you can resume the tutorial directly here.**
 
 Set the proxy to Tor (RoninDojo),
-```
+```bash
 socks5 127.0.0.1:9050
 ```
 
 or to Tor Browser depending on what you are using:
-```
+```bash
 socks5 127.0.0.1:9150
 ```
 
 This manipulation will allow you to download data on OXT via Tor, in order to not leak information about your transactions. If you are a novice and this step seems complex, know that it simply involves directing your internet traffic through Tor. The simplest method consists of launching the Tor Browser in the background on your computer, then executing only the second command to connect via this browser (`socks5 127.0.0.1:9150`).
 ![WST](assets/11.webp)
 Next, navigate to the working directory from which you intend to download the WST data using the `workdir` command. This folder will serve to store the transactional data that you will retrieve from OXT in the form of `.csv` files. This information is essential for calculating the indicators you are looking to obtain. You are free to choose the location of this directory. It might be wise to create a folder specifically for WST data. As an example, let's opt for the downloads folder. If you are using RoninDojo, this step is not necessary:
-```
+```bash
 workdir path/to/your/directory
 ```
 
 The command prompt should then have changed to indicate your working directory.
 ![WST](assets/12.webp)
 Then download the data from the pool containing your transaction. For example, if I am in the `100,000 sats` pool, the command is:
-```
+```bash
 download 0001
 ```
 ![WST](assets/13.webp)
@@ -137,14 +137,14 @@ The denomination codes on WST are as follows:
 - Pool 0.01 bitcoins: `001`
 - Pool 0.001 bitcoins: `0001`
 Once the data is downloaded, load it. For example, if I am in the pool of `100,000 sats`, the command is:
-```
+```bash
 load 0001
 ```
 
 This step takes a few minutes depending on your computer. Now is a good time to make yourself a coffee! :)
 ![WST](assets/14.webp)
 After loading the data, type the `score` command followed by your TXID (transaction identifier) to get its anonsets:
-```
+```bash
 score TXID
 ```
 

--- a/tutorials/privacy/wst-anonsets/es.md
+++ b/tutorials/privacy/wst-anonsets/es.md
@@ -55,7 +55,7 @@ Conociendo tu UTXO en la salida de los ciclos, el anonset retrospectivo determin
 Para calcular estos indicadores en tus propias monedas que han pasado por ciclos de coinjoin, puedes usar una herramienta especialmente desarrollada por Samourai Wallet: *Whirlpool Stats Tools*.
 Si tienes un RoninDojo, WST ya está preinstalado en tu nodo. Por lo tanto, puedes saltarte los pasos de instalación y seguir directamente los pasos de uso. Para aquellos que no tienen un nodo RoninDojo, veamos cómo proceder con la instalación de esta herramienta en una computadora.
 Necesitarás: Tor Browser (o Tor), Python 3.4.4 o superior, git y pip. Abre un terminal. Para verificar la presencia y versión de estos programas en tu sistema, introduce los siguientes comandos:
-```
+```bash
 python --version
 git --version
 pip --version
@@ -66,22 +66,22 @@ Si es necesario, puedes descargarlos desde sus respectivos sitios web:
 - https://www.torproject.org/download/;
 - https://git-scm.com/downloads.
 Una vez que todos estos programas estén instalados, desde un terminal, clona el repositorio de WST:
-```
+```bash
 git clone https://code.samourai.io/whirlpool/whirlpool_stats.git
 ```
 ![WST](assets/8.webp)
 Navega al directorio de WST:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Instala las dependencias:
-```
+```bash
 pip3 install -r ./requirements.txt
 ```
 ![WST](assets/9.webp)
 También puedes instalarlas manualmente (opcional):
-```
+```bash
 pip install PySocks
 pip install requests[socks]
 pip install plotly
@@ -91,12 +91,12 @@ pip install python-bitcoinrpc
 ```
 
 Navega al subdirectorio `/whirlpool_stats`:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Inicia WST:
-```
+```bash
 python3 wst.py
 ```
 ![WST](assets/10.webp)
@@ -105,26 +105,26 @@ Inicia Tor o Tor Browser en segundo plano.
 **-> Para usuarios de RoninDojo, pueden retomar el tutorial directamente aquí.**
 
 Configura el proxy a Tor (RoninDojo),
-```
+```bash
 socks5 127.0.0.1:9050
 ```
 
 o a Tor Browser dependiendo de lo que estés usando:
-```
+```bash
 socks5 127.0.0.1:9150
 ```
 
 Esta manipulación te permitirá descargar datos en OXT a través de Tor, para no revelar información sobre tus transacciones. Si eres un novato y este paso parece complejo, debes saber que simplemente implica dirigir tu tráfico de internet a través de Tor. El método más simple consiste en lanzar el Tor Browser en segundo plano en tu computadora, luego ejecutar solo el segundo comando para conectarte a través de este navegador (`socks5 127.0.0.1:9150`).
 ![WST](assets/11.webp)
 A continuación, navega al directorio de trabajo desde el cual tienes la intención de descargar los datos de WST usando el comando `workdir`. Esta carpeta servirá para almacenar los datos transaccionales que recuperarás de OXT en forma de archivos `.csv`. Esta información es esencial para calcular los indicadores que buscas obtener. Eres libre de elegir la ubicación de este directorio. Podría ser prudente crear una carpeta específicamente para los datos de WST. Como ejemplo, optemos por la carpeta de descargas. Si estás usando RoninDojo, este paso no es necesario:
-```
+```bash
 workdir path/to/your/directory
 ```
 
 El indicador del comando debería haber cambiado para indicar tu directorio de trabajo.
 ![WST](assets/12.webp)
 Luego descarga los datos del pool que contiene tu transacción. Por ejemplo, si estoy en el pool de `100,000 sats`, el comando es:
-```
+```bash
 download 0001
 ```
 ![WST](assets/13.webp)
@@ -134,14 +134,14 @@ Los códigos de denominación en WST son los siguientes:
 - Pool de 0.01 bitcoins: `001`
 - Pool de 0.001 bitcoins: `0001`
 Una vez descargados los datos, cárgalos. Por ejemplo, si estoy en el pool de `100,000 sats`, el comando es:
-```
+```bash
 load 0001
 ```
 
 Este paso tarda unos minutos dependiendo de tu computadora. ¡Ahora es un buen momento para hacerte un café! :)
 ![WST](assets/14.webp)
 Después de cargar los datos, escribe el comando `score` seguido de tu TXID (identificador de transacción) para obtener sus anonsets:
-```
+```bash
 score TXID
 ```
 

--- a/tutorials/privacy/wst-anonsets/fr.md
+++ b/tutorials/privacy/wst-anonsets/fr.md
@@ -62,7 +62,7 @@ Pour calculer ces indicateurs sur vos propres pièces qui sont passées dans des
 Si vous disposez d'un RoninDojo, WST est préinstallé sur votre nœud. Vous pouvez donc passer les étapes d'installation et suivre directement les étapes d'utilisation. Pour ceux qui ne disposent pas d'un nœud RoninDojo, voyons ensemble comment procéder à l'installation de cet outil sur un ordinateur.
 
 Vous aurez besoin de : Tor Browser (ou Tor), Python 3.4.4 ou supérieur, git et pip. Ouvrez un terminal. Afin de vérifier la présence et la version de ces logiciels sur votre système, saisissez les commandes suivantes :
-```
+```bash
 python --version
 git --version
 pip --version
@@ -74,22 +74,22 @@ Si besoin, vous pouvez les télécharger depuis leurs sites web respectifs :
 - https://git-scm.com/downloads.
 
 Une fois tous ces logiciels installés, depuis un terminal, clonez le dépôt de WST :
-```
+```bash
 git clone https://code.samourai.io/whirlpool/whirlpool_stats.git
 ```
 ![WST](assets/8.webp)
 Naviguez dans le répertoire de WST :
-```
+```bash
 cd whirlpool_stats
 ```
 
 Installez les dépendances :
-```
+```bash
 pip3 install -r ./requirements.txt
 ```
 ![WST](assets/9.webp)
 Vous pouvez éventuellement les installer manuellement (facultatif) :
-```
+```bash
 pip install PySocks
 pip install requests[socks]
 pip install plotly
@@ -99,12 +99,12 @@ pip install python-bitcoinrpc
 ```
 
 Naviguez dans le sous-dossier `/whirlpool_stats` :
-```
+```bash
 cd whirlpool_stats
 ```
 
 Démarrez WST :
-```
+```bash
 python3 wst.py
 ```
 ![WST](assets/10.webp)
@@ -113,26 +113,26 @@ Lancez Tor ou Tor Browser en fond.
 **-> Pour les utilisateurs RoninDojo, vous pouvez reprendre le tutoriel directement ici.**
 
 Définissez le proxy sur Tor (RoninDojo),
-```
+```bash
 socks5 127.0.0.1:9050
 ```
 
 ou bien sur Tor Browser en fonction de ce que vous utilisez :
-```
+```bash
 socks5 127.0.0.1:9150
 ```
 
 Cette manipulation vous permettra de télécharger les données sur OXT via Tor, afin de ne pas faire fuiter des informations sur vos transactions. Si vous êtes novice et que cette étape vous semble complexe, sachez qu'il s'agit simplement de diriger votre trafic internet à travers Tor. La méthode la plus simple consiste à lancer le navigateur Tor Browser en arrière-plan sur votre ordinateur, puis à exécuter uniquement la seconde commande pour vous connecter via ce navigateur (`socks5 127.0.0.1:9150`).
 ![WST](assets/11.webp)
 Ensuite, dirigez-vous sur le répertoire de travail depuis lequel vous avez l'intention de télécharger les données de WST à l'aide de la commande `workdir`. Ce dossier servira à stocker les données transactionnelles que vous allez récupérer depuis OXT sous forme de fichiers `.csv`. Ces informations sont essentielles au calcul des indicateurs que vous cherchez à obtenir. Vous êtes libre de choisir l'emplacement de ce répertoire. Il pourrait être judicieux de créer un dossier spécifiquement destiné aux données de WST. À titre d'exemple, optons pour le dossier de téléchargements. Si vous utilisez RoninDojo, cette étape n'est pas nécessaire :
-```
+```bash
 workdir chemin/vers/votre/répertoire
 ```
 
 L'invite de commande devrait alors avoir changé pour indiquer votre répertoire de travail.
 ![WST](assets/12.webp)
 Téléchargez ensuite les données de la pool qui contient votre transaction. Par exemple, si je suis dans la pool de `100 000 sats`, la commande est :
-```
+```bash
 download 0001
 ```
 ![WST](assets/13.webp)
@@ -143,14 +143,14 @@ Les codes de dénominations sont les suivants sur WST :
 - Pool 0,001 bitcoins : `0001`
 
 Une fois les données téléchargées, chargez-les. Par exemple, si je suis dans la pool de `100 000 sats`, la commande est :
-```
+```bash
 load 0001
 ```
 
 Cette étape prend quelques minutes en fonction de votre ordinateur. C'est le moment de vous faire un café ! :)
 ![WST](assets/14.webp)
 Après avoir chargé les données, tapez la commande `score` suivie de votre TXID (identifiant de transaction) pour obtenir ses anonsets :
-```
+```bash
 score TXID
 ```
 

--- a/tutorials/privacy/wst-anonsets/it.md
+++ b/tutorials/privacy/wst-anonsets/it.md
@@ -55,7 +55,7 @@ Conoscendo il tuo UTXO all'uscita dei cicli, l'anonset retrospettivo determina i
 Per calcolare questi indicatori sulle tue monete che hanno attraversato cicli di coinjoin, puoi utilizzare uno strumento appositamente sviluppato da Samourai Wallet: *Whirlpool Stats Tools*.
 Se possiedi un RoninDojo, WST è preinstallato sul tuo nodo. Puoi quindi saltare i passaggi di installazione e seguire direttamente quelli per l'uso. Per coloro che non dispongono di un nodo RoninDojo, vediamo come procedere con l'installazione di questo strumento su un computer.
 Avrai bisogno di: Tor Browser (o Tor), Python 3.4.4 o superiore, git e pip. Apri un terminale. Per verificare la presenza e la versione di questi software sul tuo sistema, inserisci i seguenti comandi:
-```
+```bash
 python --version
 git --version
 pip --version
@@ -66,22 +66,22 @@ Se necessario, puoi scaricarli dai rispettivi siti web:
 - https://www.torproject.org/download/;
 - https://git-scm.com/downloads.
 Una volta installati tutti questi software, da un terminale, clona il repository WST:
-```
+```bash
 git clone https://code.samourai.io/whirlpool/whirlpool_stats.git
 ```
 ![WST](assets/8.webp)
 Naviga nella directory WST:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Installa le dipendenze:
-```
+```bash
 pip3 install -r ./requirements.txt
 ```
 ![WST](assets/9.webp)
 Puoi anche installarle manualmente (opzionale):
-```
+```bash
 pip install PySocks
 pip install requests[socks]
 pip install plotly
@@ -91,12 +91,12 @@ pip install python-bitcoinrpc
 ```
 
 Naviga nella sottocartella `/whirlpool_stats`:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Avvia WST:
-```
+```bash
 python3 wst.py
 ```
 ![WST](assets/10.webp)
@@ -105,26 +105,26 @@ Avvia Tor o Tor Browser in background.
 **-> Per gli utenti RoninDojo, potete riprendere il tutorial direttamente qui.**
 
 Imposta il proxy su Tor (RoninDojo),
-```
+```bash
 socks5 127.0.0.1:9050
 ```
 
 o su Tor Browser a seconda di cosa stai utilizzando:
-```
+```bash
 socks5 127.0.0.1:9150
 ```
 
 Questa manipolazione ti permetterà di scaricare dati su OXT tramite Tor, per non divulgare informazioni sulle tue transazioni. Se sei un principiante e questo passaggio ti sembra complesso, sappi che si tratta semplicemente di indirizzare il tuo traffico internet attraverso Tor. Il metodo più semplice consiste nel lanciare il Tor Browser in background sul tuo computer, poi eseguire solo il secondo comando per connettersi tramite questo browser (`socks5 127.0.0.1:9150`).
 ![WST](assets/11.webp)
 Successivamente, naviga nella directory di lavoro da cui intendi scaricare i dati WST utilizzando il comando `workdir`. Questa cartella servirà per memorizzare i dati transazionali che recupererai da OXT sotto forma di file `.csv`. Queste informazioni sono essenziali per calcolare gli indicatori che stai cercando di ottenere. Sei libero di scegliere la posizione di questa directory. Potrebbe essere saggio creare una cartella specificamente per i dati WST. Come esempio, optiamo per la cartella dei download. Se stai utilizzando RoninDojo, questo passaggio non è necessario:
-```
+```bash
 workdir path/to/your/directory
 ```
 
 Il prompt dei comandi dovrebbe poi cambiare per indicare la tua directory di lavoro.
 ![WST](assets/12.webp)
 Poi scarica i dati dal pool contenente la tua transazione. Ad esempio, se sono nel pool `100,000 sats`, il comando è:
-```
+```bash
 download 0001
 ```
 ![WST](assets/13.webp)
@@ -134,14 +134,14 @@ I codici di denominazione su WST sono i seguenti:
 - Pool 0,01 bitcoin: `001`
 - Pool 0,001 bitcoin: `0001`
 Una volta scaricati i dati, caricateli. Ad esempio, se mi trovo nel pool di `100.000 sats`, il comando è:
-```
+```bash
 load 0001
 ```
 
 Questo passaggio richiede alcuni minuti a seconda del vostro computer. Ora è un buon momento per prepararsi un caffè! :)
 ![WST](assets/14.webp)
 Dopo aver caricato i dati, digitate il comando `score` seguito dal vostro TXID (identificativo della transazione) per ottenere i suoi anonset:
-```
+```bash
 score TXID
 ```
 

--- a/tutorials/privacy/wst-anonsets/pt.md
+++ b/tutorials/privacy/wst-anonsets/pt.md
@@ -55,7 +55,7 @@ Conhecendo seu UTXO na saída dos ciclos, o anonset retrospectivo determina o n�
 Para calcular esses indicadores em suas próprias moedas que passaram por ciclos de coinjoin, você pode usar uma ferramenta especialmente desenvolvida pela Samourai Wallet: *Whirlpool Stats Tools*.
 Se você possui um RoninDojo, o WST já está pré-instalado no seu nó. Portanto, você pode pular as etapas de instalação e seguir diretamente para as etapas de uso. Para aqueles que não possuem um nó RoninDojo, vamos ver como proceder com a instalação desta ferramenta em um computador.
 Você precisará de: Tor Browser (ou Tor), Python 3.4.4 ou superior, git e pip. Abra um terminal. Para verificar a presença e a versão desses softwares no seu sistema, insira os seguintes comandos:
-```
+```bash
 python --version
 git --version
 pip --version
@@ -66,22 +66,22 @@ Se necessário, você pode baixá-los de seus respectivos sites:
 - https://www.torproject.org/download/;
 - https://git-scm.com/downloads.
 Uma vez que todos esses softwares estejam instalados, a partir de um terminal, clone o repositório WST:
-```
+```bash
 git clone https://code.samourai.io/whirlpool/whirlpool_stats.git
 ```
 ![WST](assets/8.webp)
 Navegue até o diretório WST:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Instale as dependências:
-```
+```bash
 pip3 install -r ./requirements.txt
 ```
 ![WST](assets/9.webp)
 Você também pode instalá-las manualmente (opcional):
-```
+```bash
 pip install PySocks
 pip install requests[socks]
 pip install plotly
@@ -91,12 +91,12 @@ pip install python-bitcoinrpc
 ```
 
 Navegue até a subpasta `/whirlpool_stats`:
-```
+```bash
 cd whirlpool_stats
 ```
 
 Inicie o WST:
-```
+```bash
 python3 wst.py
 ```
 ![WST](assets/10.webp)
@@ -105,26 +105,26 @@ Inicie o Tor ou o Tor Browser em segundo plano.
 **-> Para usuários do RoninDojo, você pode retomar o tutorial diretamente aqui.**
 
 Defina o proxy para Tor (RoninDojo),
-```
+```bash
 socks5 127.0.0.1:9050
 ```
 
 ou para o Tor Browser, dependendo do que você está usando:
-```
+```bash
 socks5 127.0.0.1:9150
 ```
 
 Esta manipulação permitirá que você baixe dados no OXT via Tor, para não vazar informações sobre suas transações. Se você é um novato e esta etapa parece complexa, saiba que ela simplesmente envolve direcionar seu tráfego de internet através do Tor. O método mais simples consiste em iniciar o Tor Browser em segundo plano no seu computador e, em seguida, executar apenas o segundo comando para se conectar através deste navegador (`socks5 127.0.0.1:9150`).
 ![WST](assets/11.webp)
 Em seguida, navegue até o diretório de trabalho a partir do qual você pretende baixar os dados do WST usando o comando `workdir`. Esta pasta servirá para armazenar os dados transacionais que você irá recuperar do OXT em forma de arquivos `.csv`. Esta informação é essencial para calcular os indicadores que você está procurando obter. Você é livre para escolher a localização deste diretório. Pode ser sábio criar uma pasta especificamente para os dados do WST. Como exemplo, vamos optar pela pasta de downloads. Se você está usando RoninDojo, esta etapa não é necessária:
-```
+```bash
 workdir caminho/para/seu/diretório
 ```
 
 O prompt de comando deve então ter mudado para indicar seu diretório de trabalho.
 ![WST](assets/12.webp)
 Então, baixe os dados do pool contendo sua transação. Por exemplo, se eu estou no pool de `100,000 sats`, o comando é:
-```
+```bash
 download 0001
 ```
 ![WST](assets/13.webp)
@@ -134,14 +134,14 @@ Os códigos de denominação no WST são os seguintes:
 - Pool de 0.01 bitcoins: `001`
 - Pool de 0.001 bitcoins: `0001`
 Uma vez que os dados são baixados, carregue-os. Por exemplo, se eu estiver no pool de `100,000 sats`, o comando é:
-```
+```bash
 load 0001
 ```
 
 Este passo leva alguns minutos dependendo do seu computador. Agora é um bom momento para fazer um café! :)
 ![WST](assets/14.webp)
 Após carregar os dados, digite o comando `score` seguido pelo seu TXID (identificador de transação) para obter seus anonsets:
-```
+```bash
 score TXID
 ```
 


### PR DESCRIPTION
Following a helpful discussion with @kevinmulier, this PR addresses a display issue with code blocks in our markdown-rendered. All code blocks previously lacking a specified language now explicitly include "bash" to ensure correct display on our website.

This PR covers all my personal tutorials. If you need to modify other tutorials, I've put below a link to the pyhton script I used to modify all this quickly. 

https://github.com/LoicPandul/scripts-divers-public/blob/main/scripts/bloc-rep-bash.py 
