### PR TITLE
Remove BIP39 ids in professor.yml files

### DIFF
--- a/professors/ajelex/professor.yml
+++ b/professors/ajelex/professor.yml
@@ -1,7 +1,6 @@
 id: e320ccda-be59-492b-a81b-243d9acb592f
 name: Ajelex
 
-contributor_id: diamond-jar
 
 links:
   twitter: https://twitter.com/ajelexBTC

--- a/professors/alekos/professor.yml
+++ b/professors/alekos/professor.yml
@@ -1,7 +1,6 @@
 id: e7e63d59-ea19-4960-9446-61bd4dcc98f0
 name: Alekos Filini
 
-contributor_id: radio-talent
 
 links:
   twitter: https://twitter.com/afilini

--- a/professors/alevand/professor.yml
+++ b/professors/alevand/professor.yml
@@ -1,7 +1,6 @@
 id: f11a148f-63d8-4b02-8fb4-ac6130c41cb1
 name: alevand
 
-contributor_id: green-day
 
 links:
   twitter: https://https://x.com/AlevandX

--- a/professors/andrei/professor.yml
+++ b/professors/andrei/professor.yml
@@ -1,7 +1,6 @@
 id: 4e2b0785-bd1f-4b1d-ad17-dc699eaf5756
 name: Andrei
 
-contributor_id: grain-habit
 
 links:
   twitter:

--- a/professors/armand-the-parmant/professor.yml
+++ b/professors/armand-the-parmant/professor.yml
@@ -1,7 +1,6 @@
 id: 614eb46b-3cca-46ef-b9ae-e726849e6d1d
 name: Arman the Parman
 
-contributor_id: rebuild-kiss
 
 links:
   twitter: https://twitter.com/parman_the

--- a/professors/asi0/professor.yml
+++ b/professors/asi0/professor.yml
@@ -1,7 +1,6 @@
 id: aa19b8be-5958-4c45-8be8-a1582dd5a90b
 name: asi0
 
-contributor_id: another-satoshi
 
 links:
   twitter: https://twitter.com/asi0_flammeus

--- a/professors/benoit-malbranque/professor.yml
+++ b/professors/benoit-malbranque/professor.yml
@@ -1,7 +1,6 @@
 id: 28add585-0683-4574-9221-16b331cbd37a
 name: Benoît Malbranque
 
-contributor_id: peace-advice
 
 links:
   twitter: https://x.com/b_malbranque

--- a/professors/bitbaldo/professor.yml
+++ b/professors/bitbaldo/professor.yml
@@ -1,7 +1,6 @@
 id: 9c7c1add-eaac-4715-821c-4de60f66d7f6
 name: Matt
 
-contributor_id: matrix-beef
 
 links:
   website: https://bitcoiniop.substack.com/

--- a/professors/bitcoin-qa/professor.yml
+++ b/professors/bitcoin-qa/professor.yml
@@ -1,7 +1,6 @@
 id: 5f130a99-fac9-4ab0-85e1-573c6d38dbb9
 name: Bitcoin Q&A
 
-contributor_id: cover-brother
 
 links:
   twitter: https://twitter.com/BitcoinQ_A

--- a/professors/damien-theillier/professor.yml
+++ b/professors/damien-theillier/professor.yml
@@ -1,7 +1,6 @@
 id: 1a2d2e86-4f52-4b7c-b2c6-17f165a3d5d7
 name: Damien Theillier
 
-contributor_id: rebel-space
 
 links:
   twitter: https://x.com/dtheillier

--- a/professors/daniela/professor.yml
+++ b/professors/daniela/professor.yml
@@ -1,7 +1,6 @@
 id: 0b05838c-24af-43ff-93be-896c907e0bc1
 name: Daniela
 
-contributor_id: mad-salad
 
 links:
   twitter: https://twitter.com/danielabrozzoni

--- a/professors/darthcoin/professor.yml
+++ b/professors/darthcoin/professor.yml
@@ -1,7 +1,6 @@
 id: 7261131b-4ede-4d68-a299-5941584f5592
 name: Darth Coin
 
-contributor_id: motor-chef
 
 links:
   website: https://darthcoin.substack.com/

--- a/professors/david-st-onge/professor.yml
+++ b/professors/david-st-onge/professor.yml
@@ -1,7 +1,6 @@
 id: 525947e6-1d14-43d3-bf17-693b78b3ba09
 name: David St-Onge
 
-contributor_id: genius-flight
 
 links:
   twitter: https://twitter.com/DavidStOnge

--- a/professors/elie-sader/professor.yml
+++ b/professors/elie-sader/professor.yml
@@ -1,7 +1,6 @@
 id: 5a52397f-0148-4e4c-b489-e67578be1b7e
 name: Élie Sader
 
-contributor_id: network-pill
 
 links:
   website: https://networkeffect.fr

--- a/professors/f205sats/professor.yml
+++ b/professors/f205sats/professor.yml
@@ -1,7 +1,6 @@
 id: 94b1f27b-c0bd-432c-a2b5-17db0f6dd435
 name: f205sats
 
-contributor_id: connect-valley
 
 links:
   website:

--- a/professors/fanis-michalakis/professor.yml
+++ b/professors/fanis-michalakis/professor.yml
@@ -1,7 +1,6 @@
 id: fa93b403-3e3e-4fbe-82ac-cf9192cf69bd
 name: Fanis Michalakis
 
-contributor_id: super-brother
 
 links:
   website: https://fanismichalakis.fr/

--- a/professors/federico-tenga/professor.yml
+++ b/professors/federico-tenga/professor.yml
@@ -1,7 +1,6 @@
 id: 06971714-fbbd-4cbd-ac37-2afd1d1947f2
 name: Federico Tenga
 
-contributor_id: sand-valley
 
 links:
   website: https://medium.com/@FedericoTenga

--- a/professors/francis-calderon/professor.yml
+++ b/professors/francis-calderon/professor.yml
@@ -1,7 +1,6 @@
 id: 32334703-651c-4f2c-b835-71a3e19e2f01
 name: Francisco Calderón
 
-contributor_id: valley-egg
 
 links:
   website: https://grunch.dev/

--- a/professors/franklyn-hart/professor.yml
+++ b/professors/franklyn-hart/professor.yml
@@ -1,7 +1,6 @@
 id: ab5ff63c-7eb8-405c-956a-c20458f715f9
 name: FranklynHart
 
-contributor_id: fire-poet
 
 links:
   website: https://agora256.com

--- a/professors/gabriel-comte/professor.yml
+++ b/professors/gabriel-comte/professor.yml
@@ -1,7 +1,6 @@
 id: 880c7fa7-8d4c-4c9b-81b4-bc61ed256516
 name: Gabriel Comte
 
-contributor_id: best-lion
 
 links:
   twitter: https://x.com/don_gabron

--- a/professors/giacomo/professor.yml
+++ b/professors/giacomo/professor.yml
@@ -1,7 +1,6 @@
 id: dac3b166-31ef-41f3-bfef-6e9d3855c12c
 name: Giacomo Zucco
 
-contributor_id: old-uncle
 
 links:
   twitter: https://twitter.com/giacomozucco

--- a/professors/hari-seldon/professor.yml
+++ b/professors/hari-seldon/professor.yml
@@ -1,7 +1,6 @@
 id: ba061ee9-ef85-40a9-aa0b-a46cff642ca7
 name: Hari Seldon
 
-contributor_id: dance-attack
 
 links:
   twitter: https://twitter.com/ajelexBTC

--- a/professors/hunter-beast/professor.yml
+++ b/professors/hunter-beast/professor.yml
@@ -1,7 +1,6 @@
 id: 50d34ea6-d35f-42ee-a0b8-e5552bb3b0ca
 name: Hunter Beast
 
-contributor_id: lion-bomb
 
 links:
   website: https://cryptoquick.substack.com

--- a/professors/jacobo/professor.yml
+++ b/professors/jacobo/professor.yml
@@ -1,7 +1,6 @@
 id: 6308f931-4e97-401c-87b0-fe2d3159501c
 name: Jacobo
 
-contributor_id: casual-chaos
 
 links:
   twitter: https://twitter.com/fasja

--- a/professors/jesse-de-wit/professor.yml
+++ b/professors/jesse-de-wit/professor.yml
@@ -1,7 +1,6 @@
 id: eae56800-59a7-473b-8b52-2c6dfc99bd33
 name: Jesse de Wit
 
-contributor_id: gift-hammer
 
 links:
   twitter: https://x.com/WitDeJesse

--- a/professors/jim/professor.yml
+++ b/professors/jim/professor.yml
@@ -1,7 +1,6 @@
 id: 03cb7507-ad65-4848-88f8-bfa72e2b67f8
 name: Jim
 
-contributor_id: case-memory
 
 links:
   twitter: https://twitter.com/jimzap21

--- a/professors/jona-ramos/professor.yml
+++ b/professors/jona-ramos/professor.yml
@@ -1,7 +1,6 @@
 id: 46dad7c8-b8e2-45f0-ab03-b9e67a7c4301
 name: Jonathan Ramos
 
-contributor_id: spider-man
 
 links:
   twitter: https://x.com/jonaramos_

--- a/professors/jwburgers/professor.yml
+++ b/professors/jwburgers/professor.yml
@@ -1,7 +1,6 @@
 id: 73994a8a-c74c-4692-b22b-b5cc2a6fff40
 name: Jan-Willem Burgers
 
-contributor_id: myth-initial
 
 links:
   twitter: https://twitter.com/jwburgers

--- a/professors/loic-morel/professor.yml
+++ b/professors/loic-morel/professor.yml
@@ -1,7 +1,6 @@
 id: 6516474c-c190-41f2-b2ab-3d452ce7bdf0
 name: Loïc Morel
 
-contributor_id: pretty-private
 
 links:
   website: https://www.pandul.fr/

--- a/professors/louferlou/professor.yml
+++ b/professors/louferlou/professor.yml
@@ -1,7 +1,6 @@
 id: c7108417-5ba9-455e-b467-775cac83c9b5
 name: Louferlou
 
-contributor_id: orange-local
 
 links:
   twitter: https://x.com/Louferlou

--- a/professors/ludovic-lars/professor.yml
+++ b/professors/ludovic-lars/professor.yml
@@ -1,7 +1,6 @@
 id: 81e18c30-579e-46c1-a197-98cd32cb37ae
 name: Ludovic Lars
 
-contributor_id: satoshi-brother
 
 links:
   website: https://viresinnumeris.fr/

--- a/professors/maxim-orlovsky/professor.yml
+++ b/professors/maxim-orlovsky/professor.yml
@@ -1,7 +1,6 @@
 id: 688d9afb-810c-4858-a07f-3cfad9481d99
 name: Maxim Orlovsky
 
-contributor_id: color-machine
 
 links:
   website: https://dr.orlovsky.ch/

--- a/professors/nakamochi-team/professor.yml
+++ b/professors/nakamochi-team/professor.yml
@@ -1,7 +1,6 @@
 id: eef89f42-d077-4248-8cb3-9e5aceaf9e68
 name: Nakamochi Team
 
-contributor_id: original-switch
 
 links:
   website: https://nakamochi.io/

--- a/professors/pablo-greco/professor.yml
+++ b/professors/pablo-greco/professor.yml
@@ -1,7 +1,6 @@
 id: 7668500c-ed9e-44f2-bdbf-b05a66415742
 name: Pablo Greco
 
-contributor_id: abstract-alpha
 
 links:
   twitter: https://x.com/pablosgreco

--- a/professors/pantamis/professor.yml
+++ b/professors/pantamis/professor.yml
@@ -1,7 +1,6 @@
 id: b04a2719-7745-4bd4-aec7-e23431f4db40
 name: Théo Pantamis
 
-contributor_id: zero-shock
 
 links:
   github: https://github.com/Pantamis

--- a/professors/paolo-preto/professor.yml
+++ b/professors/paolo-preto/professor.yml
@@ -1,7 +1,6 @@
 id: d940a2d2-4dbf-4ba1-bdaf-a1f2f1a57f5f
 name: Paolo Foti
 
-contributor_id: hunt-wood
 
 links:
   twitter:

--- a/professors/peter-todd/professor.yml
+++ b/professors/peter-todd/professor.yml
@@ -1,7 +1,6 @@
 id: 7dfc5865-a0f6-4c3b-9b05-83e0d807ac59
 name: Peter Todd
 
-contributor_id: because-drama
 
 links:
   twitter: https://twitter.com/peterktodd

--- a/professors/pierre/professor.yml
+++ b/professors/pierre/professor.yml
@@ -1,7 +1,6 @@
 id: 93e251db-ee1c-4966-8dce-b54df9fca287
 name: Pierre
 
-contributor_id: electric-ankle
 
 links:
   twitter: https://twitter.com/pivi___

--- a/professors/prochronist/professor.yml
+++ b/professors/prochronist/professor.yml
@@ -1,7 +1,6 @@
 id: c3eebea1-2a89-45d1-bf01-8defd8e9d53d
 name: James Dorfman
 
-contributor_id: guitar-ostrich
 
 links:
   twitter: https://x.com/prochronist

--- a/professors/profedustream/professor.yml
+++ b/professors/profedustream/professor.yml
@@ -1,7 +1,6 @@
 id: dd20089b-7df9-4980-811a-e0dba0f70ea7
 name: ProfEduStream
 
-contributor_id: light-storm
 
 links:
   website: https://profedustream.substack.com/

--- a/professors/relai-team/professor.yml
+++ b/professors/relai-team/professor.yml
@@ -1,6 +1,5 @@
 id: a252354f-8739-43ce-99be-4b008ca67db8
 name: Relai Team
-contributor_id: relax-switch
 links:
   website: https://relai.app/
   twitter: https://x.com/Relai_app

--- a/professors/renaud/professor.yml
+++ b/professors/renaud/professor.yml
@@ -1,7 +1,6 @@
 id: b05f416c-fe76-429a-a46c-d5a8b0154a7b
 name: Renaud Lifchitz
 
-contributor_id: gate-fence
 
 links:
   website: https://bio.link/renaudl

--- a/professors/rikki/professor.yml
+++ b/professors/rikki/professor.yml
@@ -1,7 +1,6 @@
 id: b0bcf23e-3ac9-49dc-846d-3979306c6368
 name: Rikki
 
-contributor_id: kangaroo-junk
 
 links:
   twitter: https://twitter.com/Rikki6ixx

--- a/professors/rogzy/professor.yml
+++ b/professors/rogzy/professor.yml
@@ -1,7 +1,6 @@
 id: 2e1b5182-567e-453a-af29-36009340ff02
 name: Rogzy
 
-contributor_id: rabbit-hole
 
 links:
   website: https://www.decouvrebitcoin.com

--- a/professors/seb-bunney/professor.yml
+++ b/professors/seb-bunney/professor.yml
@@ -1,7 +1,6 @@
 id: 5dd0b2fe-0e03-463c-b6a9-6dddb3952e82
 name: Seb Bunney
 
-contributor_id: hybrid-tornado
 
 links:
   twitter: https://twitter.com/sebbunney

--- a/professors/sosylos/professor.yml
+++ b/professors/sosylos/professor.yml
@@ -1,7 +1,6 @@
 id: fe12ea99-744f-4a00-aef9-36ee1bbacb77
 name: Sosylos
 
-contributor_id: empower-output
 
 links:
   twitter: https://x.com/Sol_Ysos

--- a/professors/southerbitcoiner/professor.yml
+++ b/professors/southerbitcoiner/professor.yml
@@ -1,7 +1,6 @@
 id: 6f05b7e4-b6e3-4ed7-8ce3-fd21ba496ed0
 name: Southerbitcoiner
 
-contributor_id: six-phone
 
 links:
   website: https://www.southernbitcoiner.com/

--- a/professors/tether-team/professor.yml
+++ b/professors/tether-team/professor.yml
@@ -1,6 +1,5 @@
 id: 4c0147d0-56ad-4b71-8050-b136344c374c
 name: Tether Team
-contributor_id: stable-coin
 links:
   website: https://tether.to/
   twitter: https://x.com/Tether_to/

--- a/professors/theo-mogenet/professor.yml
+++ b/professors/theo-mogenet/professor.yml
@@ -1,7 +1,6 @@
 id: 3a838eea-570a-494e-b641-23d5b39f2927
 name: Théo Mogenet
 
-contributor_id: hazard-bonus
 
 links:
   website: https://institutbitcoin.fr/

--- a/professors/winter-hodler/professor.yml
+++ b/professors/winter-hodler/professor.yml
@@ -1,7 +1,6 @@
 id: 8260ed86-de30-468b-88bc-6ed4140a24e2
 name: WINTER ☩ HODLER
 
-contributor_id: write-school
 
 links:
   twitter: https://twitter.com/KST_Energy


### PR DESCRIPTION
BIP39 IDs are unnecessary since we now use UUIDs to identify the professors. This PR removes all of them in professor.yml files.