### PR TITLE
[TUTORIAL] Bacca - fix links

### DIFF
--- a/tutorials/wallet/bacca/cs.md
+++ b/tutorials/wallet/bacca/cs.md
@@ -99,8 +99,11 @@ Nyní máte přístup k rozhraní softwaru.
 Pokud je váš Ledger nový, ujistěte se, že jste nastavili kód PIN a uložili frázi pro obnovení. Pro tyto úvodní kroky nepotřebujete Ledger Live. Jednoduše připojte Ledger přes USB kabel a napájejte jej. Pokud si nejste jisti, jak postupovat v těchto dvou krocích, můžete se podívat na začátek návodu specifického pro váš model:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
 https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Použití Bacca
 
 Připojte Ledger k počítači a odemkněte jej pomocí nastaveného kódu PIN. Bacca by měla automaticky detekovat váš Ledger.

--- a/tutorials/wallet/bacca/cs.md
+++ b/tutorials/wallet/bacca/cs.md
@@ -99,8 +99,8 @@ Nyní máte přístup k rozhraní softwaru.
 Pokud je váš Ledger nový, ujistěte se, že jste nastavili kód PIN a uložili frázi pro obnovení. Pro tyto úvodní kroky nepotřebujete Ledger Live. Jednoduše připojte Ledger přes USB kabel a napájejte jej. Pokud si nejste jisti, jak postupovat v těchto dvou krocích, můžete se podívat na začátek návodu specifického pro váš model:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
 ## Použití Bacca
 
 Připojte Ledger k počítači a odemkněte jej pomocí nastaveného kódu PIN. Bacca by měla automaticky detekovat váš Ledger.

--- a/tutorials/wallet/bacca/de.md
+++ b/tutorials/wallet/bacca/de.md
@@ -99,8 +99,11 @@ Sie haben nun Zugriff auf die Softwareoberfläche.
 Wenn Ihr Ledger neu ist, müssen Sie zunächst den PIN-Code einrichten und die Wiederherstellungsphrase speichern. Für diese ersten Schritte benötigen Sie Ledger Live nicht. Schließen Sie Ihren Ledger einfach über das USB-Kabel an, um ihn mit Strom zu versorgen. Wenn Sie sich nicht sicher sind, wie Sie mit diesen beiden Schritten vorgehen sollen, können Sie am Anfang der Anleitung für Ihr Modell nachlesen:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Verwendung von Bacca
 
 Schließen Sie Ihren Ledger an Ihren Computer an und entsperren Sie ihn mit dem von Ihnen eingestellten PIN-Code. Bacca sollte Ihren Ledger automatisch erkennen.

--- a/tutorials/wallet/bacca/en.md
+++ b/tutorials/wallet/bacca/en.md
@@ -99,7 +99,11 @@ You now have access to the software interface.
 Before you start, if your Ledger is new, make sure you have set up the PIN code and saved the recovery phrase. You don't need Ledger Live for these initial steps. Simply connect your Ledger via the USB cable to power it. If you're not sure how to proceed with these two steps, you can refer to the beginning of the tutorial specific to your model:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
+
 https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+
 https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
 ## Using Bacca
 

--- a/tutorials/wallet/bacca/en.md
+++ b/tutorials/wallet/bacca/en.md
@@ -100,11 +100,10 @@ Before you start, if your Ledger is new, make sure you have set up the PIN code 
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
 
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
 
-
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
 ## Using Bacca
 
 Connect your Ledger to your computer and unlock it using the PIN code you have set. Bacca should automatically detect your Ledger.

--- a/tutorials/wallet/bacca/es.md
+++ b/tutorials/wallet/bacca/es.md
@@ -99,8 +99,11 @@ Ahora tiene acceso a la interfaz del software.
 Antes de empezar, si su Ledger es nuevo, asegúrese de haber configurado el código PIN y guardado la frase de recuperación. No necesita Ledger Live para estos pasos iniciales. Simplemente conecta tu Ledger a través del cable USB para encenderlo. Si no estás seguro de cómo proceder con estos dos pasos, puedes consultar el principio del tutorial específico para tu modelo:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Uso de Bacca
 
 Conecte su Ledger a su ordenador y desbloquéelo utilizando el código PIN que haya establecido. Bacca debería detectar automáticamente su Ledger.

--- a/tutorials/wallet/bacca/et.md
+++ b/tutorials/wallet/bacca/et.md
@@ -99,8 +99,11 @@ Nüüd on teil juurdepääs tarkvaraliidesele.
 Kui teie Ledger on uus, veenduge enne alustamist, et olete seadistanud PIN-koodi ja salvestanud taastamislauset. Nende esialgsete sammude jaoks ei ole teil vaja Ledger Live'i. Lihtsalt ühendage oma Ledger USB-kaabli kaudu, et see saaks voolu. Kui te ei ole kindel, kuidas nende kahe sammuga edasi minna, võite vaadata oma mudelile vastava õpetuse algust:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Bacca kasutamine
 
 Ühendage oma Ledger arvutiga ja vabastage see seatud PIN-koodi abil. Bacca peaks teie Ledgeri automaatselt tuvastama.

--- a/tutorials/wallet/bacca/fi.md
+++ b/tutorials/wallet/bacca/fi.md
@@ -99,8 +99,11 @@ Sinulla on nyt pääsy ohjelmiston käyttöliittymään.
 Jos Ledger on uusi, varmista ennen aloittamista, että olet määrittänyt PIN-koodin ja tallentanut palautuslausekkeen. Et tarvitse Ledger Liveä näihin alkuvaiheisiin. Kytke Ledgeriin virta USB-kaapelilla. Jos et ole varma, miten edetä näissä kahdessa vaiheessa, voit tutustua malliasi koskevan ohjeen alkuun:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Baccan käyttäminen
 
 Liitä Ledger tietokoneeseen ja avaa sen lukitus asettamallasi PIN-koodilla. Baccan pitäisi tunnistaa Ledger automaattisesti.

--- a/tutorials/wallet/bacca/fr.md
+++ b/tutorials/wallet/bacca/fr.md
@@ -102,9 +102,9 @@ Avant de commencer, si votre Ledger est neuve, assurez-vous d'avoir configuré l
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
 
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
 
 ## Utilisation de Bacca
 

--- a/tutorials/wallet/bacca/fr.md
+++ b/tutorials/wallet/bacca/fr.md
@@ -143,3 +143,5 @@ Si vous avez trouvé ce tutoriel utile, je vous serais reconnaissant de laisser 
 Je vous recommande également de consulter ce tutoriel sur GnuPG, qui vous expliquera comment vérifier l'intégrité et l'authenticité de vos logiciels avant leur installation. C'est une pratique importante, notamment lorsque vous installez des logiciels de gestion de portefeuille tels que Liana ou Sparrow :
 
 https://planb.network/tutorials/others/general/integrity-authenticity-21d0420a-be02-4663-94a3-8d487f23becc
+
+

--- a/tutorials/wallet/bacca/id.md
+++ b/tutorials/wallet/bacca/id.md
@@ -99,8 +99,11 @@ Anda sekarang memiliki akses ke antarmuka perangkat lunak.
 Sebelum memulai, jika Ledger Anda masih baru, pastikan Anda telah mengatur kode PIN dan menyimpan frasa pemulihan. Anda tidak memerlukan Ledger Live untuk langkah awal ini. Cukup sambungkan Ledger Anda melalui kabel USB untuk menyalakannya. Jika Anda tidak yakin bagaimana cara melanjutkan kedua langkah ini, Anda dapat merujuk ke awal tutorial khusus untuk model Anda:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Menggunakan Bacca
 
 Hubungkan Buku Besar Anda ke komputer Anda dan buka kuncinya menggunakan kode PIN yang telah Anda tetapkan. Bacca akan secara otomatis mendeteksi Ledger Anda.

--- a/tutorials/wallet/bacca/it.md
+++ b/tutorials/wallet/bacca/it.md
@@ -99,10 +99,10 @@ Ora si ha accesso all'interfaccia del software.
 Prima di iniziare, se il vostro Ledger è nuovo, assicuratevi di aver impostato il codice PIN e salvato la frase di recupero. Per queste fasi iniziali non è necessario Ledger Live. È sufficiente collegare il Ledger tramite il cavo USB per alimentarlo. Se non si è sicuri di come procedere con questi due passaggi, si può fare riferimento all'inizio del tutorial specifico per il proprio modello:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-.
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-.
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
 
 ## Utilizzo di Bacca
 

--- a/tutorials/wallet/bacca/it.md
+++ b/tutorials/wallet/bacca/it.md
@@ -99,8 +99,11 @@ Ora si ha accesso all'interfaccia del software.
 Prima di iniziare, se il vostro Ledger è nuovo, assicuratevi di aver impostato il codice PIN e salvato la frase di recupero. Per queste fasi iniziali non è necessario Ledger Live. È sufficiente collegare il Ledger tramite il cavo USB per alimentarlo. Se non si è sicuri di come procedere con questi due passaggi, si può fare riferimento all'inizio del tutorial specifico per il proprio modello:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+.
 https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+.
 https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Utilizzo di Bacca
 
 Collegare il Ledger al computer e sbloccarlo utilizzando il codice PIN impostato. Bacca dovrebbe rilevare automaticamente il Ledger.

--- a/tutorials/wallet/bacca/ja.md
+++ b/tutorials/wallet/bacca/ja.md
@@ -99,8 +99,11 @@ cargo run -p ledger_manager_gui
 始める前に、Ledgerが新しい場合は、PINコードを設定し、リカバリーフレーズを保存していることを確認してください。これらの初期ステップにはLedger Liveは必要ありません。USBケーブルでLedgerを接続し、電源を入れるだけです。この2つのステップの進め方がわからない場合は、お使いのモデルに特化したチュートリアルの冒頭を参照してください：
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## バッカの使用
 
 Ledger をコンピューターに接続し、設定した PIN コードを使用してロックを解除します。Bacca が自動的に Ledger を検出します。

--- a/tutorials/wallet/bacca/nb-NO.md
+++ b/tutorials/wallet/bacca/nb-NO.md
@@ -99,8 +99,11 @@ Du har nå tilgang til programvaregrensesnittet.
 Hvis du har en ny Ledger, må du sørge for at du har satt opp PIN-koden og lagret gjenopprettingsfrasen før du starter. Du trenger ikke Ledger Live for disse innledende trinnene. Du trenger bare å koble til Ledger via USB-kabelen for å gi den strøm. Hvis du ikke er sikker på hvordan du går frem med disse to trinnene, kan du se begynnelsen av veiledningen som er spesifikk for din modell:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Bruk av Bacca
 
 Koble Ledger til datamaskinen, og lås den opp ved hjelp av PIN-koden du har angitt. Bacca bør automatisk oppdage Ledger.

--- a/tutorials/wallet/bacca/pt.md
+++ b/tutorials/wallet/bacca/pt.md
@@ -99,8 +99,11 @@ Tem agora acesso à interface do software.
 Antes de começar, se o seu Ledger for novo, certifique-se de que configurou o código PIN e guardou a frase de recuperação. Não precisa do Ledger Live para estes passos iniciais. Basta ligar o Ledger através do cabo USB para o alimentar. Se não tiver a certeza de como proceder com estes dois passos, pode consultar o início do tutorial específico para o seu modelo:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Utilização de Bacca
 
 Ligue o seu Ledger ao computador e desbloqueie-o utilizando o código PIN que definiu. O Bacca deve detetar automaticamente o seu Ledger.

--- a/tutorials/wallet/bacca/ru.md
+++ b/tutorials/wallet/bacca/ru.md
@@ -99,8 +99,11 @@ cargo run -p ledger_manager_gui
 Прежде чем начать, если ваш Ledger новый, убедитесь, что вы настроили PIN-код и сохранили фразу восстановления. Для этих начальных шагов вам не нужна программа Ledger Live. Просто подключите Ledger к питанию через USB-кабель. Если вы не знаете, как выполнить эти два шага, обратитесь к началу руководства по конкретной модели:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Использование Бакки
 
 Подключите Ledger к компьютеру и разблокируйте его с помощью установленного PIN-кода. Bacca автоматически обнаружит ваш Ledger.

--- a/tutorials/wallet/bacca/vi.md
+++ b/tutorials/wallet/bacca/vi.md
@@ -99,8 +99,11 @@ You now have access to the software interface.
 Before you start, if your Ledger is new, make sure you have set up the PIN code and saved the recovery phrase. You don't need Ledger Live for these initial steps. Simply connect your Ledger via the USB cable to power it. If you're not sure how to proceed with these two steps, you can refer to the beginning of the tutorial specific to your model:
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## Using Bacca
 
 Connect your Ledger to your computer and unlock it using the PIN code you have set. Bacca should automatically detect your Ledger.

--- a/tutorials/wallet/bacca/zh-Hans.md
+++ b/tutorials/wallet/bacca/zh-Hans.md
@@ -99,8 +99,11 @@ cargo run -p ledger_manager_gui
 开始之前，如果你的 Ledger 是新的，请确保你已经设置了 PIN 码并保存了恢复短语。这些初始步骤不需要 Ledger Live。只需通过 USB 电缆连接 Ledger，为其供电即可。如果你不确定如何进行这两个步骤，可以参考针对你的型号的教程开头部分：
 
 https://planb.network/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
-https://planb.network/fr/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
-https://planb.network/fr/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
+https://planb.network/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
+
+https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a
+
 ## 使用巴卡
 
 将 Ledger 与电脑连接，使用设置的 PIN 码解锁。Bacca 会自动检测到您的记账本。


### PR DESCRIPTION
The link previews weren’t appearing because of the `/fr/` in the URLs. All languages fixed