### PR TITLE
Value missing for category key in YAML

### DIFF
--- a/tutorials/others/proton-drive/tutorial.yml
+++ b/tutorials/others/proton-drive/tutorial.yml
@@ -4,7 +4,7 @@ tags:
   - security
   - privacy
 
-category:
+category: general
 
 level: beginner
 

--- a/tutorials/others/security-key/tutorial.yml
+++ b/tutorials/others/security-key/tutorial.yml
@@ -4,7 +4,7 @@ tags:
   - 2FA
   - security
 
-category:
+category: general
 
 level: beginner
 


### PR DESCRIPTION
A value was missing for the `category` keys in the YAML of two tutorials: Proton Drive and YubiKey. This PR fixes that. Thanks, @trigger67 , for pointing it out 👍 
