### PR TITLE
[TUTORIAL] Bitcoin Core change title

### DIFF
--- a/tutorials/node/bitcoin-core-linux/cs.md
+++ b/tutorials/node/bitcoin-core-linux/cs.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Spuštění vlastního uzlu s Bitcoin Core
 ---
 

--- a/tutorials/node/bitcoin-core-linux/de.md
+++ b/tutorials/node/bitcoin-core-linux/de.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core-Knotenpunkt (Linux)
+name: Bitcoin Core (Linux)
 description: Führen Sie Ihren eigenen Knotenpunkt mit Bitcoin Core aus
 ---
 
@@ -130,3 +130,4 @@ Um die Protokolle Ihres Bitcoin-Knotens in Bezug auf die Interaktion mit Tor gen
 > - Tor-Konfigurationsanleitung von Jon Atack
 
 Wie immer, wenn Sie Fragen haben, zögern Sie nicht, sie mit der Agora256-Community zu teilen. Gemeinsam lernen wir, um morgen besser zu sein als heute!
+

--- a/tutorials/node/bitcoin-core-linux/en.md
+++ b/tutorials/node/bitcoin-core-linux/en.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Running your own node with Bitcoin Core
 ---
 
@@ -124,3 +124,4 @@ To view the logs of your Bitcoin node specifically related to its interaction wi
 - Tor configuration guide by Jon Atack
 
 As always, if you have any questions, feel free to share them with the Agora256 community. We learn together to be better tomorrow than we are today!
+

--- a/tutorials/node/bitcoin-core-linux/es.md
+++ b/tutorials/node/bitcoin-core-linux/es.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (linux)
+name: Bitcoin Core (Linux)
 description: Faire tourner son propre nœud avec Bitcoin Core
 ---
 
@@ -130,3 +130,4 @@ Para consultar los registros de su nodo Bitcoin en relación específicamente co
 > - Guía de configuración de Tor por Jon Atack
 
 Como siempre, si tiene alguna pregunta, no dude en compartirla con la comunidad Agora256, ¡aprendemos juntos para ser mejores mañana de lo que somos hoy!
+

--- a/tutorials/node/bitcoin-core-linux/et.md
+++ b/tutorials/node/bitcoin-core-linux/et.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Oma sõlme käitamine Bitcoin Core'iga
 ---
 

--- a/tutorials/node/bitcoin-core-linux/fi.md
+++ b/tutorials/node/bitcoin-core-linux/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Oma noden pyörittäminen Bitcoin Corella
 ---
 

--- a/tutorials/node/bitcoin-core-linux/fr.md
+++ b/tutorials/node/bitcoin-core-linux/fr.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core  (linux)
+name: Bitcoin Core (Linux)
 description: Faire tourner son propre nœud avec Bitcoin Core
 ---
 
@@ -132,3 +132,4 @@ Pour consulter les logs de votre nœud Bitcoin en ce qui à trait plus spécifiq
 > - Guide de configuration Tor par Jon Atack
 
 Comme toujours, si vous avez des questions, n'hésitez pas à les partager à la communauté Agora256, nous apprenons ensemble, pour être meilleur demain que nous ne le sommes aujourd'hui!
+

--- a/tutorials/node/bitcoin-core-linux/id.md
+++ b/tutorials/node/bitcoin-core-linux/id.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Menjalankan node Anda sendiri dengan Bitcoin Core
 ---
 

--- a/tutorials/node/bitcoin-core-linux/it.md
+++ b/tutorials/node/bitcoin-core-linux/it.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (linux)
+name: Bitcoin Core (Linux)
 description: Eseguire il proprio nodo con Bitcoin Core
 ---
 
@@ -130,3 +130,4 @@ Per consultare i log del tuo nodo Bitcoin relativi alla sua interazione con Tor,
 > - Guida alla configurazione di Tor di Jon Atack
 
 Come sempre, se hai domande, non esitare a condividerle con la comunità di Agora256, impariamo insieme per essere migliori domani di quanto non siamo oggi!
+

--- a/tutorials/node/bitcoin-core-linux/ja.md
+++ b/tutorials/node/bitcoin-core-linux/ja.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Bitcoin Coreを使って自分自身のノードを運用する
 ---
 
@@ -119,3 +119,4 @@ Bitcoin CoreをTorネットワークのみを使用してピアと接続する�
 > - Tor configuration guide by Jon Atack
 
 いつものように、質問があればAgora256コミュニティで共有してください。私たちは一緒に学び、今日よりも明日より良くなります！
+

--- a/tutorials/node/bitcoin-core-linux/nb-NO.md
+++ b/tutorials/node/bitcoin-core-linux/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Kjør din egen node med Bitcoin Core
 ---
 

--- a/tutorials/node/bitcoin-core-linux/pt.md
+++ b/tutorials/node/bitcoin-core-linux/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (linux)
+name: Bitcoin Core (Linux)
 description: Executando seu próprio nó com Bitcoin Core
 ---
 
@@ -129,3 +129,4 @@ Para verificar os logs do seu nó Bitcoin em relação à sua interação com o 
 > - Guia de configuração do Tor por Jon Atack
 
 Como sempre, se você tiver alguma dúvida, não hesite em compartilhá-la com a comunidade Agora256, estamos aprendendo juntos para sermos melhores amanhã do que somos hoje!
+

--- a/tutorials/node/bitcoin-core-linux/ru.md
+++ b/tutorials/node/bitcoin-core-linux/ru.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Запуск собственного узла с помощью Bitcoin Core
 ---
 

--- a/tutorials/node/bitcoin-core-linux/vi.md
+++ b/tutorials/node/bitcoin-core-linux/vi.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Node (linux)
+name: Bitcoin Core (Linux)
 description: Tự chạy node của bạn với Bitcoin Core
 ---
 

--- a/tutorials/node/bitcoin-core-linux/zh-Hans.md
+++ b/tutorials/node/bitcoin-core-linux/zh-Hans.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core节点（Linux）
+name: Bitcoin Core (Linux)
 description: 使用Bitcoin Core运行您自己的节点
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/cs.md
+++ b/tutorials/node/bitcoin-core-mac-windows/cs.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Instalace Bitcoin Core na Mac nebo Windows
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/de.md
+++ b/tutorials/node/bitcoin-core-mac-windows/de.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Bitcoin Core auf Mac oder Windows installieren
 ---
 
@@ -146,3 +146,4 @@ Sobald Sie bestätigt haben, beginnt der Download der Blockchain. Es wird mehrer
 ![image](assets/15.webp)
 
 Sie können den Computer ausschalten und später mit dem Download fortfahren, es wird keinen Schaden verursachen.
+

--- a/tutorials/node/bitcoin-core-mac-windows/en.md
+++ b/tutorials/node/bitcoin-core-mac-windows/en.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Install Bitcoin Core on Mac or Windows
 ---
 
@@ -148,3 +148,4 @@ Once you confirm, the blockchain will begin downloading. It will take many days.
 ![image](assets/15.webp)
 
 You can shut down the computer and come back to download if you want, it won’t do any damage.
+

--- a/tutorials/node/bitcoin-core-mac-windows/es.md
+++ b/tutorials/node/bitcoin-core-mac-windows/es.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Instalar Bitcoin Core en Mac o Windows
 ---
 
@@ -146,3 +146,4 @@ Una vez que confirmes, la cadena de bloques comenzará a descargarse. Tomará va
 ![image](assets/15.webp)
 
 Puedes apagar la computadora y volver a descargar si quieres, no causará ningún daño.
+

--- a/tutorials/node/bitcoin-core-mac-windows/et.md
+++ b/tutorials/node/bitcoin-core-mac-windows/et.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core Noeud (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Paigalda Bitcoin Core Macile või Windowsile
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/fi.md
+++ b/tutorials/node/bitcoin-core-mac-windows/fi.md
@@ -1,5 +1,5 @@
 ---
-name: Bitcoin Core -solmu (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Asenna Bitcoin Core Macille tai Windowsille
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/fr.md
+++ b/tutorials/node/bitcoin-core-mac-windows/fr.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Installer Bitcoin Core sur Mac ou Windows
 ---
 
@@ -145,3 +145,4 @@ Une fois que vous confirmez, le téléchargement de la blockchain commencera. Ce
 ![image](assets/15.webp)
 
 Vous pouvez éteindre l'ordinateur et revenir pour télécharger si vous le souhaitez, cela ne causera aucun dommage.
+

--- a/tutorials/node/bitcoin-core-mac-windows/id.md
+++ b/tutorials/node/bitcoin-core-mac-windows/id.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Memasang Bitcoin Core di Mac atau Windows
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/it.md
+++ b/tutorials/node/bitcoin-core-mac-windows/it.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Installare Bitcoin Core su Mac o Windows
 ---
 
@@ -146,3 +146,4 @@ Una volta confermato, il download della blockchain inizierà. Ci vorranno molti 
 ![image](assets/15.webp)
 
 Puoi spegnere il computer e tornare per il download se vuoi, non causerà danni.
+

--- a/tutorials/node/bitcoin-core-mac-windows/ja.md
+++ b/tutorials/node/bitcoin-core-mac-windows/ja.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: MacまたはWindowsにBitcoin Coreをインストールしよう
 ---
 
@@ -147,3 +147,4 @@ Bitcoin Coreがロードされ、いくつかのオプションが表示され�
 ![image](assets/15.webp)
 
 ダウンロードを一時停止してコンピューターをシャットダウンし、後で戻ってダウンロードを続けたい場合は、それも可能です。何の損害もありません。
+

--- a/tutorials/node/bitcoin-core-mac-windows/nb-NO.md
+++ b/tutorials/node/bitcoin-core-mac-windows/nb-NO.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Installer Bitcoin Core på Mac eller Windows
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/pt.md
+++ b/tutorials/node/bitcoin-core-mac-windows/pt.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Instalar o Bitcoin Core no Mac ou Windows
 ---
 
@@ -146,3 +146,4 @@ Depois de confirmar, o blockchain começará a ser baixado. Isso levará vários
 ![image](assets/15.webp)
 
 Você pode desligar o computador e voltar para fazer o download se quiser, não causará nenhum dano.
+

--- a/tutorials/node/bitcoin-core-mac-windows/ru.md
+++ b/tutorials/node/bitcoin-core-mac-windows/ru.md
@@ -1,5 +1,5 @@
 ---
-name: Установка Bitcoin Core (Mac и Windows)
+name: Bitcoin Core (macOS & Windows)
 description: Установка Bitcoin Core на Mac или Windows
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/vi.md
+++ b/tutorials/node/bitcoin-core-mac-windows/vi.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: Cài đặt Bitcoin Core trên Mac hoặc Windows
 ---
 

--- a/tutorials/node/bitcoin-core-mac-windows/zh-Hans.md
+++ b/tutorials/node/bitcoin-core-mac-windows/zh-Hans.md
@@ -1,5 +1,5 @@
 ---
-name: Noeud Bitcoin Core (mac & windows)
+name: Bitcoin Core (macOS & Windows)
 description: 在Mac或Windows上安装Bitcoin Core
 ---
 


### PR DESCRIPTION
I have changed the title of the 2 Bitcoin Core tutorials in all languages:
- There were translation errors in the title;
- The term "node" is unnecessary in the title since it's already in the "node" subcategory;
- Standardized to match other titles.

No additional translation needed.