### PR TITLE
[BTC302] Fix BTC Map chapter title

### DIFF
--- a/courses/btc302/fr.md
+++ b/courses/btc302/fr.md
@@ -626,7 +626,7 @@ Liker et retweeter sur les réseaux sociaux les posts des autres communautés pe
 ####
 En parallèle, il est évidemment possible de **proposer aux organisateurs de meet-ups et aux bitcoiners ayant créé une communauté de se réunir deux ou trois fois dans l'année en visio afin de faire un point sur l'évolution des projets nationaux et des communautés associées. Cela peut également se faire lors des événements physiques**, l'objectif étant simple: écouter le ressenti de chacun, discuter de l'évolution des communautés présentes, mais aussi partager des idées et projets qui ont aboutis, de proposer des solutions lorsque cela est nécessaire, etc. Un bilan écrit de cette réunion peut même être partagé après cette "réunion" aux organisateurs(rices) des communautés de votre pays qui n'étaient pas présent(e)s.
 
-## [Btcmap.org](https://btcmap.org/)
+## BTC Map
 <chapterId>365f43d4-7b2c-5961-a184-157b8c1a0116</chapterId>
 
 À ce stade, votre communauté est déjà lancée. Il ne reste plus qu'à attendre l'arrivée de nouvelles personnes intéressées dans l'optique de la développer.


### PR DESCRIPTION
Issue only on `fr.md`, in the title of chapter 4.4 which contained a link:

`4.4. [Btcmap.org](https://btcmap.org/)`

I fixed it in this PR:

`4.4. BTC Map`

The other languages are ok.

![BTC302 issue](https://github.com/user-attachments/assets/0946299b-9087-41ab-b303-7005ed1240d2)
