### PR TITLE
[TUTORIAL] Fix Elysium yaml

### DIFF
--- a/tutorials/wallet/elysium/tutorial.yml
+++ b/tutorials/wallet/elysium/tutorial.yml
@@ -8,7 +8,7 @@ tags:
   - lightning
   - self-sovereignty
 
-category: Mobile
+category: mobile
 
 level: beginner
 


### PR DESCRIPTION
The YAML file for the tutorial on Elysium includes the key `category: Mobile` instead of `category: mobile`, which is causing an error on the site (see image).
![elysium fix](https://github.com/user-attachments/assets/493915d2-7237-4f13-b87f-f9727401bec6)
