### PR TITLE
[TUTORIAL] Passphrase - Add 2 new links

### DIFF
--- a/tutorials/wallet/passphrase/cs.md
+++ b/tutorials/wallet/passphrase/cs.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 Na COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Na Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Na Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/de.md
+++ b/tutorials/wallet/passphrase/de.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 Auf einer COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Auf einem Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Auf einem Passport (Batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/en.md
+++ b/tutorials/wallet/passphrase/en.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 On a COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+On a Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+On a Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/es.md
+++ b/tutorials/wallet/passphrase/es.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 En una COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+En un Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+En un Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/et.md
+++ b/tutorials/wallet/passphrase/et.md
@@ -37,6 +37,14 @@ Paroolilause seadistamiseks Ledger seadmel (Stax, Flex või Nano), võite konsul
 
 https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-438a-8fe0-e59147ef2f49
 
-COLDCARD-il:
+COLDCARD seadmel:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Jade Plus seadmel:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Passport (batch-2) seadmel:
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/fi.md
+++ b/tutorials/wallet/passphrase/fi.md
@@ -37,6 +37,14 @@ Salasanan asettamiseksi Ledger-laitteeseen (Stax, Flex tai Nano), voit katsoa t√
 
 https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-438a-8fe0-e59147ef2f49
 
-COLDCARD-laitteella:
+COLDCARD -laitteella:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Jade Plus -laitteella:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Passport (batch-2) -laitteella:
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/fr.md
+++ b/tutorials/wallet/passphrase/fr.md
@@ -41,3 +41,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 Sur une COLDCARD :
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Sur un Jade Plus :
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Sur un Passport (batch-2) :
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/id.md
+++ b/tutorials/wallet/passphrase/id.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 Pada COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Pada Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Pada Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/it.md
+++ b/tutorials/wallet/passphrase/it.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 Su una COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Su un Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Su un Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/ja.md
+++ b/tutorials/wallet/passphrase/ja.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 COLDCARDで:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Jade Plus で:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Passport (batch-2) で:
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/nb-NO.md
+++ b/tutorials/wallet/passphrase/nb-NO.md
@@ -37,3 +37,15 @@ Det er også viktig å lagre denne passordfrasen på riktig måte, på samme må
 Hvis du vil sette opp en passordfrase på en Ledger-enhet (Stax, Flex eller Nano), kan du se denne veiledningen:
 
 https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-438a-8fe0-e59147ef2f49
+
+På en COLDCARD :
+
+https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+På en Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+På en Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/pt.md
+++ b/tutorials/wallet/passphrase/pt.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 Em uma COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Em um Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Em um Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/ru.md
+++ b/tutorials/wallet/passphrase/ru.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 На COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+На Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+На Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/vi.md
+++ b/tutorials/wallet/passphrase/vi.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 Trên COLDCARD:
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+Trên Jade Plus:
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+Trên Passport (batch-2):
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236

--- a/tutorials/wallet/passphrase/zh-Hans.md
+++ b/tutorials/wallet/passphrase/zh-Hans.md
@@ -40,3 +40,11 @@ https://planb.network/tutorials/wallet/hardware/passphrase-ledger-9ae6d9a2-7293-
 在 COLDCARD 上：
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
+
+在 Jade Plus 上：
+
+https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-4618-860d-cd771373a262
+
+在 Passport (batch-2) 上：
+
+https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236


### PR DESCRIPTION
I added links to the Jade Plus and Passport tutorials in the theoretical tutorial on the BIP39 passphrase. Links were added in all languages. No translation needed.