### PR TITLE
Change builder key in YAML files of the contribution tutorials

### DIFF
--- a/tutorials/others/add-event/tutorial.yml
+++ b/tutorials/others/add-event/tutorial.yml
@@ -1,4 +1,4 @@
-builder: PlanB Network
+builder: PlanB Contribution
 
 tags:
   - GitHub

--- a/tutorials/others/add-new-language-weblate/tutorial.yml
+++ b/tutorials/others/add-new-language-weblate/tutorial.yml
@@ -1,4 +1,4 @@
-builder: PlanB Network
+builder: PlanB Contribution
 
 tags:
   - Weblate

--- a/tutorials/others/content-review-tutorial/tutorial.yml
+++ b/tutorials/others/content-review-tutorial/tutorial.yml
@@ -1,4 +1,4 @@
-builder: PlanB Network
+builder: PlanB Contribution
 
 tags:
   - PlanB Network

--- a/tutorials/others/correct-errors/tutorial.yml
+++ b/tutorials/others/correct-errors/tutorial.yml
@@ -1,4 +1,4 @@
-builder: PlanB Network
+builder: PlanB Contribution
 
 tags:
   - GitHub

--- a/tutorials/others/create-teacher-profile/tutorial.yml
+++ b/tutorials/others/create-teacher-profile/tutorial.yml
@@ -1,4 +1,4 @@
-builder: PlanB Network
+builder: PlanB Contribution
 
 tags:
   - GitHub

--- a/tutorials/others/translate-front-weblate/tutorial.yml
+++ b/tutorials/others/translate-front-weblate/tutorial.yml
@@ -1,4 +1,4 @@
-builder: PlanB Network
+builder: PlanB Contribution
 
 tags:
   - Weblate

--- a/tutorials/others/write-tutorials/tutorial.yml
+++ b/tutorials/others/write-tutorials/tutorial.yml
@@ -1,4 +1,4 @@
-builder: PlanB Network
+builder: PlanB Contribution
 
 tags:
   - GitHub


### PR DESCRIPTION
I changed all the `builder` keys in the `tutorial.yml` YAML files of the latest contribution tutorials, switching those that had `PlanB Network` as a value to `PlanB Contribution`. The goal is to ensure that these tutorials are not associated with the PlanB builder, because otherwise, the logo I had planned is automatically replaced with the PlanB logo.

To avoid unsightly redundancy, it's better to have the custom logos for each tutorial that I had planned in each `/assets` folder.
![Capture d'écran 2024-06-11 084124](https://github.com/DecouvreBitcoin/sovereign-university-data/assets/137194052/d4b07301-c8b2-4144-90db-ca5789b212ba)
