### PR TITLE
[TUTORIAL] Update passphrase BIP39

### DIFF
--- a/tutorials/wallet/passphrase/cs.md
+++ b/tutorials/wallet/passphrase/cs.md
@@ -49,4 +49,7 @@ Na Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Na zařízení Trezor (Safe 3, Safe 5 nebo Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/de.md
+++ b/tutorials/wallet/passphrase/de.md
@@ -49,4 +49,7 @@ Auf einem Passport (Batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Auf einem Trezor-Gerät (Safe 3, Safe 5 oder Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/en.md
+++ b/tutorials/wallet/passphrase/en.md
@@ -49,4 +49,7 @@ On a Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+On a Trezor device (Safe 3, Safe 5 or Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/es.md
+++ b/tutorials/wallet/passphrase/es.md
@@ -49,4 +49,7 @@ En un Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+En un dispositivo Trezor (Safe 3, Safe 5 o Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/et.md
+++ b/tutorials/wallet/passphrase/et.md
@@ -49,4 +49,7 @@ Passport (batch-2) seadmel:
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Trezor-seadmel (Safe 3, Safe 5 või Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/fi.md
+++ b/tutorials/wallet/passphrase/fi.md
@@ -49,4 +49,7 @@ Passport (batch-2) -laitteella:
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Trezor-laitteella (Safe 3, Safe 5 tai Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/fr.md
+++ b/tutorials/wallet/passphrase/fr.md
@@ -50,3 +50,6 @@ Sur un Passport (batch-2) :
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Sur un appareil Trezor (Safe 3, Safe 5 ou Model One) :
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42

--- a/tutorials/wallet/passphrase/id.md
+++ b/tutorials/wallet/passphrase/id.md
@@ -49,4 +49,7 @@ Pada Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Pada perangkat Trezor (Safe 3, Safe 5, atau Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/it.md
+++ b/tutorials/wallet/passphrase/it.md
@@ -49,4 +49,7 @@ Su un Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Su un dispositivo Trezor (Safe 3, Safe 5 o Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/ja.md
+++ b/tutorials/wallet/passphrase/ja.md
@@ -49,4 +49,7 @@ Passport (batch-2) で:
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Trezorデバイス（Safe 3、Safe 5、またはModel One）で：
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/nb-NO.md
+++ b/tutorials/wallet/passphrase/nb-NO.md
@@ -50,4 +50,7 @@ På en Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+På en Trezor-enhet (Safe 3, Safe 5 eller Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/pt.md
+++ b/tutorials/wallet/passphrase/pt.md
@@ -49,4 +49,7 @@ Em um Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Em um dispositivo Trezor (Safe 3, Safe 5 ou Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/ru.md
+++ b/tutorials/wallet/passphrase/ru.md
@@ -49,4 +49,7 @@ https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+На устройстве Trezor (Safe 3, Safe 5 или Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/vi.md
+++ b/tutorials/wallet/passphrase/vi.md
@@ -49,4 +49,7 @@ Trên Passport (batch-2):
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+Trên thiết bị Trezor (Safe 3, Safe 5 hoặc Model One):
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 

--- a/tutorials/wallet/passphrase/zh-Hans.md
+++ b/tutorials/wallet/passphrase/zh-Hans.md
@@ -49,4 +49,7 @@ https://planb.network/tutorials/wallet/hardware/jade-plus-sparrow-938abf16-e10a-
 
 https://planb.network/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
+在 Trezor 设备上（Safe 3、Safe 5 或 Model One）：
+
+https://planb.network/tutorials/wallet/backup/trezor-passphrase-0474b5bf-496f-4f97-aefe-445368fdca42
 


### PR DESCRIPTION
Updated the passphrase tutorial to add the link to the new Trezor Passphrase tutorial. Modification made in all languages. No translation needed.