### PR TITLE
[HIS201] Fix duplicate <isCourseReview> <isCourseExam>

### DIFF
--- a/courses/his201/cs.md
+++ b/courses/his201/cs.md
@@ -1217,14 +1217,6 @@ Tento záhadný aspekt obklopující tvůrce Bitcoinu byl dobře shrnut Hal Finn
 >
 > Co znamená to S?"
 
-## Recenze & Hodnocení
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Závěrečná zkouška
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Převzetí komunity
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/de.md
+++ b/courses/his201/de.md
@@ -1225,13 +1225,6 @@ Dieser mysteriöse Aspekt, der den Schöpfer von Bitcoin umgibt, wurde im Juni 2
 >
 > Wofür steht das S?"
 
-## Bewertungen & Noten
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Abschlussprüfung
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
 
 ## Die Übernahme durch die Gemeinschaft
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>

--- a/courses/his201/en.md
+++ b/courses/his201/en.md
@@ -1339,14 +1339,6 @@ This mysterious aspect surrounding the creator of Bitcoin was well summarized by
 > What does the S stand for?"
 
 
-## Reviews & Ratings
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Final Exam
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## The Community Taking Over
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/es.md
+++ b/courses/his201/es.md
@@ -1213,14 +1213,6 @@ Este aspecto misterioso que rodea al creador de Bitcoin fue bien resumido por Ha
 >
 > ¿Qué significa la S?"
 
-## Reseñas & Valoraciones
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Examen Final
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## La Comunidad se hace cargo
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/et.md
+++ b/courses/his201/et.md
@@ -1289,16 +1289,6 @@ See müstiline aspekt Bitcoini looja ümber võeti hästi kokku Hal Finney poolt
 >
 > Mida tähendab S?"
 
-## Hinnangud & Reitingud
-
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Lõpueksam
-
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Kogukonna ülevõtmine
 
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>

--- a/courses/his201/fi.md
+++ b/courses/his201/fi.md
@@ -1302,16 +1302,6 @@ Tämä mystinen näkökulma Bitcoinin luojasta tiivistettiin hyvin Hal Finneyn t
 >
 > Mitä S tarkoittaa?"
 
-## Arviot & Arvosanat
-
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Loppukoe
-
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Yhteisön ottaminen haltuun
 
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>

--- a/courses/his201/fr.md
+++ b/courses/his201/fr.md
@@ -1428,14 +1428,6 @@ Cette dimension mystérieuse entourant le créateur de Bitcoin a par ailleurs é
 > Que représente le S ? »
 
 
-## Avis & Notes
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Examen final
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## La prise de relai de la communauté
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/id.md
+++ b/courses/his201/id.md
@@ -1235,14 +1235,6 @@ Aspek misterius yang mengelilingi pencipta Bitcoin ini dirangkum dengan baik ole
 >
 > Apa arti huruf S itu?"
 
-## Ulasan & Penilaian
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Ujian Akhir
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Komunitas Mengambil Alih
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/it.md
+++ b/courses/his201/it.md
@@ -1225,14 +1225,6 @@ Questo aspetto misterioso che circonda il creatore di Bitcoin è stato ben riass
 >
 > Cosa rappresenta la S?"
 
-## Recensioni & Valutazioni
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Esame Finale
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Il Passaggio alla Comunità
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/ja.md
+++ b/courses/his201/ja.md
@@ -1232,15 +1232,6 @@ Bitcoinの創設者を取り巻くこの神秘的な側面は、2014年に亡く
 >
 > Sは何を意味するのか？"
 
-
-## レビュー & 評価
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## 最終試験
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## コミュニティの引き継ぎ
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/nb-NO.md
+++ b/courses/his201/nb-NO.md
@@ -1289,16 +1289,6 @@ Dette mystiske aspektet rundt skaperen av Bitcoin ble godt oppsummert av Hal Fin
 >
 > Hva står S for?"
 
-## Vurderinger & Karakterer
-
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Avsluttende eksamen
-
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Fellesskapet tar over
 
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>

--- a/courses/his201/pt.md
+++ b/courses/his201/pt.md
@@ -1209,14 +1209,6 @@ Este aspecto misterioso em torno do criador do Bitcoin foi bem resumido por Hal 
 >
 > O que o S representa?"
 
-## Avaliações & Notas
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Exame Final
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## A Comunidade Assumindo o Controle
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/ru.md
+++ b/courses/his201/ru.md
@@ -1226,14 +1226,6 @@ EFF потребовалось некоторое время, чтобы нач�
 >
 > Что означает буква S?"
 
-## Отзывы & Оценки
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Итоговый экзамен
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Переход к сообществу
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/vi.md
+++ b/courses/his201/vi.md
@@ -1242,14 +1242,6 @@ Khía cạnh bí ẩn xung quanh người tạo ra Bitcoin đã được Hal Fin
 >
 > Chữ S đại diện cho cái gì?"
 
-## Nhận xét & Đánh giá
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## Kỳ Thi Cuối Kỳ
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## Cộng Đồng Tiếp Quản
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 

--- a/courses/his201/zh-Hans.md
+++ b/courses/his201/zh-Hans.md
@@ -1235,15 +1235,6 @@ Satoshi将网站、论坛和wiki的控制权转移给了Martti，Martti已经在
 >
 > S代表什么？"
 
-
-## 评价 & 评分
-<chapterId>73825805-29e2-54bf-a8c3-62614b52fbef</chapterId>
-<isCourseReview>true</isCourseReview>
-
-## 期末考试
-<chapterId>39e43ec2-5b38-5174-882a-c1f7d284b9e6</chapterId>
-<isCourseExam>true</isCourseExam>
-
 ## 社区接管
 <chapterId>16c5e6d6-2412-48c6-9687-6af92cf0d89a</chapterId>
 


### PR DESCRIPTION
In all languages of HIS201, there were `<isCourseReview>` and `<isCourseExam>` chapters appearing in the middle of other chapters, even though they were already correctly placed at the end of the course.

I removed the misplaced occurrences in all languages.