### PR TITLE
[TUTORIAL] Fix YAML keys last_contribution_date

### DIFF
--- a/tutorials/node/lightning-network-daemon-linux/tutorial.yml
+++ b/tutorials/node/lightning-network-daemon-linux/tutorial.yml
@@ -7,10 +7,13 @@ tags:
 category : lightning-network
 level : intermediate
 professor_id: 81a82a0f-3003-4459-9d6a-67f860efb20e
+
+# Proofreading metadata
+
 original_language: fr
 proofreading: 
   - language : fr
-    last_contribution: 2025-04-26
+    last_contribution_date: 2025-04-26
     urgency: 1
     contributors_names: 
      - heyolaniran

--- a/tutorials/privacy/mempool-space/tutorial.yml
+++ b/tutorials/privacy/mempool-space/tutorial.yml
@@ -14,7 +14,7 @@ category: analysis
 original_language: fr
 proofreading:
   - language: fr
-    last-contribution: 2025-05-06
+    last_contribution_date: 2025-05-06
     urgency: 1
     contributors_names:
       - heyolaniran

--- a/tutorials/wallet/breez/tutorial.yml
+++ b/tutorials/wallet/breez/tutorial.yml
@@ -13,7 +13,7 @@ tags:
 original_language: fr
 proofreading:
 - language: fr
-  last_contribution: 2025-04-29
+  last_contribution_date: 2025-04-29
   urgency: 1
   contributors_names: 
     - heyolaniran

--- a/tutorials/wallet/misty-breez/tutorial.yml
+++ b/tutorials/wallet/misty-breez/tutorial.yml
@@ -13,7 +13,7 @@ tags:
 original_language: fr
 proofreading:
 - language: fr
-  last_contribution: 2025-05-02
+  last_contribution_date: 2025-05-02
   urgency: 1
   contributors_names: 
     - heyolaniran


### PR DESCRIPTION
On some of Olaniran's tutorials, the YAML keys `last_contribution_date` were incorrect. I’ve fixed them.

Sorry for this mistake, it’s my fault, I didn’t catch it during the review. I’ll make a verification script for these small standard things in future reviews to avoid this.