### PR TITLE
[FIX TYPO] Cyrillic in the text

### DIFF
--- a/resources/newsletters/adler-crypto-insight/newsletter.yml
+++ b/resources/newsletters/adler-crypto-insight/newsletter.yml
@@ -1,5 +1,5 @@
 id: 2f96b9c7-1c7c-4342-bdcb-e5ca3ce678e8
-title: "Adler's Сrypto Insight"
+title: "Adler's Crypto Insight"
 author: Alex Adler Jr
 level: beginner
 publication_date: 2024-07-21


### PR DESCRIPTION
Fixed cyrillic typos in adler's newsletter. However, all other "c" characters except the title's one didn't count as edited after having forced the latin "c" everywhere inside this newsletter, folder title included. 