### PR TITLE
[TUTORIAL] Fix YAML keys last_contribution_date 2

### DIFF
--- a/tutorials/exchange/flash/tutorial.yml
+++ b/tutorials/exchange/flash/tutorial.yml
@@ -13,7 +13,7 @@ tags:
 original_language: fr
 proofreading: 
 - language: fr
-  last-contribution: 2025-05-03
+  last_contribution_date: 2025-05-03
   urgency: 1
   contributors_names: 
     - heyolaniran


### PR DESCRIPTION
On some of Olaniran's tutorials, the YAML keys last_contribution_date were incorrect. I’ve fixed them.

Sorry for this mistake, it’s my fault, I didn’t catch it during the review. I’ll make a verification script for these small standard things in future reviews to avoid this.