### PR TITLE
Update BTC204 time

### DIFF
--- a/courses/btc204/course.yml
+++ b/courses/btc204/course.yml
@@ -2,7 +2,7 @@ topic: bitcoin
 subtopic: bitcoin
 
 level: intermediate
-hours: 10
+hours: 9
 
 professors:
   - pretty-private


### PR DESCRIPTION
I just updated the `hours:` field in BTC204 with the new calculation standard for courses time.