### PR TITLE
[TUTORIALS] Correct tutorials name

### DIFF
--- a/tutorials/mining/ocean-pool/cs.md
+++ b/tutorials/mining/ocean-pool/cs.md
@@ -1,6 +1,5 @@
 ---
-name: Těžba v oceánu
-
+name: Ocean Mining
 description: Úvod do těžby v oceánu
 ---
 

--- a/tutorials/mining/ocean-pool/et.md
+++ b/tutorials/mining/ocean-pool/et.md
@@ -1,6 +1,5 @@
 ---
-name: Ookeani Kaevandamine
-
+name: Ocean Mining
 description: Sissejuhatus Ookeani Kaevandamisse
 ---
 

--- a/tutorials/mining/ocean-pool/pt.md
+++ b/tutorials/mining/ocean-pool/pt.md
@@ -1,6 +1,5 @@
 ---
-name: Mineração Oceânica
-
+name: Ocean Mining
 description: Introdução à Mineração Oceânica
 ---
 

--- a/tutorials/mining/public-pool/cs.md
+++ b/tutorials/mining/public-pool/cs.md
@@ -1,5 +1,5 @@
 ---
-name: Veřejný bazén
+name: Public Pool
 description: Úvod do Veřejného bazénu
 ---
 

--- a/tutorials/mining/public-pool/et.md
+++ b/tutorials/mining/public-pool/et.md
@@ -1,5 +1,5 @@
 ---
-name: Avalik Bassein
+name: Public Pool
 description: Sissejuhatus Avalikku Basseini
 ---
 

--- a/tutorials/mining/public-pool/id.md
+++ b/tutorials/mining/public-pool/id.md
@@ -1,5 +1,5 @@
 ---
-name: Kolam Umum
+name: Public Pool
 description: Pengenalan Kolam Umum
 ---
 

--- a/tutorials/mining/public-pool/pt.md
+++ b/tutorials/mining/public-pool/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Piscina Pública
+name: Public Pool
 description: Introdução à Piscina Pública
 ---
 

--- a/tutorials/node/mynode/et.md
+++ b/tutorials/node/mynode/et.md
@@ -1,5 +1,5 @@
 ---
-name: Minu Node
+name: My Node
 description: Seadista oma bitcoin MyNode
 ---
 

--- a/tutorials/node/watch-tower/es.md
+++ b/tutorials/node/watch-tower/es.md
@@ -1,5 +1,5 @@
 ---
-name: Torre de Vigilancia
+name: Watch Tower
 description: Comprender y utilizar una torre de vigilancia
 ---
 

--- a/tutorials/node/watch-tower/et.md
+++ b/tutorials/node/watch-tower/et.md
@@ -1,5 +1,5 @@
 ---
-name: Vaatetorn
+name: Watch Tower
 description: Vaatetorni mõistmine ja kasutamine
 ---
 

--- a/tutorials/node/watch-tower/fi.md
+++ b/tutorials/node/watch-tower/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Vartiotorni
+name: Watch Tower
 description: Vartiotornin ymmärtäminen ja käyttäminen
 ---
 

--- a/tutorials/node/watch-tower/fr.md
+++ b/tutorials/node/watch-tower/fr.md
@@ -1,5 +1,5 @@
 ---
-name: Tour de guet
+name: Watch Tower
 description: Comprendre et utiliser une tour de guet
 ---
 

--- a/tutorials/node/watch-tower/id.md
+++ b/tutorials/node/watch-tower/id.md
@@ -1,5 +1,5 @@
 ---
-name: Menara Pengawas
+name: Watch Tower
 description: Memahami dan menggunakan menara pengawas
 ---
 

--- a/tutorials/privacy/boltzmann-entropy/es.md
+++ b/tutorials/privacy/boltzmann-entropy/es.md
@@ -1,5 +1,5 @@
 ---
-name: Calculadora de Boltzmann
+name: Boltzmann Calculator
 description: Comprender el concepto de entropía y cómo usar Boltzmann
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/boltzmann-entropy/et.md
+++ b/tutorials/privacy/boltzmann-entropy/et.md
@@ -1,5 +1,5 @@
 ---
-name: Boltzmanni Kalkulaator
+name: Boltzmann Calculator
 description: Mõista entroopia kontseptsiooni ja kuidas Boltzmanni kasutada
 ---
 ![kaas](assets/cover.webp)

--- a/tutorials/privacy/boltzmann-entropy/fi.md
+++ b/tutorials/privacy/boltzmann-entropy/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Boltzmann-laskin
+name: Boltzmann Calculator
 description: Ymmärrä entropian käsite ja miten käyttää Boltzmannia
 ---
 ![kansi](assets/cover.webp)

--- a/tutorials/privacy/boltzmann-entropy/nb-NO.md
+++ b/tutorials/privacy/boltzmann-entropy/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: Boltzmann-kalkulator
+name: Boltzmann Calculator
 description: Forstå konseptet med entropi og hvordan du bruker Boltzmann
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/boltzmann-entropy/pt.md
+++ b/tutorials/privacy/boltzmann-entropy/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Calculadora Boltzmann
+name: Boltzmann Calculator
 description: Entenda o conceito de entropia e como usar a Boltzmann
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/oxt-analysis/cs.md
+++ b/tutorials/privacy/oxt-analysis/cs.md
@@ -1,5 +1,5 @@
 ---
-name: OXT - Analýza řetězce
+name: OXT - Chain Analysis
 description: Zvládněte základy analýzy řetězce na Bitcoinu
 ---
 ![obálka](assets/cover.webp)

--- a/tutorials/privacy/oxt-analysis/es.md
+++ b/tutorials/privacy/oxt-analysis/es.md
@@ -1,5 +1,5 @@
 ---
-name: OXT - Análisis de Cadena
+name: OXT - Chain Analysis
 description: Domina los fundamentos básicos del análisis de cadena en Bitcoin
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/oxt-analysis/et.md
+++ b/tutorials/privacy/oxt-analysis/et.md
@@ -1,5 +1,5 @@
 ---
-name: OXT - Ahelanalüüs
+name: OXT - Chain Analysis
 description: Omanda Bitcoinil põhineva ahelanalüüsi algtõed
 ---
 ![kaas](assets/cover.webp)

--- a/tutorials/privacy/oxt-analysis/fi.md
+++ b/tutorials/privacy/oxt-analysis/fi.md
@@ -1,5 +1,5 @@
 ---
-name: OXT - Ketjuanalyysi
+name: OXT - Chain Analysis
 description: Hallitse Bitcoinin ketjuanalyysin perusteet
 ---
 ![kansi](assets/cover.webp)

--- a/tutorials/privacy/oxt-analysis/id.md
+++ b/tutorials/privacy/oxt-analysis/id.md
@@ -1,5 +1,5 @@
 ---
-name: OXT - Analisis Rantai
+name: OXT - Chain Analysis
 description: Kuasai dasar-dasar analisis rantai pada Bitcoin
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/oxt-analysis/pt.md
+++ b/tutorials/privacy/oxt-analysis/pt.md
@@ -1,5 +1,5 @@
 ---
-name: OXT - Análise de Cadeia
+name: OXT - Chain Analysis
 description: Domine os fundamentos básicos da análise de cadeia no Bitcoin
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/wst-anonsets/es.md
+++ b/tutorials/privacy/wst-anonsets/es.md
@@ -1,5 +1,5 @@
 ---
-name: Herramientas de Estadísticas de Whirlpool - Anonsets
+name: Whirlpool Stats Tools - Anonsets
 description: Entiende el concepto de anonset y cómo calcularlo con WST
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/wst-anonsets/et.md
+++ b/tutorials/privacy/wst-anonsets/et.md
@@ -1,5 +1,5 @@
 ---
-name: Whirlpooli statistikatööriistad - Anonsets
+name: Whirlpool Stats Tools - Anonsets
 description: Mõista anonset'i kontseptsiooni ja kuidas seda WST abil arvutada
 ---
 ![kaas](assets/cover.webp)

--- a/tutorials/privacy/wst-anonsets/fi.md
+++ b/tutorials/privacy/wst-anonsets/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Whirlpool Stats Tools - Anonsetit
+name: Whirlpool Stats Tools - Anonsets
 description: Ymmärrä anonsetin käsite ja kuinka laskea se WST:n avulla
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/privacy/wst-anonsets/pt.md
+++ b/tutorials/privacy/wst-anonsets/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Ferramentas de Estatísticas Whirlpool - Anonsets
+name: Whirlpool Stats Tools - Anonsets
 description: Entenda o conceito de anonset e como calculá-lo com o WST
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/Bitkit-Wallet/et.md
+++ b/tutorials/wallet/Bitkit-Wallet/et.md
@@ -1,6 +1,5 @@
 ---
-name: Bitkit Rahakott
-
+name: Bitkit Wallet
 description: Seadista oma isehalduslik on-chain ja Lightning Rahakott
 ---
 

--- a/tutorials/wallet/aqua/it.md
+++ b/tutorials/wallet/aqua/it.md
@@ -1,5 +1,5 @@
 ---
-name: Acqua
+name: Aqua
 description: Bitcoin, Lightning e Liquid in un unico portafoglio
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/aqua/pt.md
+++ b/tutorials/wallet/aqua/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Água
+name: Aqua
 description: Bitcoin, Lightning e Liquid numa única carteira
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-2FA/de.md
+++ b/tutorials/wallet/blockstream-green-2FA/de.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Grün - 2FA
+name: Blockstream Green - 2FA
 description: Einrichten einer 2/2-Multisig auf Green Wallet
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-2FA/es.md
+++ b/tutorials/wallet/blockstream-green-2FA/es.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - 2FA
+name: Blockstream Green - 2FA
 description: Configurar un multisig 2/2 en Monedero Verde
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-2FA/it.md
+++ b/tutorials/wallet/blockstream-green-2FA/it.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - 2FA
+name: Blockstream Green - 2FA
 description: Impostazione di un multisig 2/2 su Green Wallet
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/cs.md
+++ b/tutorials/wallet/blockstream-green-desktop/cs.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Stolní počítače
+name: Blockstream Green - Desktop
 description: Používání Zelené peněženky v počítači
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/de.md
+++ b/tutorials/wallet/blockstream-green-desktop/de.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Grün - Desktop
+name: Blockstream Green - Desktop
 description: Verwendung von Green Wallet auf Ihrem Computer
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/es.md
+++ b/tutorials/wallet/blockstream-green-desktop/es.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - Escritorio
+name: Blockstream Green - Desktop
 description: Utilizar Green Wallet en su ordenador
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/et.md
+++ b/tutorials/wallet/blockstream-green-desktop/et.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - töölaud
+name: Blockstream Green - Desktop
 description: Green Walleti kasutamine arvutis
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/fi.md
+++ b/tutorials/wallet/blockstream-green-desktop/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Työpöytä
+name: Blockstream Green - Desktop
 description: Green Walletin käyttäminen tietokoneella
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/it.md
+++ b/tutorials/wallet/blockstream-green-desktop/it.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - Desktop
+name: Blockstream Green - Desktop
 description: Utilizzo di Green Wallet sul computer
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/nb-NO.md
+++ b/tutorials/wallet/blockstream-green-desktop/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Skrivebord
+name: Blockstream Green - Desktop
 description: Bruke Green Wallet på datamaskinen din
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-desktop/pt.md
+++ b/tutorials/wallet/blockstream-green-desktop/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Ambiente de trabalho
+name: Blockstream Green - Desktop
 description: Utilizar a Green Wallet no seu computador
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/cs.md
+++ b/tutorials/wallet/blockstream-green-liquid/cs.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Tekutý
+name: Blockstream Green - Liquid
 description: Nastavení portfolia v postranním řetězci sítě Liquid Network
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/de.md
+++ b/tutorials/wallet/blockstream-green-liquid/de.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Grün - Flüssig
+name: Blockstream Green - Liquid
 description: Einrichten eines Portfolios auf der Liquid Network Sidechain
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/es.md
+++ b/tutorials/wallet/blockstream-green-liquid/es.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - Líquido
+name: Blockstream Green - Liquid
 description: Creación de una cartera en la red lateral de Liquid Network
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/et.md
+++ b/tutorials/wallet/blockstream-green-liquid/et.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - vedelik
+name: Blockstream Green - Liquid
 description: Portfelli loomine Liquid Networki külgahelas
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/fi.md
+++ b/tutorials/wallet/blockstream-green-liquid/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Nestemäinen
+name: Blockstream Green - Liquid
 description: Salkun perustaminen Liquid Networkin sivuketjuun
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/id.md
+++ b/tutorials/wallet/blockstream-green-liquid/id.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Hijau - Cair
+name: Blockstream Green - Liquid
 description: Menyiapkan portofolio di sidechain Liquid Network
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/it.md
+++ b/tutorials/wallet/blockstream-green-liquid/it.md
@@ -1,5 +1,5 @@
 ---
-name: Verde Blockstream - Liquido
+name: Blockstream Green - Liquid
 description: Impostazione di un portafoglio sulla sidechain di Liquid Network
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/nb-NO.md
+++ b/tutorials/wallet/blockstream-green-liquid/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Flytende
+name: Blockstream Green - Liquid
 description: Sette opp en portefølje på Liquid Network-sidekjeden
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-liquid/pt.md
+++ b/tutorials/wallet/blockstream-green-liquid/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - Líquido
+name: Blockstream Green - Liquid
 description: Criação de uma carteira na sidechain da Liquid Network
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/cs.md
+++ b/tutorials/wallet/blockstream-green-watch-only/cs.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Pouze pro sledování
+name: Blockstream Green - Watch-Only
 description: Konfigurace portfolia pouze pro sledování
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/de.md
+++ b/tutorials/wallet/blockstream-green-watch-only/de.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Nur beobachten
+name: Blockstream Green - Watch-Only
 description: Konfiguration eines reinen Überwachungsportfolios
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/es.md
+++ b/tutorials/wallet/blockstream-green-watch-only/es.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - Sólo en observación
+name: Blockstream Green - Watch-Only
 description: Configuración de la cartera de sólo vigilancia
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/et.md
+++ b/tutorials/wallet/blockstream-green-watch-only/et.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Ainult vaatamiseks
+name: Blockstream Green - Watch-Only
 description: Ainult vaatlusportfelli konfiguratsioon
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/fi.md
+++ b/tutorials/wallet/blockstream-green-watch-only/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Vain katselua
+name: Blockstream Green - Watch-Only
 description: Pelkän salkun kokoonpano
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/id.md
+++ b/tutorials/wallet/blockstream-green-watch-only/id.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Hanya untuk Ditonton
+name: Blockstream Green - Watch-Only
 description: Konfigurasi portofolio khusus jam tangan
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/it.md
+++ b/tutorials/wallet/blockstream-green-watch-only/it.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Solo per guardare
+name: Blockstream Green - Watch-Only
 description: Configurazione del portafoglio di soli orologi
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green-watch-only/nb-NO.md
+++ b/tutorials/wallet/blockstream-green-watch-only/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Kun for Watch-Only
+name: Blockstream Green - Watch-Only
 description: Konfigurasjon av kun overvåkingsportefølje
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/cs.md
+++ b/tutorials/wallet/blockstream-green/cs.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Mobilní zařízení
+name: Blockstream Green - Mobile
 description: Vytvoření portfolia mobilního softwaru
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/de.md
+++ b/tutorials/wallet/blockstream-green/de.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Mobil
+name: Blockstream Green - Mobile
 description: Aufbau eines mobilen Softwareportfolios
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/es.md
+++ b/tutorials/wallet/blockstream-green/es.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - Móvil
+name: Blockstream Green - Mobile
 description: Crear una cartera de software móvil
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/et.md
+++ b/tutorials/wallet/blockstream-green/et.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - mobiilne
+name: Blockstream Green - Mobile
 description: Mobiilse tarkvara portfelli loomine
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/fi.md
+++ b/tutorials/wallet/blockstream-green/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Mobiili
+name: Blockstream Green - Mobile
 description: Mobiiliohjelmistosalkun perustaminen
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/id.md
+++ b/tutorials/wallet/blockstream-green/id.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Seluler
+name: Blockstream Green - Mobile
 description: Menyiapkan portofolio perangkat lunak seluler
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/it.md
+++ b/tutorials/wallet/blockstream-green/it.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Verde - Mobile
+name: Blockstream Green - Mobile
 description: Impostazione di un portafoglio software mobile
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/nb-NO.md
+++ b/tutorials/wallet/blockstream-green/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Mobil
+name: Blockstream Green - Mobile
 description: Etablering av en mobil programvareportefølje
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/blockstream-green/pt.md
+++ b/tutorials/wallet/blockstream-green/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Blockstream Green - Telemóvel
+name: Blockstream Green - Mobile
 description: Criação de uma carteira de software móvel
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/cs.md
+++ b/tutorials/wallet/passphrase-ledger/cs.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Heslo pro Ledger
+name: Passphrase BIP39 Ledger
 description: Jak přidat heslo do vaší peněženky Ledger?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/de.md
+++ b/tutorials/wallet/passphrase-ledger/de.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase Ledger
+name: Passphrase BIP39 Ledger
 description: Wie fügt man seinem Ledger-Wallet eine Passphrase hinzu?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/en.md
+++ b/tutorials/wallet/passphrase-ledger/en.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase Ledger
+name: Passphrase BIP39 Ledger
 description: How to add a passphrase to your Ledger wallet?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/es.md
+++ b/tutorials/wallet/passphrase-ledger/es.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase Ledger
+name: Passphrase BIP39 Ledger
 description: Cómo añadir una frase de contraseña a tu monedero Ledger?
 ---
 

--- a/tutorials/wallet/passphrase-ledger/et.md
+++ b/tutorials/wallet/passphrase-ledger/et.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Paroolilausete Ledger
+name: Passphrase BIP39 Ledger
 description: Kuidas lisada paroolilauset oma Ledger rahakotti?
 ---
 ![kaas](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/fi.md
+++ b/tutorials/wallet/passphrase-ledger/fi.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase Ledger
+name: Passphrase BIP39 Ledger
 description: Kuinka lisätä salasana Ledger-lompakkoosi?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/id.md
+++ b/tutorials/wallet/passphrase-ledger/id.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase Ledger
+name: Passphrase BIP39 Ledger
 description: Bagaimana cara menambahkan passphrase ke dompet Ledger Anda?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/it.md
+++ b/tutorials/wallet/passphrase-ledger/it.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase Ledger
+name: Passphrase BIP39 Ledger
 description: Come aggiungere una passphrase al tuo portafoglio Ledger?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/nb-NO.md
+++ b/tutorials/wallet/passphrase-ledger/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passordbok
+name: Passphrase BIP39 Ledger
 description: Hvordan legger du til en passordfrase i Ledger-lommeboken din?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase-ledger/pt.md
+++ b/tutorials/wallet/passphrase-ledger/pt.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase Ledger
+name: Passphrase BIP39 Ledger
 description: Como adicionar uma passphrase à sua carteira Ledger?
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/cs.md
+++ b/tutorials/wallet/passphrase/cs.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Heslo
+name: Passphrase BIP39
 description: Porozumění tomu, jak heslo funguje
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/de.md
+++ b/tutorials/wallet/passphrase/de.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase
+name: Passphrase BIP39
 description: Verständnis darüber, wie eine Passphrase funktioniert
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/en.md
+++ b/tutorials/wallet/passphrase/en.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase
+name: Passphrase BIP39
 description: Understanding how a passphrase works
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/es.md
+++ b/tutorials/wallet/passphrase/es.md
@@ -1,5 +1,5 @@
 ---
-name: Frase de paso BIP39
+name: Passphrase BIP39
 description: Entendiendo cómo funciona una frase de paso
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/et.md
+++ b/tutorials/wallet/passphrase/et.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Paroolilause
+name: Passphrase BIP39
 description: Mõistmaks, kuidas paroolilause töötab
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/fi.md
+++ b/tutorials/wallet/passphrase/fi.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Salasana
+name: Passphrase BIP39
 description: Ymmärrys siitä, miten salasana toimii
 ---
 ![kansi](assets/cover.webp)

--- a/tutorials/wallet/passphrase/id.md
+++ b/tutorials/wallet/passphrase/id.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase
+name: Passphrase BIP39
 description: Memahami cara kerja passphrase
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/it.md
+++ b/tutorials/wallet/passphrase/it.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 Passphrase
+name: Passphrase BIP39
 description: Comprendere il funzionamento di una passphrase
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/nb-NO.md
+++ b/tutorials/wallet/passphrase/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: BIP39 passordfrase
+name: Passphrase BIP39
 description: Forstå hvordan en passordfrase fungerer
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/passphrase/pt.md
+++ b/tutorials/wallet/passphrase/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Frase-senha BIP39
+name: Passphrase BIP39
 description: Entendendo como uma frase-senha funciona
 ---
 ![cover](assets/cover.webp)

--- a/tutorials/wallet/trezor/cs.md
+++ b/tutorials/wallet/trezor/cs.md
@@ -1,6 +1,5 @@
 ---
 name: Trezor model One
-
 description: Nastavení a používání Trezoru modelu One
 ---
 

--- a/tutorials/wallet/trezor/de.md
+++ b/tutorials/wallet/trezor/de.md
@@ -1,6 +1,5 @@
 ---
-name: Trezor Modell One
-
+name: Trezor model One
 description: Einrichtung und Verwendung des Trezor Modell One
 ---
 

--- a/tutorials/wallet/trezor/es.md
+++ b/tutorials/wallet/trezor/es.md
@@ -1,6 +1,5 @@
 ---
-name: Trezor modelo One
-
+name: Trezor model One
 description: Configuración y uso del Trezor modelo One
 ---
 

--- a/tutorials/wallet/trezor/et.md
+++ b/tutorials/wallet/trezor/et.md
@@ -1,6 +1,5 @@
 ---
 name: Trezor model One
-
 description: Trezor model One seadistamine ja kasutamine
 ---
 

--- a/tutorials/wallet/trezor/fi.md
+++ b/tutorials/wallet/trezor/fi.md
@@ -1,6 +1,5 @@
 ---
 name: Trezor model One
-
 description: Trezor model Onen käyttöönotto ja käyttö
 ---
 

--- a/tutorials/wallet/trezor/fr.md
+++ b/tutorials/wallet/trezor/fr.md
@@ -1,6 +1,5 @@
 ---
-name: Trezor modèle One
-
+name: Trezor model One
 description: Configuration et utilisation du Trezor modèle One
 ---
 

--- a/tutorials/wallet/trezor/id.md
+++ b/tutorials/wallet/trezor/id.md
@@ -1,6 +1,5 @@
 ---
 name: Trezor model One
-
 description: Pengaturan dan penggunaan Trezor model One
 ---
 

--- a/tutorials/wallet/trezor/it.md
+++ b/tutorials/wallet/trezor/it.md
@@ -1,6 +1,5 @@
 ---
 name: Trezor model One
-
 description: Configurazione e utilizzo di Trezor model One
 ---
 

--- a/tutorials/wallet/trezor/nb-NO.md
+++ b/tutorials/wallet/trezor/nb-NO.md
@@ -1,6 +1,5 @@
 ---
 name: Trezor model One
-
 description: Oppsett og bruk av Trezor model One
 ---
 

--- a/tutorials/wallet/trezor/pt.md
+++ b/tutorials/wallet/trezor/pt.md
@@ -1,6 +1,5 @@
 ---
-name: Trezor modelo One
-
+name: Trezor model One
 description: Configuração e uso do Trezor modelo One
 ---
 


### PR DESCRIPTION
Some tutorial `name:` were translated when they shouldn’t have been because they were brand or software names. For example: "Blockstream Green" became "Blockstream Verde" in Italian. This has been corrected in all languages except those with special characters (ru, zh, ja, vi), as I find it difficult to determine if the title is consistent. Do you think I should include these in the modifications? Thanks
