### PR TITLE
New privacy subsection: Analysis

### DIFF
--- a/tutorials/privacy/boltzmann-entropy/tutorial.yml
+++ b/tutorials/privacy/boltzmann-entropy/tutorial.yml
@@ -5,7 +5,7 @@ tags:
   - entropy
   - Boltzmann
 
-category: bitcoin
+category: analysis
 
 level: advanced
 

--- a/tutorials/privacy/oxt-analysis/tutorial.yml
+++ b/tutorials/privacy/oxt-analysis/tutorial.yml
@@ -5,7 +5,7 @@ tags:
   - education
   - analysis
 
-category: bitcoin
+category: analysis
 
 level: advanced
 

--- a/tutorials/privacy/remix-whirlpool/tutorial.yml
+++ b/tutorials/privacy/remix-whirlpool/tutorial.yml
@@ -5,7 +5,7 @@ tags:
   - education
   - Whirlpool
 
-category: bitcoin
+category: analysis
 
 level: advanced
 

--- a/tutorials/privacy/wst-anonsets/tutorial.yml
+++ b/tutorials/privacy/wst-anonsets/tutorial.yml
@@ -5,7 +5,7 @@ tags:
   - WST
   - coinjoin
 
-category: bitcoin
+category: analysis
 
 level: advanced
 


### PR DESCRIPTION
Proposal for restructuring the `/privacy` section with a rebalancing. The following articles have been moved from the `/bitcoin` section to a new subsection `/analysis`:
- Remix coinjoins;
- Boltzmann / entropy;
- Chain Analysis;
- Anonsets.