### PR TITLE
[COURSES] Fix quizz difficulty ECO201 and MIN201

### DIFF
--- a/courses/eco201/quizz/044/question.yml
+++ b/courses/eco201/quizz/044/question.yml
@@ -1,6 +1,6 @@
 id: 4f049946-e8a3-416a-b74d-f5abfeff43c5
 chapterId: 2578a9d8-90e9-58dd-a8c5-6366948564c7
-difficulty: intermediate
+difficulty: hard
 duration: 30
 author: DecouvreBitcoin
 tags:

--- a/courses/min201/quizz/041/question.yml
+++ b/courses/min201/quizz/041/question.yml
@@ -1,6 +1,6 @@
 id: 003be99a-48ea-443b-bc73-d18aa55ee72c
 chapterId: e6676214-007c-5181-968e-c27536231bd6
-difficulty: intermediate
+difficulty: hard
 duration: 30
 author: DecouvreBitcoin
 tags:


### PR DESCRIPTION
I just adjusted 1 question difficulty on ECO201 and MIN201 to meet the minimum distribution requirements (at least 5 easy, 15 intermediate, 20 hard). Following this PR all courses now comply with the minimum distribution, except ECO104 whose quizz needs to be completely reworked.