### PR TITLE
BTC204 add additional "Conclusion" section

### DIFF
--- a/courses/btc204/cs.md
+++ b/courses/btc204/cs.md
@@ -3618,6 +3618,8 @@ Vzhledem k tomu, že se jedná o novou funkci, je doporučeno být opatrný a vy
 
 _K vytvoření této kapitoly o Silent Payments jsem použil [web s vysvětlením Silent Payments](https://silentpayments.xyz/) a [dokument s vysvětlením BIP352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)._
 
+# Závěr
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 
 ## Dejte nám zpětnou vazbu k tomuto kurzu
@@ -3628,8 +3630,7 @@ _K vytvoření této kapitoly o Silent Payments jsem použil [web s vysvětlení
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Závěr
-
+## Poslední slovo
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Gratuluji k dokončení tohoto školení o soukromí v Bitcoinu!

--- a/courses/btc204/de.md
+++ b/courses/btc204/de.md
@@ -3651,6 +3651,8 @@ Da dieses Feature neu ist, ist es ratsam, Vorsicht walten zu lassen und Silent P
 _Um dieses Kapitel über Silent Payments zu erstellen, habe ich [die Silent Payments Erklärungsseite](https://silentpayments.xyz/) und [das BIP352 Erklärungsdokument](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) verwendet._
 
 
+# Fazit
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 ## Geben Sie uns Ihr Feedback zu diesem Kurs
 <chapterId>195d149f-80fa-5816-8b46-995a9226d082</chapterId>
@@ -3660,8 +3662,7 @@ _Um dieses Kapitel über Silent Payments zu erstellen, habe ich [die Silent Paym
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Schlussfolgerung
-
+## Das Schlusswort
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Herzlichen Glückwunsch zum Abschluss dieses Trainings über Privatsphäre in Bitcoin!

--- a/courses/btc204/en.md
+++ b/courses/btc204/en.md
@@ -3648,6 +3648,8 @@ Since this feature is recent, it is advisable to exercise caution and avoid usin
 
 *To create this chapter on Silent Payments, I used [the Silent Payments explanation site](https://silentpayments.xyz/) and [the BIP352 explanation document](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki).*
 
+# Conclusion
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 
 ## Give us some feedback about this course
@@ -3658,7 +3660,7 @@ Since this feature is recent, it is advisable to exercise caution and avoid usin
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Conclusion
+## The Final Word
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Congratulations on completing this training on privacy in Bitcoin!

--- a/courses/btc204/es.md
+++ b/courses/btc204/es.md
@@ -3684,6 +3684,8 @@ Dado que esta característica es reciente, es aconsejable ejercer precaución y 
 _Para crear este capítulo sobre Pagos Silenciosos, utilicé [el sitio de explicación de Pagos Silenciosos](https://silentpayments.xyz/) y [el documento de explicación del BIP352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)._
 
 
+# Conclusión
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 ## Danos tu opinión sobre este curso
 <chapterId>195d149f-80fa-5816-8b46-995a9226d082</chapterId>
@@ -3693,8 +3695,7 @@ _Para crear este capítulo sobre Pagos Silenciosos, utilicé [el sitio de explic
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Conclusión
-
+## La palabra final
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 ¡Felicidades por completar esta capacitación sobre la privacidad en Bitcoin!

--- a/courses/btc204/fi.md
+++ b/courses/btc204/fi.md
@@ -3629,6 +3629,8 @@ Koska tämä ominaisuus on uusi, on suositeltavaa olla varovainen ja välttää 
 
 _Tämän Silent Payments -luvun luomiseen käytin [Silent Payments -selityssivustoa](https://silentpayments.xyz/) ja [BIP352-selitysdokumenttia](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)._
 
+# Johtopäätös
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 
 ## Anna meille palautetta tästä kurssista
@@ -3639,8 +3641,7 @@ _Tämän Silent Payments -luvun luomiseen käytin [Silent Payments -selityssivus
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Yhteenveto
-
+## Viimeinen sana
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Onnittelut Bitcoinin yksityisyyden suojan koulutuksen suorittamisesta!

--- a/courses/btc204/fr.md
+++ b/courses/btc204/fr.md
@@ -3888,6 +3888,9 @@ Puisque cette fonctionnalité est récente, il est conseillé de faire preuve de
 *Pour créer ce chapitre sur les Silent Payments, j'ai utilisé [le site d'explication des Silent Payments](https://silentpayments.xyz/) et [le document d'explication du BIP352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki).*
 
 
+# Conclusion
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
+
 
 ## Donnez-nous votre avis sur ce cours
 <chapterId>195d149f-80fa-5816-8b46-995a9226d082</chapterId>
@@ -3897,7 +3900,7 @@ Puisque cette fonctionnalité est récente, il est conseillé de faire preuve de
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Conclusion
+## Le mot de la fin
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Félicitations pour avoir terminé cette formation sur la confidentialité sur Bitcoin !

--- a/courses/btc204/it.md
+++ b/courses/btc204/it.md
@@ -3488,6 +3488,8 @@ Dato che questa funzionalità è recente, è consigliabile esercitare cautela ed
 _Per creare questo capitolo sui Pagamenti Silenziosi, ho utilizzato [il sito di spiegazione dei Pagamenti Silenziosi](https://silentpayments.xyz/) e [il documento di spiegazione del BIP352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)._
 
 
+# Conclusione
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 ## Dacci un feedback su questo corso
 <chapterId>195d149f-80fa-5816-8b46-995a9226d082</chapterId>
@@ -3497,8 +3499,7 @@ _Per creare questo capitolo sui Pagamenti Silenziosi, ho utilizzato [il sito di 
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Conclusione
-
+## La parola finale
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Congratulazioni per aver completato questa formazione sulla privacy in Bitcoin!

--- a/courses/btc204/ja.md
+++ b/courses/btc204/ja.md
@@ -3441,6 +3441,8 @@ Silent Paymentsの提案は比較的最近のもので、これまでに実装�
 
 *このSilent Paymentsの章を作成するために、[Silent Paymentsの説明サイト](https://silentpayments.xyz/)と[BIP352の説明文書](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)を使用しました。*
 
+# 結論
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 
 ## このコースについてのフィードバックをお寄せください
@@ -3451,7 +3453,7 @@ Silent Paymentsの提案は比較的最近のもので、これまでに実装�
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## 結論
+## 最後の言葉
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Bitcoinにおけるプライバシーに関するこのトレーニングを完了したことをお祝いします！

--- a/courses/btc204/pt.md
+++ b/courses/btc204/pt.md
@@ -3494,6 +3494,8 @@ Como essa funcionalidade é recente, é aconselhável exercer cautela e evitar u
 
 *Para criar este capítulo sobre Pagamentos Silenciosos, usei [o site de explicação dos Pagamentos Silenciosos](https://silentpayments.xyz/) e [o documento de explicação do BIP352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki).*
 
+# Conclusão
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 
 ## Dê-nos seu feedback sobre este curso
@@ -3504,7 +3506,7 @@ Como essa funcionalidade é recente, é aconselhável exercer cautela e evitar u
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Conclusão
+## A palavra final
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Parabéns por completar este treinamento sobre privacidade no Bitcoin!

--- a/courses/btc204/ru.md
+++ b/courses/btc204/ru.md
@@ -3707,6 +3707,8 @@ sp1qqvhjvsq2vz8zwrw372vuzle7472zup2ql3pz64yn5cpkw5ngv2n6jq4nl8cgm6zmu48yk3eq33ry
 
 *Для создания этой главы о Silent Payments я использовал [сайт с объяснением Silent Payments](https://silentpayments.xyz/) и [документ с объяснением BIP352](https://github.com/Биткойн/bips/blob/master/bip-0352.mediawiki).*
 
+# Заключение
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 
 ## Оставьте отзыв о данном курсе
@@ -3717,7 +3719,7 @@ sp1qqvhjvsq2vz8zwrw372vuzle7472zup2ql3pz64yn5cpkw5ngv2n6jq4nl8cgm6zmu48yk3eq33ry
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Заключение
+## Заключительное слово
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Поздравляю с завершением нашего курса по конфиденциальности в Биткойн!

--- a/courses/btc204/vi.md
+++ b/courses/btc204/vi.md
@@ -3454,6 +3454,8 @@ Vì tính năng này là mới, nên cần thận trọng và tránh sử dụng
 
 *Để tạo chương này về Silent Payments, tôi đã sử dụng [trang giải thích Silent Payments](https://silentpayments.xyz/) và [tài liệu giải thích BIP352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki).*
 
+# Kết luận
+<partId>2aee56c0-b285-4799-b4f7-373a552ee2b2</partId>
 
 
 ## Cho chúng tôi biết phản hồi của bạn về khóa học này
@@ -3464,7 +3466,7 @@ Vì tính năng này là mới, nên cần thận trọng và tránh sử dụng
 <chapterId>e803d394-e3c1-5816-a6b4-a69a2472019c</chapterId>
 <isCourseExam>true</isCourseExam>
 
-## Kết luận
+## Lời kết
 <chapterId>cd8e5c67-50e4-4dcd-8e04-88ba5ec95305</chapterId>
 
 Xin chúc mừng bạn đã hoàn thành khóa đào tạo này về quyền riêng tư trên mạng lưới Bitcoin!


### PR DESCRIPTION
The last 3 chapters of the course ("Evaluate the Course", "Final Exam", and "Conclusion") have been moved to a new, separate section named "Conclusion" with a new UUID. The UUIDs of the individual chapters remain unchanged. These modifications have been made across all languages. This can be merged directly.
