### PR TITLE
et + zh-Hans SCU101 links to tutorials

### DIFF
--- a/courses/scu101/et.md
+++ b/courses/scu101/et.md
@@ -370,7 +370,7 @@ Kuldreegel: Küberturvalisus on liikuv sihtmärk, mis kohandub teie õppimisteek
 
 <chapterId>afc9ab5d-7664-5a9b-ab50-225ac9ba8f7c</chapterId>
 
-Pange tähele, et hetkel sisaldab see kursuse osa ainult prantsuskeelseid õpetusi. Me töötame hetkel video tõlkimisega teie keelde. Kui soovite meid tõlkimisel aidata, võtke meiega ühendust [GitHub](https://github.com/DecouvreBitcoin/sovereign-university-data) kaudu.
+https://planb.network/tutorials/others/proton-mail
 
 ![video](https://youtu.be/vpYJYWhmEZg)
 
@@ -378,29 +378,40 @@ Pange tähele, et hetkel sisaldab see kursuse osa ainult prantsuskeelseid õpetu
 
 <chapterId>09468ec1-95b7-56a4-a636-7618044568e1</chapterId>
 
+https://planb.network/tutorials/others/authy
+
+https://planb.network/tutorials/others/security-key
+
 ![video](https://youtu.be/mNcAKRDmz5o)
 
 ## Paroolihalduri loomine
 
 <chapterId>ed579680-4e7b-5f65-8541-14e519a3b242</chapterId>
-
+https://planb.network/tutorials/others/bitwarden
+https://planb.network/tutorials/others/keypass
 ![video](https://youtu.be/y7Xkv4E5YmU)
 
 ## Oma kontode turvamine
 
 <chapterId>7a774b34-aed0-57dd-b8f7-cf3be51c0d70</chapterId>
+
+https://planb.network/tutorials/others/bitwarden
+https://planb.network/tutorials/others/keypass
 ![video](https://youtu.be/0JHZRALmGY0)
 
 ## Varundamise seadistamine
 
 <chapterId>01cfcde1-77cb-506c-8df1-fa18a2e8cc6b</chapterId>
-
+https://planb.network/tutorials/others/proton-drive
+https://planb.network/tutorials/others/veracrypt
 ![video](https://youtu.be/wTJnlSUkDRI)
 
 ## Brauseri ja VPN-i vahetus
 
 <chapterId>8dc08feb-313c-5259-a54f-64aa68a07608</chapterId>
-
+https://planb.network/tutorials/others/ivpn
+https://planb.network/tutorials/others/mullvad
+https://planb.network/tutorials/others/tor-browser
 ![video](https://youtu.be/vc6-Ouca09g)
 
 # Mine kaugemale

--- a/courses/scu101/zh-Hans.md
+++ b/courses/scu101/zh-Hans.md
@@ -366,7 +366,7 @@ TOR是合法的，被记者、自由活动家以及希望在专制国家逃避�
 
 <chapterId>afc9ab5d-7664-5a9b-ab50-225ac9ba8f7c</chapterId>
 
-请注意，目前这部分课程只包含法语的操作教程。我们正在努力翻译视频以发布您的语言版本。如果您想帮助我们翻译，请通过[GitHub](https://github.com/DecouvreBitcoin/sovereign-university-data)联系我们。
+https://planb.network/tutorials/others/proton-mail
 
 ![video](https://youtu.be/vpYJYWhmEZg)
 
@@ -374,29 +374,40 @@ TOR是合法的，被记者、自由活动家以及希望在专制国家逃避�
 
 <chapterId>09468ec1-95b7-56a4-a636-7618044568e1</chapterId>
 
+https://planb.network/tutorials/others/authy
+
+https://planb.network/tutorials/others/security-key
+
 ![video](https://youtu.be/mNcAKRDmz5o)
 
 ## 创建密码管理器
 
 <chapterId>ed579680-4e7b-5f65-8541-14e519a3b242</chapterId>
-
+https://planb.network/tutorials/others/bitwarden
+https://planb.network/tutorials/others/keypass
 ![video](https://youtu.be/y7Xkv4E5YmU)
 
 ## 保护您的账户
 
 <chapterId>7a774b34-aed0-57dd-b8f7-cf3be51c0d70</chapterId>
+
+https://planb.network/tutorials/others/bitwarden
+https://planb.network/tutorials/others/keypass
 ![video](https://youtu.be/0JHZRALmGY0)
 
 ## 备份设置
 
 <chapterId>01cfcde1-77cb-506c-8df1-fa18a2e8cc6b</chapterId>
-
+https://planb.network/tutorials/others/proton-drive
+https://planb.network/tutorials/others/veracrypt
 ![video](https://youtu.be/wTJnlSUkDRI)
 
 ## 更换浏览器和VPN
 
 <chapterId>8dc08feb-313c-5259-a54f-64aa68a07608</chapterId>
-
+https://planb.network/tutorials/others/ivpn
+https://planb.network/tutorials/others/mullvad
+https://planb.network/tutorials/others/tor-browser
 ![video](https://youtu.be/vc6-Ouca09g)
 
 # 进一步了解


### PR DESCRIPTION
The translations of SCU101 into Estonian (et) and Simplified Chinese (zh-Hans) were done before the tutorials in the practical section were merged. Therefore, the links to the tutorials were missing. This PR adds all the tutorial links to these two translations.
