### PR TITLE
Sparrow Multisig it proofreading

### DIFF
--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -18,7 +18,7 @@ Questo meccanismo consente di condividere il controllo di un portafoglio tra pi�
 
 
 
-Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un Multisig Wallet richiede la protezione di diverse frasi Mnemonic (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un Multisig 2-of-3 Wallet, per recuperare il Wallet è necessario disporre di tutte e tre le frasi Mnemonic o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai bitcoin che proteggono.
+Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un Multisig Wallet richiede la protezione di diverse frasi Mnemonic (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un Multisig 2-of-3 Wallet, per recuperare il Wallet è necessario disporre di tutte e tre le frasi Mnemonic o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai Bitcoin che proteggono.
 
 
 
@@ -27,8 +27,8 @@ In sintesi, per recuperare un portafoglio Multisig, è necessario :
 
 
 
-- Oppure accedere a tutte le frasi Mnemonic associate a ciascun fattore di firma;
-- O avere il numero minimo di frasi Mnemonic richiesto dalla soglia per poter firmare, e anche avere accesso alle xpub di tutti i fattori per recuperare le chiavi pubbliche necessarie.
+- Accedere a tutte le frasi Mnemonic associate a ciascun fattore di firma;
+- Oppure avere il numero minimo di frasi Mnemonic richiesto dalla soglia per poter firmare, e anche avere accesso alle xpub di tutti i fattori per recuperare le chiavi pubbliche necessarie.
 
 
 
@@ -40,11 +40,11 @@ La gestione dei backup del portafoglio Multisig è facilitata da *Descrittori di
 
 
 
-Multisig è particolarmente adatto ai bitcoiners che cercano una maggiore sicurezza o una gestione collettiva dei fondi: aziende, associazioni, famiglie o singoli utenti che detengono una quantità significativa di bitcoin. Può essere utilizzato per creare schemi di governance decentralizzati, ad esempio per distribuire l'autorità di firma tra diversi manager o membri del team.
+Multisig è particolarmente adatto ai Bitcoiners che cercano una maggiore sicurezza o una gestione collettiva dei fondi: aziende, associazioni, famiglie o singoli utenti che detengono una quantità significativa di Bitcoin. Può essere utilizzato per creare schemi di governance decentralizzati, ad esempio per distribuire l'autorità di firma tra diversi manager o membri del team.
 
 
 
-In questa esercitazione impareremo a creare e utilizzare un classico Wallet a più firme con **Sparrow Wallet**. Se desiderate creare un portafoglio multi-firma personalizzato con orologi a tempo, vi consiglio di utilizzare il Liana:
+In questa esercitazione impareremo a creare e utilizzare un classico Wallet a più firme con **Sparrow Wallet**. Se desiderate creare un portafoglio multi-firma personalizzato con blocchi temporali (timelocks), vi consiglio di utilizzare Liana:
 
 
 
@@ -54,20 +54,20 @@ https://planb.network/tutorials/wallet/desktop/liana-306ef457-700c-4fdd-b07a-8fb
 
 
 
-In questa esercitazione vi mostrerò come creare un Multisig con [Sparrow Wallet portfolio management software](https://sparrowwallet.com/download/). Se non avete ancora installato questo software, fatelo subito. Se avete bisogno di aiuto, abbiamo anche un tutorial dettagliato sulla configurazione di Sparrow Wallet :
+In questa esercitazione vi mostrerò come creare un Multisig con [Sparrow Wallet portfolio management software](https://sparrowwallet.com/download/). Se non avete ancora installato questo software, fatelo subito. Se avete bisogno di aiuto, abbiamo anche un tutorial dettagliato sulla configurazione di Sparrow Wallet:
 
 
 
 https://planb.network/tutorials/wallet/desktop/sparrow-c674e2ac-d46f-4c82-92a7-7d1b0e262f5d)
 
-Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardware. Per un Multisig 2-de-3, ad esempio, si può utilizzare :
+Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardware. Per un Multisig 2-di-3, ad esempio, si possono utilizzare:
 
 
 
 
 - Un Trezor modello 1;
-- Ledger Flex;
-- Una Coldcard MK3.
+- Un Ledger Flex;
+- Un Coldcard MK3.
 
 
 
@@ -75,13 +75,13 @@ Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardwar
 
 
 
-È una buona idea utilizzare diverse marche di Hardware Wallet nella configurazione del Multisig. In questo modo si garantisce che se un modello specifico presenta un problema serio, ciò influisce sulla sicurezza generale del Multisig. In questo modo si garantisce che se un modello specifico presenta un problema grave, questo non influisce sulla sicurezza complessiva del Multisig. Inoltre, si può beneficiare dei vantaggi specifici di ciascun dispositivo. Inoltre, consente di beneficiare dei vantaggi specifici di ciascun dispositivo. Ad esempio, nella mia configurazione :
+È una buona idea utilizzare diverse marche di Hardware Wallet nella configurazione Multisig. In questo modo si garantisce che se un modello specifico presenta un problema grave, questo non influisce sulla sicurezza complessiva del Multisig. Inoltre, ciò consente di beneficiare dei vantaggi specifici di ciascun dispositivo. Ad esempio, nella mia configurazione:
 
 
 
 
 
-- Il Trezor Model One è completamente open-source, il che rende possibile la verifica della generazione seed. Tuttavia, non essendo dotato di un elemento sicuro, rimane vulnerabile agli attacchi fisici;
+- Il Trezor Model One è completamente open-source, il che rende possibile la verifica della generazione seed. Tuttavia, non essendo dotato di un chip anti manomissione (Secure Element), rimane vulnerabile agli attacchi fisici;
 
 
 
@@ -93,11 +93,11 @@ Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardwar
 
 
 
-- La Coldcard è dotata di un Secure Element e il suo codice è ricercabile. È una scelta interessante per la nostra configurazione, in quanto offre funzioni di verifica non disponibili su altri modelli.
+- Il Coldcard è dotato di un Secure Element e il suo codice è rintracciabile. È una scelta interessante per la nostra configurazione, in quanto offre funzioni di verifica non disponibili su altri modelli.
 
 
 
-Prima di configurare il Multisig Wallet, assicurarsi che ogni Hardware Wallet sia configurato correttamente (generazione e salvataggio del Mnemonic, definizione del PIN). Per istruzioni dettagliate, è possibile consultare i nostri tutorial per ogni Hardware Wallet, ad esempio :
+Prima di configurare il Multisig Wallet, assicurarsi che ogni Hardware Wallet sia configurato correttamente (generazione e salvataggio delle frasi Mnemonic, definizione del PIN). Per istruzioni dettagliate, è possibile consultare i nostri tutorial per ogni Hardware Wallet, ad esempio :
 
 
 
@@ -107,7 +107,7 @@ https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-73e86d1a-6fe6-4d8b-bb15-8690298020e3
 
-Come vedremo più avanti in questo tutorial, è anche possibile integrare nella configurazione del Multisig un fattore che non è associato a un Hardware Wallet, ma le cui chiavi private sono memorizzate sul vostro PC. Questo metodo è ovviamente meno sicuro dell'uso esclusivo di portafogli hardware, ma può essere rilevante in alcuni casi. Ad esempio, per un Multisig 2-de-3, si potrebbe optare per due portafogli hardware e un Software Wallet.
+Come vedremo più avanti in questo tutorial, è anche possibile integrare nella configurazione del Multisig un fattore che non è associato a un Hardware Wallet, ma le cui chiavi private sono memorizzate sul vostro PC. Questo metodo è ovviamente meno sicuro dell'uso esclusivo con Hardware Wallet, ma può essere rilevante in alcuni casi. Ad esempio, per un Multisig 2-de-3, si potrebbe optare per due Hardware Wallet e un Software Wallet.
 
 
 
@@ -123,7 +123,7 @@ Aprire Sparrow Wallet, fare clic sulla scheda "*File*", quindi selezionare "*New
 
 
 
-Assegnare un nome al portafoglio con più firme, quindi fare clic su "*Crea Wallet*" per confermare.
+Assegnare un nome al portafoglio con più firme, quindi fare clic su "*Create Wallet*" per confermare.
 
 
 
@@ -131,7 +131,7 @@ Assegnare un nome al portafoglio con più firme, quindi fare clic su "*Crea Wall
 
 
 
-Nel menu a discesa "*Tipo di politica*", selezionare l'opzione "*Multi firma*".
+Nel menu a discesa "*Policy Type*", selezionare l'opzione "*Multi Signature*".
 
 
 
@@ -159,7 +159,7 @@ Inizio con la Coldcard. Nella scheda "*Keystore 1*", scelgo l'opzione "*Airgappe
 
 
 
-Sulla Coldcard, una volta sbloccato il dispositivo, vado al menu "*Impostazioni*", quindi a "*Portafogli Multisig*".
+Sul Coldcard, una volta sbloccato il dispositivo, vado al menu "*Settings*", quindi a "*Multisig Wallets*".
 
 
 
@@ -167,7 +167,7 @@ Sulla Coldcard, una volta sbloccato il dispositivo, vado al menu "*Impostazioni*
 
 
 
-Questo menu consente di gestire i portafogli Multisig a cui partecipa la Coldcard. Se voglio crearne uno nuovo, seleziono "*Esporta XPUB*".
+Questo menù consente di gestire i portafogli Multisig in cui partecipa Coldcard. Se voglio crearne uno nuovo, seleziono "*Esport XPUB*".
 
 
 
@@ -175,7 +175,7 @@ Questo menu consente di gestire i portafogli Multisig a cui partecipa la Coldcar
 
 
 
-Per il campo "*Numero di conto*", se si gestisce un solo conto, è possibile lasciarlo vuoto e convalidare direttamente premendo il pulsante di conferma.
+Per il campo "*Account Number*", se si gestisce un solo conto, è possibile lasciarlo vuoto e convalidare direttamente premendo il pulsante di conferma.
 
 
 
@@ -183,7 +183,7 @@ Per il campo "*Numero di conto*", se si gestisce un solo conto, è possibile las
 
 
 
-La scheda Coldcard visualizza quindi generate un file contenente la vostra xpub, salvata sulla scheda Micro SD.
+La scheda Coldcard vi mostra quindi un file contenente la vostra xpub appena generata, salvata sulla scheda Micro SD.
 
 
 
@@ -191,7 +191,7 @@ La scheda Coldcard visualizza quindi generate un file contenente la vostra xpub,
 
 
 
-Inserire la Micro SD nel computer. In Sparrow Wallet, fare clic sul pulsante "*Importa file...*" accanto a "*Coldcard Multisig*", quindi selezionare il file creato dalla Coldcard sulla scheda.
+Inserire la Micro SD nel computer. In Sparrow Wallet, fare clic sul pulsante "*Import file...*" accanto a "*Coldcard Multisig*", quindi selezionare il file creato dal Coldcard sulla scheda.
 
 
 
@@ -199,7 +199,7 @@ Inserire la Micro SD nel computer. In Sparrow Wallet, fare clic sul pulsante "*I
 
 
 
-Il vostro xpub è stato importato con successo. Ora ripetiamo la procedura con gli altri due portafogli hardware.
+Il vostro xpub è stato importato con successo. Ora ripetiamo la procedura con gli altri due Hardware Wallet.
 
 
 
@@ -215,7 +215,7 @@ Per il Ledger Flex, seleziono "*Keystore 2*", quindi faccio clic su "*Connected 
 
 
 
-Quindi fare clic sul pulsante "*Scansione...*".
+Quindi fare clic sul pulsante "*Scan...*".
 
 
 
@@ -223,7 +223,7 @@ Quindi fare clic sul pulsante "*Scansione...*".
 
 
 
-Accanto al nome del portafoglio hardware, fare clic su "*Import Keystore*".
+Accanto al nome dell'Hardware Wallet, fare clic su "*Import Keystore*".
 
 
 
@@ -231,7 +231,7 @@ Accanto al nome del portafoglio hardware, fare clic su "*Import Keystore*".
 
 
 
-Il secondo firmatario è ora correttamente registrato in Sparrow Wallet.
+Il secondo firmatario è ora correttamente registrato su Sparrow Wallet.
 
 
 
@@ -247,7 +247,7 @@ Ripeto esattamente la stessa procedura con il Trezor One per finalizzare la conf
 
 
 
-Nella mia configurazione non è contemplato questo caso, ma se si desidera includere una firma tramite un Software Wallet in Sparrow (Hot Wallet) all'interno del proprio Multisig, è sufficiente fare clic sul pulsante "*Nuovo o importato Software Wallet*".
+Nella mia configurazione non è contemplato questo caso, ma se si desidera includere una firma tramite un Software Wallet in Sparrow (Hot Wallet) all'interno del proprio Multisig, è sufficiente fare clic sul pulsante "*New or Imported Software Wallet*".
 
 
 
@@ -259,7 +259,7 @@ Ora che tutti i dispositivi di firma sono stati importati in Sparrow Wallet, è 
 
 
 
-Scegliere una password forte per proteggere l'accesso al proprio Sparrow Wallet Wallet. Questa password protegge le chiavi pubbliche, gli indirizzi, le etichette e la cronologia delle transazioni da accessi non autorizzati.
+Scegliere una password forte per proteggere l'accesso al proprio Sparrow Wallet. Questa password protegge le chiavi pubbliche, gli indirizzi, le etichette e la cronologia delle transazioni da accessi non autorizzati.
 
 
 
@@ -271,15 +271,15 @@ Ricordate di salvare la password in un luogo sicuro, ad esempio in un gestore di
 
 
 
-## Backup di un portafoglio Multisig
+## Backup di un Multisig Wallet
 
 
 
-Ora salveremo il nostro *Descrittore script di uscita* sulla Coldcard (questo vale solo per gli utenti che hanno una Coldcard nel loro Multisig) e, soprattutto, ne terremo una copia di backup su un supporto indipendente.
+Ora salveremo il nostro *Descrittore script di uscita* sul Coldcard (questo vale solo per gli utenti che hanno un Coldcard nel loro Multisig) e, soprattutto, ne terremo una copia di backup su un supporto indipendente.
 
 
 
-Il *Descrittore* contiene tutte le xpub del portafoglio Multisig, nonché i percorsi di derivazione utilizzati per generate le chiavi. Ricordiamo quanto visto nella Parte 1: per ripristinare un portafoglio Multisig, è necessario avere **tutte** le frasi Mnemonic, oppure solo il numero minimo richiesto per raggiungere la soglia di firma. Tuttavia, in quest'ultimo caso, è essenziale avere anche **gli xpub** dei firmatari mancanti. Il *Descrittore* contiene tutte le xpub del Multisig.
+Il *Descrittore* contiene tutte le xpub del Multisig Wallet, nonché i percorsi di derivazione utilizzati per generate le chiavi. Ricordiamo quanto visto nella Parte 1: per ripristinare un Multisig Wallet, è necessario avere **tutte** le frasi Mnemonic, oppure solo il numero minimo richiesto per raggiungere la soglia di firma. Tuttavia, in quest'ultimo caso, è essenziale avere anche **gli xpub** dei firmatari mancanti. Il *Descrittore* contiene tutte le xpub del Multisig.
 
 
 
@@ -287,15 +287,15 @@ Se non è chiaro, ricordate solo questo: per recuperare un Multisig, è necessar
 
 
 
-Questo *Descrittore* non contiene chiavi private, ma solo chiavi pubbliche. Ciò significa che non dà accesso ai fondi. Non è quindi critico come le frasi Mnemonic, che danno pieno accesso ai bitcoin. Il rischio del *Descrittore* è legato esclusivamente alla riservatezza: in caso di compromissione, una terza parte potrebbe osservare tutte le vostre transazioni, ma non potrebbe spendere i vostri fondi.
+Questo *Descrittore* non contiene chiavi private, ma solo chiavi pubbliche. Ciò significa che non dà accesso ai fondi. Non è quindi critico come le frasi Mnemonic, che danno pieno accesso ai Bitcoin. Il rischio del *Descrittore* è legato esclusivamente alla riservatezza: in caso di compromissione, una terza parte potrebbe osservare tutte le vostre transazioni, ma non potrebbe spendere i vostri fondi.
 
 
 
-Consiglio vivamente di creare diverse copie di questo *Descriptor* e di conservarle con ciascun dispositivo di firma del Multisig. Ad esempio, nel mio caso, stampo il *Descriptor* su carta e ne conservo una copia con la Coldcard, un'altra con il Trezor e una con il Ledger. Inoltre, salvo questo *Descriptor* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno dei portafogli hardware. In questo modo, massimizzo le possibilità di non perdere mai questo *Descriptor* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
+Consiglio vivamente di creare diverse copie di questo *Descrittore* e di conservarle con ciascun dispositivo di firma del Multisig. Ad esempio, nel mio caso, stampo il *Descrittore* su carta e ne conservo una copia sul Coldcard, un'altra sul Trezor e una sul Ledger. Inoltre, salvo questo *Descrittore* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno degli Hardware Wallet. In questo modo, massimizzo le possibilità di non perdere mai questo *Descrittore* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
 
 
 
-Una volta creato il portafoglio Multisig, Sparrow fornisce automaticamente questo *Descrittore*. Fare clic sul pulsante "*Salva PDF...*" per salvarlo sia come testo che come codice QR.
+Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *Descrittore*. Fare clic sul pulsante "*SavePDF...*" per salvarlo sia come testo che come codice QR.
 
 
 
@@ -311,15 +311,15 @@ Una volta creato il portafoglio Multisig, Sparrow fornisce automaticamente quest
 
 
 
-Registreremo anche questo *Descrittore* nella Coldcard (se ne usate una nella vostra configurazione). Ciò consentirà a Coldcard di verificare che ogni transazione firmata in seguito corrisponda al Wallet originale: xpub corretto, formato Address corretto, percorso di derivazione corretto... Senza questo *Descrittore* importato, Coldcard non può confermare che gli indirizzi Exchange non siano stati dirottati o che il PSBT non sia stato manomesso.
+Registreremo anche questo *Descrittore* sul Coldcard (se ne usate uno nella vostra configurazione). Ciò consentirà al Coldcard di verificare che ogni transazione firmata in seguito corrisponda al Wallet originale: xpub corretto, formato Address corretto, percorso di derivazione corretto... Senza questo *Descrittore* importato, Coldcard non può confermare che gli indirizzi Exchange non siano stati dirottati o che il PSBT non sia stato manomesso.
 
 
 
-Questo è ciò che rende la Coldcard così interessante in un Multisig: offre controlli aggiuntivi contro alcuni attacchi sofisticati, che altri portafogli hardware non consentono (a condizione, ovviamente, che la si usi per firmare).
+Questo è ciò che rende Coldcard così interessante in un Multisig: offre controlli aggiuntivi contro alcuni attacchi sofisticati, che altri Hardware Wallet non consentono (a condizione, ovviamente, che lo si usi per firmare).
 
 
 
-In Sparrow, accedere al menu "*Impostazioni*", quindi fare clic su "*Esportazione...*".
+In Sparrow, accedere al menu "*Settings*", quindi fare clic su "*Export...*".
 
 
 
@@ -327,7 +327,7 @@ In Sparrow, accedere al menu "*Impostazioni*", quindi fare clic su "*Esportazion
 
 
 
-Accanto all'opzione "*Coldcard Multisig*", fare clic su "*Esporta file...*" e salvare il file di testo sulla scheda Micro SD.
+Accanto all'opzione "*Coldcard Multisig*", fare clic su "*Export file...*" e salvare il file di testo sulla scheda Micro SD.
 
 
 
@@ -335,7 +335,7 @@ Accanto all'opzione "*Coldcard Multisig*", fare clic su "*Esporta file...*" e sa
 
 
 
-Inserire quindi la scheda nella Coldcard. Andare al menu "*Impostazioni*", quindi "Portafogli Multisig*" e selezionare "*Importa da SD*".
+Inserire quindi la scheda nel Coldcard. Andare al menu "*Settings*", quindi "*Multisig Wallet*" e selezionare "*Import from SD*".
 
 
 
@@ -367,7 +367,7 @@ Controllare i parametri di configurazione del Multisig, quindi confermare la reg
 
 
 
-Il Multisig è ora correttamente salvato nella Coldcard. Se si dispone di più Coldcard nello stesso Multisig, ripetere questa procedura per ciascuna di esse.
+Il Multisig è ora correttamente salvato sul Coldcard. Se si dispone di più Coldcard nello stesso Multisig, ripetere questa procedura per ciascuna di esse.
 
 
 
@@ -377,7 +377,7 @@ Oltre a salvare il *Descrittore*, non dimenticate di prestare particolare attenz
 
 https://planb.network/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-Prima di ricevere i primi bitcoin sul Multisig, **vi consiglio vivamente di eseguire un test di ripristino a vuoto**. Annotare alcune informazioni di riferimento, come la prima ricezione del Address, quindi ripristinare i portafogli hardware mentre il Wallet è ancora vuoto. Successivamente, provare a ripristinare il Multisig Wallet sui portafogli hardware utilizzando i backup cartacei della frase Mnemonic, quindi su Sparrow utilizzando il *Descrittore*. Verificare che il primo Address generato dopo il ripristino corrisponda a quello scritto originariamente. Se così fosse, si può essere certi che i backup cartacei sono affidabili.
+Prima di ricevere i primi Bitcoin sul Multisig, **vi consiglio vivamente di eseguire un test di ripristino a vuoto**. Annotare alcune informazioni di riferimento, come la prima ricezione dell'Address, quindi ripristinare gli Hardware Wallet mentre il Wallet è ancora vuoto. Successivamente, provare a ripristinare il Multisig Wallet sui portafogli Hardware utilizzando i backup cartacei della frase Mnemonic, mentre su Sparrow utilizzando il *Descrittore*. Verificare che il primo Address generato dopo il ripristino corrisponda a quello scritto originariamente. Se così fosse, si può essere certi che i backup cartacei sono affidabili.
 
 
 
@@ -387,11 +387,11 @@ Per saperne di più su come eseguire un test di ripristino, vi suggerisco di con
 
 https://planb.network/tutorials/wallet/backup/recovery-test-5a75db51-a6a1-4338-a02a-164a8d91b895
 
-## Ricevere bitcoin sul vostro Multisig
+## Ricevere Bitcoin sul vostro Multisig
 
 
 
-Il vostro Wallet è ora pronto a ricevere bitcoin. In Sparrow, fare clic sulla scheda "*Receive*".
+Il vostro Wallet è ora pronto a ricevere Bitcoin. In Sparrow, fare clic sulla scheda "*Receive*".
 
 
 
@@ -399,11 +399,11 @@ Il vostro Wallet è ora pronto a ricevere bitcoin. In Sparrow, fare clic sulla s
 
 
 
-Prima di utilizzare il Address generato da Sparrow Wallet, prendetevi il tempo di verificarlo direttamente sullo schermo dei vostri portafogli hardware. In questo modo vi assicurerete che il Address non sia stato alterato e che i vostri dispositivi possiedano le chiavi private necessarie per spendere i fondi associati. Questo aiuta a proteggersi da una serie di vettori di attacco.
+Prima di utilizzare l'Address generato da Sparrow Wallet, prendetevi il tempo di verificarlo direttamente sullo schermo dei vostri Hardware Wallet. In questo modo vi assicurerete che l'Address non sia stato alterato e che i vostri dispositivi possiedano le chiavi private necessarie per spendere i fondi associati. Questo aiuta a proteggersi da una serie di vettori di attacco.
 
 
 
-A tal fine, fare clic su "*Display Address*" per visualizzare il Address sul Trezor o sul Ledger, se collegato via cavo.
+A tal fine, fare clic su "*Display Address*" per visualizzare l'Address sul Trezor o sul Ledger, se collegato via cavo.
 
 
 
@@ -427,11 +427,11 @@ Si vedranno quindi gli indirizzi di ricezione generati dal Multisig.
 
 
 
-Verificare che il Address visualizzato su ogni Hardware Wallet corrisponda esattamente a quello del Wallet di Sparrow. È consigliabile eseguire questa operazione appena prima di condividere il Address con il pagatore, per essere sicuri della sua integrità.
+Verificare che l'Address visualizzato su ogni Hardware Wallet corrisponda esattamente a quello del Wallet di Sparrow. È consigliabile eseguire questa operazione appena prima di condividere l'Address con il pagatore, per essere sicuri della sua integrità.
 
 
 
-È quindi possibile assegnare un'"etichetta" a questo Address, per indicare l'origine dei bitcoin ricevuti. Questo è un buon modo per organizzare la gestione dei vostri UTXO.
+È quindi possibile assegnare un "Label" (etichetta) a questo Address, per indicare l'origine dei Bitcoin ricevuti. Questo è un buon modo per organizzare la gestione dei vostri UTXO.
 
 
 
@@ -439,7 +439,7 @@ Verificare che il Address visualizzato su ogni Hardware Wallet corrisponda esatt
 
 
 
-Una volta verificato, è possibile utilizzare il Address per ricevere bitcoin.
+Una volta verificato, è possibile utilizzare l'Address per ricevere Bitcoin.
 
 
 
@@ -447,11 +447,11 @@ Una volta verificato, è possibile utilizzare il Address per ricevere bitcoin.
 
 
 
-## Inviare bitcoin con il vostro Multisig
+## Inviare Bitcoin con il vostro Multisig
 
 
 
-Ora che avete ricevuto i primi Satss sul vostro Multisig Wallet, potete anche spenderli! In Sparrow, vai alla scheda "*Invio*" per creare una nuova transazione.
+Ora che avete ricevuto i primi Sats sul vostro Multisig Wallet, potete anche spenderli! In Sparrow, vai alla scheda "*Send*" per creare una nuova transazione.
 
 
 
@@ -459,7 +459,7 @@ Ora che avete ricevuto i primi Satss sul vostro Multisig Wallet, potete anche sp
 
 
 
-Se si desidera utilizzare il *Controllo monete*, ossia selezionare manualmente gli UTXO da spendere, andare alla scheda "*UTXO*". Scegliete gli UTXO che desiderate spendere, quindi cliccate su "*Invia selezionati*". Si verrà automaticamente reindirizzati alla scheda "*Invio*", con gli UTXO già precompilati.
+Se si desidera utilizzare il *Coin Control*, ossia la selezione manualmente gli UTXO da spendere, andare alla scheda "*UTXO*". Scegliete gli UTXO che desiderate spendere, quindi cliccate su "*Send Selected*". Si verrà automaticamente reindirizzati alla scheda "*Send*", con gli UTXO già precompilati.
 
 
 
@@ -467,7 +467,7 @@ Se si desidera utilizzare il *Controllo monete*, ossia selezionare manualmente g
 
 
 
-Inserire la destinazione Address. È possibile aggiungere più indirizzi facendo clic su "*+ Aggiungi*".
+Inserire la destinazione dell'Address. È possibile aggiungere più indirizzi facendo clic su "*+ Aggiungi*".
 
 
 
@@ -475,7 +475,7 @@ Inserire la destinazione Address. È possibile aggiungere più indirizzi facendo
 
 
 
-Aggiungere una "*Etichetta*" per descrivere lo scopo di questa spesa, per facilitare la tracciabilità delle transazioni.
+Aggiungere una "*Label*" (Etichetta) per descrivere lo scopo di questa spesa, così da facilitare la tracciabilità delle transazioni.
 
 
 
@@ -483,7 +483,7 @@ Aggiungere una "*Etichetta*" per descrivere lo scopo di questa spesa, per facili
 
 
 
-Inserire l'importo da inviare al Address selezionato.
+Inserire l'importo da inviare all'Address selezionato.
 
 
 
@@ -491,11 +491,11 @@ Inserire l'importo da inviare al Address selezionato.
 
 
 
-Regolare il tasso di carica in base alle condizioni attuali della rete. Ad esempio, consultare [Mempool.space](https://Mempool.space/) per selezionare un livello di carica adeguato.
+Regolare la quantità di fees in base alle condizioni attuali della rete. Ad esempio, consultare [Mempool.space](https://Mempool.space/) per selezionare una fee adeguata.
 
 
 
-Dopo aver controllato tutti i parametri della transazione, fare clic su "*Crea transazione*".
+Dopo aver controllato tutti i parametri della transazione, fare clic su "*Create Transaction*".
 
 
 
@@ -503,7 +503,7 @@ Dopo aver controllato tutti i parametri della transazione, fare clic su "*Crea t
 
 
 
-Se siete soddisfatti di tutto, fate clic su "*Finalizza transazione per la firma*".
+Se siete soddisfatti di tutto, fate clic su "*Finalize Transaction for Signing*".
 
 
 
@@ -511,7 +511,7 @@ Se siete soddisfatti di tutto, fate clic su "*Finalizza transazione per la firma
 
 
 
-Nella parte inferiore dello schermo, vedrete che Sparrow è in attesa di 2 firme. Questo è normale: il Wallet usato qui è un Multisig 2-de-3.
+Nella parte inferiore dello schermo, vedrete che Sparrow è in attesa di 2 firme. Questo è normale: il Wallet usato qui è un Multisig 2-di-3.
 
 
 
@@ -519,7 +519,7 @@ Nella parte inferiore dello schermo, vedrete che Sparrow è in attesa di 2 firme
 
 
 
-Inizio a firmare con la mia Coldcard. A tal fine, inserisco una scheda Micro SD nel computer, quindi faccio clic su "*Salva transazione*".
+Inizio a firmare con il mio Coldcard. A tal fine, inserisco una scheda Micro SD nel computer, quindi faccio clic su "*Save Transaction*".
 
 
 
@@ -527,11 +527,11 @@ Inizio a firmare con la mia Coldcard. A tal fine, inserisco una scheda Micro SD 
 
 
 
-Esistono 3 modi per trasmettere la transazione da firmare al Hardware Wallet e poi recuperarla da Sparrow. Il primo è utilizzare una scheda Micro SD, come faremo qui per la Coldcard. Il secondo è tramite una connessione via cavo, che utilizzeremo per la seconda firma (Ledger e Trezor). Infine, è possibile utilizzare la comunicazione tramite codice QR, per i dispositivi dotati di fotocamera come Coldcard Q, Jade Plus o Passport V2.
+Esistono 3 modi per trasmettere la transazione dal firmare all'Hardware Wallet e poi recuperarla da Sparrow. Il primo è utilizzare una scheda Micro SD, come faremo qui per Coldcard. Il secondo è tramite una connessione via cavo, che utilizzeremo per la seconda firma (Ledger e Trezor). Infine, è possibile utilizzare la comunicazione tramite codice QR, per i dispositivi dotati di fotocamera come Coldcard Q, Jade Plus o Passport V2.
 
 
 
-Una volta salvato il PSBT (*Partially Signed Bitcoin Transaction*) sulla Micro SD, lo inserisco nella Coldcard MK3, quindi seleziono il menu "*Pronto per la firma*".
+Una volta salvato il PSBT (*Partially Signed Bitcoin Transaction*) sulla Micro SD, lo inserisco nel Coldcard MK3, quindi seleziono il menu "*Ready To Sign*".
 
 
 
@@ -539,7 +539,7 @@ Una volta salvato il PSBT (*Partially Signed Bitcoin Transaction*) sulla Micro S
 
 
 
-Sullo schermo del Hardware Wallet, controllare attentamente i parametri della transazione: il Address del destinatario, l'importo inviato e le spese. Una volta confermata la transazione, convalidare per procedere alla firma.
+Sullo schermo dell'Hardware Wallet, controllare attentamente i parametri della transazione: l'Address del destinatario, l'importo inviato e le spese. Una volta confermata la transazione, convalidare per procedere alla firma.
 
 
 
@@ -547,7 +547,7 @@ Sullo schermo del Hardware Wallet, controllare attentamente i parametri della tr
 
 
 
-Riportare quindi la Micro SD sul computer e fare clic su "*Carica transazione*" in Sparrow. Selezionate il PSBT firmato da Coldcard dai vostri file.
+Riportare quindi la Micro SD sul computer e fare clic su "*Load Transaction*" su Sparrow. Selezionate il PSBT firmato su Coldcard dai vostri file.
 
 
 
@@ -555,7 +555,7 @@ Riportare quindi la Micro SD sul computer e fare clic su "*Carica transazione*" 
 
 
 
-Si può notare che la firma Coldcard è stata aggiunta. Ora utilizzerò un secondo dispositivo, in questo caso il Ledger, per eseguire la seconda firma richiesta. Lo collego, lo sblocco e poi faccio clic su "*Firma*" su Sparrow.
+Si può notare che la firma Coldcard è stata aggiunta. Ora utilizzerò un secondo dispositivo, in questo caso il Ledger, per eseguire la seconda firma richiesta. Lo collego, lo sblocco e poi faccio clic su "*Sign*" su Sparrow.
 
 
 
@@ -563,7 +563,7 @@ Si può notare che la firma Coldcard è stata aggiunta. Ora utilizzerò un secon
 
 
 
-Fare clic su "*Firma*" accanto al nome del proprio Hardware Wallet.
+Fare clic su "*Sign*" accanto al nome del proprio Hardware Wallet.
 
 
 
@@ -571,7 +571,7 @@ Fare clic su "*Firma*" accanto al nome del proprio Hardware Wallet.
 
 
 
-La prima volta che si utilizza il Ledger con questo Multisig, Sparrow chiederà di verificare le chiavi pubbliche estese (xpub) dei cofirmatari. Come nel caso della Coldcard, questo passaggio impedisce di firmare alla cieca in seguito. Per convalidare queste informazioni, confrontare le xpub visualizzate sullo schermo del Ledger con quelle fornite direttamente dagli altri portafogli hardware.
+La prima volta che si utilizza Ledger con questo Multisig, Sparrow chiederà di verificare le chiavi pubbliche estese (xpub) dei cofirmatari. Come nel caso di Coldcard, questo passaggio impedisce di firmare alla cieca in seguito. Per convalidare queste informazioni, confrontare le xpub visualizzate sullo schermo del Ledger con quelle fornite direttamente dagli altri Hardware Wallet.
 
 
 
@@ -579,7 +579,7 @@ La prima volta che si utilizza il Ledger con questo Multisig, Sparrow chiederà 
 
 
 
-Controllare il Address del destinatario, l'importo trasferito e la tariffa della transazione, quindi firmare la transazione.
+Controllare l'Address del destinatario, l'importo trasferito e la tariffa della transazione, quindi firmare la transazione.
 
 
 
@@ -587,7 +587,7 @@ Controllare il Address del destinatario, l'importo trasferito e la tariffa della
 
 
 
-Premere lo schermo per firmare.
+Toccare sullo schermo per firmare.
 
 
 
@@ -595,7 +595,7 @@ Premere lo schermo per firmare.
 
 
 
-Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portafoglio Multisig. Controllate la transazione un'ultima volta e, se tutto va bene, fate clic su "*Diffusione della transazione*" per trasmetterla in rete.
+Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portafoglio Multisig. Controllate la transazione un'ultima volta e, se tutto va bene, fate clic su "*Broadcast Transaction*" per trasmetterla in rete.
 
 
 
@@ -603,7 +603,7 @@ Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portaf
 
 
 
-Questa transazione si trova nella scheda "*Transazioni*" di Sparrow Wallet.
+Questa transazione si trova nella scheda "*Transactions*" di Sparrow Wallet.
 
 
 
@@ -611,11 +611,11 @@ Questa transazione si trova nella scheda "*Transazioni*" di Sparrow Wallet.
 
 
 
-Congratulazioni, ora sapete come impostare e utilizzare una firma multipla Wallet su Sparrow. Se avete trovato utile questa guida, vi sarei grato se lasciaste un pollice Green qui sotto. Non esitate a condividere questo articolo sui vostri social network. Grazie per la condivisione!
+Congratulazioni, ora sapete come impostare e utilizzare un Wallet a firma multipla su Sparrow. Se avete trovato utile questa guida, vi sarei grato se lasciaste un pollice verde qui sotto. Non esitate a condividere questo articolo sui vostri social network. Grazie per la condivisione!
 
 
 
-Per andare oltre, vi consiglio di consultare questo tutorial su un altro metodo per aumentare la sicurezza del vostro Bitcoin Wallet, il passphrase BIP39 :
+Per andare oltre, vi consiglio di consultare questo tutorial su un altro metodo per aumentare la sicurezza del vostro Bitcoin Wallet, il passphrase BIP39:
 
 
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -81,19 +81,19 @@ Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardwar
 
 
 
-- Il Trezor Model One è completamente open-source, il che rende possibile la verifica della generazione seed. Tuttavia, non essendo dotato di un chip anti manomissione (Secure Element), rimane vulnerabile agli attacchi fisici;
+- Trezor Model One è completamente open-source, il che rende possibile la verifica della generazione seed. Tuttavia, non essendo dotato di un chip anti manomissione (Secure Element), rimane vulnerabile agli attacchi fisici;
 
 
 
 
 
-- Il Ledger Flex, invece, beneficia di un firmware proprietario non verificabile, ma incorpora un Secure Element che offre un'eccellente protezione fisica;
+- Ledger Flex, invece, beneficia di un firmware proprietario non verificabile, ma incorpora un Secure Element che offre un'eccellente protezione fisica;
 
 
 
 
 
-- Il Coldcard è dotato di un Secure Element e il suo codice è rintracciabile. È una scelta interessante per la nostra configurazione, in quanto offre funzioni di verifica non disponibili su altri modelli.
+- Coldcard è dotato di un Secure Element e il suo codice è rintracciabile. È una scelta interessante per la nostra configurazione, in quanto offre funzioni di verifica non disponibili su altri modelli.
 
 
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -18,7 +18,7 @@ Questo meccanismo consente di condividere il controllo di un portafoglio tra pi�
 
 
 
-Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un Multisig Wallet richiede la protezione di diverse frasi Mnemonic (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un Multisig 2-of-3 Wallet, per recuperare il Wallet è necessario disporre di tutte e tre le frasi Mnemonic o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai Bitcoin che proteggono.
+Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un Multisig Wallet richiede la protezione di diverse frasi Mnemonic (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un Multisig 2-di-3 Wallet, per recuperare il Wallet è necessario disporre di tutte e tre le frasi Mnemonic o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai Bitcoin che proteggono.
 
 
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -6,7 +6,7 @@ Descrizione: Creare un portafoglio multi-firma su Sparrow
 
 
 
-Un Wallet multi-firma (spesso chiamato "*Multisig*") è una struttura Bitcoin Wallet che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un Wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un UTXO, il Multisig si basa su un modello **m-of-n**: delle _n_ chiavi associate al Wallet, _m_ devono imperativamente co-firmare ogni transazione.
+Un Wallet multi-firma (spesso chiamato "*Multisig*") è una struttura Bitcoin Wallet che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un Wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un UTXO, il Multisig si basa su un modello **m-di-n**: delle _n_ chiavi associate al Wallet, _m_ devono imperativamente co-firmare ogni transazione.
 
 
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -1,6 +1,6 @@
 ---
-name: Passero Wallet - Multisig
-description: Creare un portafoglio multi-firma su Sparrow
+Nome: Sparrow Wallet - Multisig
+Descrizione: Creare un portafoglio multi-firma su Sparrow
 ---
 ![cover](assets/cover.webp)
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -1,16 +1,16 @@
 ---
-Nome: Sparrow Wallet - Multisig
-Descrizione: Creare un portafoglio multi-firma su Sparrow
+Name: Sparrow - Multisig
+Description: Creare un wallet multi-firma su Sparrow
 ---
 ![cover](assets/cover.webp)
 
 
 
-Un Wallet multi-firma (spesso chiamato "*Multisig*") è una struttura Bitcoin Wallet che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un Wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un UTXO, il Multisig si basa su un modello **m-di-n**: delle _n_ chiavi associate al Wallet, _m_ devono imperativamente co-firmare ogni transazione.
+Un wallet multi-firma (spesso chiamato "*Multisig*") è un contratto Bitcoin che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un UTXO, il Multisig si basa su un modello **m-di-n**: delle _n_ chiavi associate al wallet, _m_ devono imperativamente co-firmare ogni transazione.
 
 
 
-Questo meccanismo consente di condividere il controllo di un portafoglio tra più entità o dispositivi. Ad esempio, in una configurazione 2 su 3, vengono generate tre serie di chiavi indipendenti, ma solo due sono necessarie per sbloccare i fondi. Questa architettura riduce drasticamente i rischi associati alla compromissione o alla perdita di una chiave: un ladro che ha accesso a una sola chiave non può svuotare il Wallet, e un utente che ne perde una può comunque accedere ai suoi fondi con le altre due.
+Questo meccanismo consente di condividere il controllo di un wallet tra più entità o dispositivi. Ad esempio, in una configurazione 2 su 3, vengono generate tre serie di chiavi indipendenti, ma solo due sono necessarie per sbloccare i fondi. Questa architettura riduce drasticamente i rischi associati alla compromissione o alla perdita di una chiave: un ladro che ha accesso a una sola chiave non può svuotare il wallet, e un utente che ne perde una può comunque accedere ai suoi fondi con le altre due.
 
 
 
@@ -18,17 +18,17 @@ Questo meccanismo consente di condividere il controllo di un portafoglio tra pi�
 
 
 
-Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un Multisig Wallet richiede la protezione di diverse frasi Mnemonic (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un Multisig 2-di-3 Wallet, per recuperare il Wallet è necessario disporre di tutte e tre le frasi Mnemonic o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai Bitcoin che proteggono.
+Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un Multisig wallet richiede la protezione di diverse frasi Mnemonic (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un wallet Multisig 2-di-3, per recuperare il wallet è necessario disporre di tutte e tre le frasi Mnemonic o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai bitcoin che proteggono.
 
 
 
-In sintesi, per recuperare un portafoglio Multisig, è necessario :
+In sintesi, per recuperare un wallet Multisig, è necessario :
 
 
 
 
 - Accedere a tutte le frasi Mnemonic associate a ciascun fattore di firma;
-- Oppure avere il numero minimo di frasi Mnemonic richiesto dalla soglia per poter firmare, e anche avere accesso alle xpub di tutti i fattori per recuperare le chiavi pubbliche necessarie.
+- Oppure avere il numero minimo di frasi Mnemonic richiesto dalla soglia per poter firmare, e anche avere accesso alle xpub di tutti gli intestatari del wallet per recuperare le chiavi pubbliche necessarie.
 
 
 
@@ -36,15 +36,15 @@ In sintesi, per recuperare un portafoglio Multisig, è necessario :
 
 
 
-La gestione dei backup del portafoglio Multisig è facilitata da *Descrittori di script di uscita*, che raggruppano tutti i dati pubblici necessari per accedere ai fondi. Tuttavia, questa funzionalità non è ancora implementata in tutti i software di gestione del portafoglio.
+La gestione dei backup del wallet Multisig è facilitata da *[Output Script Descriptors](https://planb.network/resources/glossary/output-script-descriptors)*, che raggruppano tutti i dati pubblici necessari per accedere ai fondi. Tuttavia, questa funzionalità non è ancora implementata in tutti i software di gestione del wallet.
 
 
 
-Multisig è particolarmente adatto ai Bitcoiners che cercano una maggiore sicurezza o una gestione collettiva dei fondi: aziende, associazioni, famiglie o singoli utenti che detengono una quantità significativa di Bitcoin. Può essere utilizzato per creare schemi di governance decentralizzati, ad esempio per distribuire l'autorità di firma tra diversi manager o membri del team.
+Un wallet Multisig è particolarmente adatto ai bitcoiners che cercano una maggiore sicurezza o una gestione collettiva dei fondi: aziende, associazioni, famiglie o singoli utenti che detengono una quantità significativa di bitcoin. Può essere utilizzato per creare schemi di governance decentralizzati, ad esempio per distribuire l'autorità di firma tra diversi manager o membri del team.
 
 
 
-In questa esercitazione impareremo a creare e utilizzare un classico Wallet a più firme con **Sparrow Wallet**. Se desiderate creare un portafoglio multi-firma personalizzato con blocchi temporali (timelocks), vi consiglio di utilizzare Liana:
+In questa esercitazione imparerai a creare e utilizzare un classico wallet a più firme con **Sparrow**. Se desideri creare un wallet multi-firma personalizzato con [timelocks](https://planb.network/resources/glossary/timelock), ti consiglio di utilizzare Liana:
 
 
 
@@ -54,13 +54,13 @@ https://planb.network/tutorials/wallet/desktop/liana-306ef457-700c-4fdd-b07a-8fb
 
 
 
-In questa esercitazione vi mostrerò come creare un Multisig con [Sparrow Wallet portfolio management software](https://sparrowwallet.com/download/). Se non avete ancora installato questo software, fatelo subito. Se avete bisogno di aiuto, abbiamo anche un tutorial dettagliato sulla configurazione di Sparrow Wallet:
+In questa esercitazione ti mostrerò come creare un Multisig con [Sparrow](https://sparrowwallet.com/download/). Se non hai ancora installato questo software, fallo subito. Se hai bisogno di aiuto, abbiamo anche un tutorial dettagliato sulla configurazione di Sparrow:
 
 
 
 https://planb.network/tutorials/wallet/desktop/sparrow-c674e2ac-d46f-4c82-92a7-7d1b0e262f5d)
 
-Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardware. Per un Multisig 2-di-3, ad esempio, si possono utilizzare:
+Per configurare un wallet multi-firma, sono necessari diversi hardware wallet. Per un Multisig 2-di-3, ad esempio, si possono utilizzare:
 
 
 
@@ -81,7 +81,7 @@ Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardwar
 
 
 
-- Trezor Model One è completamente open-source, il che rende possibile la verifica della generazione seed. Tuttavia, non essendo dotato di un chip anti manomissione (Secure Element), rimane vulnerabile agli attacchi fisici;
+- Trezor Model One è completamente open-source, il che rende possibile la verifica della generazione seed. Tuttavia, non essendo dotato di un Secure Element (chip fatto apposta per resistere ad attacchi fisici e informatici), rimane vulnerabile agli attacchi fisici;
 
 
 
@@ -97,7 +97,7 @@ Per configurare un Wallet multi-firma, sono necessari diversi portafogli hardwar
 
 
 
-Prima di configurare il Multisig Wallet, assicurarsi che ogni Hardware Wallet sia configurato correttamente (generazione e salvataggio delle frasi Mnemonic, definizione del PIN). Per istruzioni dettagliate, è possibile consultare i nostri tutorial per ogni Hardware Wallet, ad esempio :
+Prima di configurare il Multisig Wallet, assicurati che ogni Hardware Wallet sia configurato correttamente (generazione e salvataggio delle frasi Mnemonic, definizione del PIN). Per istruzioni dettagliate, puoi consultare i nostri tutorial per ogni Hardware Wallet, ad esempio :
 
 
 
@@ -107,7 +107,7 @@ https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-73e86d1a-6fe6-4d8b-bb15-8690298020e3
 
-Come vedremo più avanti in questo tutorial, è anche possibile integrare nella configurazione del Multisig un fattore che non è associato a un Hardware Wallet, ma le cui chiavi private sono memorizzate sul vostro PC. Questo metodo è ovviamente meno sicuro dell'uso esclusivo con Hardware Wallet, ma può essere rilevante in alcuni casi. Ad esempio, per un Multisig 2-de-3, si potrebbe optare per due Hardware Wallet e un Software Wallet.
+Come vedrai più avanti in questo tutorial, è anche possibile integrare nella configurazione del Multisig un fattore che non è associato a un Hardware Wallet, ma le cui chiavi private sono memorizzate sul tuo PC. Questo metodo è ovviamente meno sicuro dell'uso esclusivo con Hardware Wallet, ma può essere rilevante in alcuni casi. Ad esempio, per un Multisig 2-di-3, si potrebbe optare per due Hardware Wallet e un Software Wallet.
 
 
 
@@ -115,7 +115,7 @@ Come vedremo più avanti in questo tutorial, è anche possibile integrare nella 
 
 
 
-Aprire Sparrow Wallet, fare clic sulla scheda "*File*", quindi selezionare "*New Wallet*".
+Apri Sparrow, fai clic sulla scheda "*File*", quindi seleziona "*New Wallet*".
 
 
 
@@ -123,7 +123,7 @@ Aprire Sparrow Wallet, fare clic sulla scheda "*File*", quindi selezionare "*New
 
 
 
-Assegnare un nome al portafoglio con più firme, quindi fare clic su "*Create Wallet*" per confermare.
+Assegna un nome al wallet multisig, quindi clicca su "*Create Wallet*" per confermare.
 
 
 
@@ -131,7 +131,7 @@ Assegnare un nome al portafoglio con più firme, quindi fare clic su "*Create Wa
 
 
 
-Nel menu a discesa "*Policy Type*", selezionare l'opzione "*Multi Signature*".
+Nel menu a discesa "*Policy Type*", seleziona l'opzione "*Multi Signature*".
 
 
 
@@ -139,7 +139,7 @@ Nel menu a discesa "*Policy Type*", selezionare l'opzione "*Multi Signature*".
 
 
 
-Nell'angolo in alto a destra è possibile definire il numero totale di chiavi nel Multisig e il numero di cofirmatari necessari per autorizzare una spesa. Nel mio esempio, si tratta di uno schema di 2 su 3.
+Nell'angolo in alto a destra è possibile definire il numero totale di chiavi nel Multisig e il numero di cofirmatari necessari per autorizzare una transazione. Nel mio esempio, si tratta di uno schema 2 di 3.
 
 
 
@@ -147,7 +147,7 @@ Nell'angolo in alto a destra è possibile definire il numero totale di chiavi ne
 
 
 
-Nella parte inferiore della finestra, Sparrow Wallet visualizza tre "*Keystore*". Ognuno di essi rappresenta un set di chiavi. Qui sto usando tre portafogli hardware, quindi ogni "*Keystore*" corrisponde a uno di essi. Ora li configureremo.
+Nella parte inferiore della finestra, Sparrow visualizza tre "*Keystore*". Ognuno di essi rappresenta un set di chiavi. Qui sto usando tre Hardware Wallet, quindi ogni "*Keystore*" corrisponde a uno di essi. Ora li configureremo.
 
 
 
@@ -167,7 +167,7 @@ Sul Coldcard, una volta sbloccato il dispositivo, vado al menu "*Settings*", qui
 
 
 
-Questo menù consente di gestire i portafogli Multisig in cui partecipa Coldcard. Se voglio crearne uno nuovo, seleziono "*Esport XPUB*".
+Questo menù consente di gestire i Multisig Wallet in cui partecipa Coldcard. Se voglio crearne uno nuovo, seleziono "*Esport XPUB*".
 
 
 
@@ -183,7 +183,7 @@ Per il campo "*Account Number*", se si gestisce un solo conto, è possibile lasc
 
 
 
-La scheda Coldcard vi mostra quindi un file contenente la vostra xpub appena generata, salvata sulla scheda Micro SD.
+La scheda Coldcard ti mostra quindi un file contenente la tua xpub appena generata, salvata sulla scheda Micro SD.
 
 
 
@@ -191,7 +191,7 @@ La scheda Coldcard vi mostra quindi un file contenente la vostra xpub appena gen
 
 
 
-Inserire la Micro SD nel computer. In Sparrow Wallet, fare clic sul pulsante "*Import file...*" accanto a "*Coldcard Multisig*", quindi selezionare il file creato dal Coldcard sulla scheda.
+Inserisci la Micro SD nel computer. Su Sparrow, fai clic sul pulsante "*Import file...*" accanto a "*Coldcard Multisig*", quindi seleziona il file creato dal Coldcard sulla scheda.
 
 
 
@@ -199,7 +199,7 @@ Inserire la Micro SD nel computer. In Sparrow Wallet, fare clic sul pulsante "*I
 
 
 
-Il vostro xpub è stato importato con successo. Ora ripetiamo la procedura con gli altri due Hardware Wallet.
+Il tuo xpub è stato importato con successo. Ora ripeti la procedura con gli altri due Hardware Wallet.
 
 
 
@@ -207,7 +207,7 @@ Il vostro xpub è stato importato con successo. Ora ripetiamo la procedura con g
 
 
 
-Per il Ledger Flex, seleziono "*Keystore 2*", quindi faccio clic su "*Connected Hardware Wallet*". Assicurarsi che il Ledger sia collegato al computer, sbloccato e che l'applicazione Bitcoin sia aperta.
+Per il Ledger Flex, seleziona "*Keystore 2*", quindi fai clic su "*Connected Hardware Wallet*". Assicurati che il Ledger sia collegato al computer, sbloccato e che l'applicazione Bitcoin sia aperta.
 
 
 
@@ -215,7 +215,7 @@ Per il Ledger Flex, seleziono "*Keystore 2*", quindi faccio clic su "*Connected 
 
 
 
-Quindi fare clic sul pulsante "*Scan...*".
+Quindi fai clic sul pulsante "*Scan...*".
 
 
 
@@ -223,7 +223,7 @@ Quindi fare clic sul pulsante "*Scan...*".
 
 
 
-Accanto al nome dell'Hardware Wallet, fare clic su "*Import Keystore*".
+Accanto al nome dell'Hardware Wallet, fai clic su "*Import Keystore*".
 
 
 
@@ -231,7 +231,7 @@ Accanto al nome dell'Hardware Wallet, fare clic su "*Import Keystore*".
 
 
 
-Il secondo firmatario è ora correttamente registrato su Sparrow Wallet.
+Il secondo firmatario è ora correttamente registrato su Sparrow.
 
 
 
@@ -239,7 +239,7 @@ Il secondo firmatario è ora correttamente registrato su Sparrow Wallet.
 
 
 
-Ripeto esattamente la stessa procedura con il Trezor One per finalizzare la configurazione del Multisig.
+Ripeti esattamente la stessa procedura con il Trezor One per finalizzare la configurazione del Multisig.
 
 
 
@@ -247,11 +247,11 @@ Ripeto esattamente la stessa procedura con il Trezor One per finalizzare la conf
 
 
 
-Nella mia configurazione non è contemplato questo caso, ma se si desidera includere una firma tramite un Software Wallet in Sparrow (Hot Wallet) all'interno del proprio Multisig, è sufficiente fare clic sul pulsante "*New or Imported Software Wallet*".
+Nella mia configurazione non è contemplato questo caso, ma se desideri includere una firma tramite un Software Wallet in Sparrow (Hot Wallet) all'interno del proprio Multisig, è sufficiente fare clic sul pulsante "*New or Imported Software Wallet*".
 
 
 
-Ora che tutti i dispositivi di firma sono stati importati in Sparrow Wallet, è possibile finalizzare la creazione di Multisig facendo clic su "*Apply*".
+Ora che tutti i dispositivi di firma sono stati importati su Sparrow, è possibile finalizzare la creazione di Multisig facendo clic su "*Apply*".
 
 
 
@@ -259,11 +259,11 @@ Ora che tutti i dispositivi di firma sono stati importati in Sparrow Wallet, è 
 
 
 
-Scegliere una password forte per proteggere l'accesso al proprio Sparrow Wallet. Questa password protegge le chiavi pubbliche, gli indirizzi, le etichette e la cronologia delle transazioni da accessi non autorizzati.
+Scegli una password forte per proteggere l'accesso al proprio Sparrow. Questa password protegge le chiavi pubbliche, gli indirizzi, le etichette e la cronologia delle transazioni da accessi non autorizzati.
 
 
 
-Ricordate di salvare la password in un luogo sicuro, ad esempio in un gestore di password, per evitare di perderla.
+Ricorda di salvare la password in un luogo sicuro, ad esempio in un gestore di password, per evitare di perderla.
 
 
 
@@ -275,27 +275,27 @@ Ricordate di salvare la password in un luogo sicuro, ad esempio in un gestore di
 
 
 
-Ora salveremo il nostro *Descrittore script di uscita* sul Coldcard (questo vale solo per gli utenti che hanno un Coldcard nel loro Multisig) e, soprattutto, ne terremo una copia di backup su un supporto indipendente.
+Ora salva il tuo *Output Script Descriptors* sul Coldcard (questo vale solo per gli utenti che hanno un Coldcard nel loro Multisig) e, soprattutto, tieni una copia di backup su un supporto indipendente.
 
 
 
-Il *Descrittore* contiene tutte le xpub del Multisig Wallet, nonché i percorsi di derivazione utilizzati per generate le chiavi. Ricordiamo quanto visto nella Parte 1: per ripristinare un Multisig Wallet, è necessario avere **tutte** le frasi Mnemonic, oppure solo il numero minimo richiesto per raggiungere la soglia di firma. Tuttavia, in quest'ultimo caso, è essenziale avere anche **gli xpub** dei firmatari mancanti. Il *Descrittore* contiene tutte le xpub del Multisig.
+Il *Descriptor* contiene tutte le xpub del Multisig Wallet, nonché i percorsi di derivazione utilizzati per generate le chiavi. Ricorda quanto visto nella Parte 1: per ripristinare un Multisig Wallet, è necessario avere **tutte** le frasi Mnemonic, oppure solo il numero minimo richiesto per raggiungere la soglia di firma. Tuttavia, in quest'ultimo caso, è essenziale avere anche **gli xpub** dei firmatari mancanti. Il *Descriptor* contiene tutte le xpub del Multisig.
 
 
 
-Se non è chiaro, ricordate solo questo: per recuperare un Multisig, è necessario il numero minimo di frasi Mnemonic per ogni Hardware Wallet utilizzato, a seconda della soglia (nel mio caso: 2 frasi), oltre al *Descrittore*.
+Se non è chiaro, ricorda solo questo: per recuperare un Multisig, è necessario il numero minimo di frasi Mnemonic per ogni Hardware Wallet utilizzato, a seconda della soglia (nel mio caso: 2 frasi), oltre al *Descriptor*.
 
 
 
-Questo *Descrittore* non contiene chiavi private, ma solo chiavi pubbliche. Ciò significa che non dà accesso ai fondi. Non è quindi critico come le frasi Mnemonic, che danno pieno accesso ai Bitcoin. Il rischio del *Descrittore* è legato esclusivamente alla riservatezza: in caso di compromissione, una terza parte potrebbe osservare tutte le vostre transazioni, ma non potrebbe spendere i vostri fondi.
+Questo *Descriptor* non contiene chiavi private, ma solo chiavi pubbliche. Ciò significa che non dà accesso ai fondi. Non è quindi critico come le frasi Mnemonic, che danno pieno accesso ai bitcoin. Il rischio del *Descriptor* è legato esclusivamente alla riservatezza: in caso di compromissione, una terza parte potrebbe osservare tutte le tue transazioni, ma non potrebbe spendere i tuoi fondi.
 
 
 
-Consiglio vivamente di creare diverse copie di questo *Descrittore* e di conservarle con ciascun dispositivo di firma del Multisig. Ad esempio, nel mio caso, stampo il *Descrittore* su carta e ne conservo una copia sul Coldcard, un'altra sul Trezor e una sul Ledger. Inoltre, salvo questo *Descrittore* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno degli Hardware Wallet. In questo modo, massimizzo le possibilità di non perdere mai questo *Descrittore* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
+Consiglio vivamente di creare diverse copie di questo *Descriptor* e di conservarle con ciascun dispositivo di firma del Multisig. Ad esempio, nel mio caso, stampo il *Descriptor* su carta e ne conservo una copia nello stesso luogo dove riponi il Coldcard, un'altra insieme al Trezor e una insieme al Ledger. Inoltre, salvo questo *Descriptor* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno degli Hardware Wallet. In questo modo, massimizzo le possibilità di non perdere mai questo *Descrittore* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
 
 
 
-Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *Descrittore*. Fare clic sul pulsante "*SavePDF...*" per salvarlo sia come testo che come codice QR.
+Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *Descriptor*. Fai clic sul pulsante "*SavePDF...*" per salvarlo sia come testo che come codice QR.
 
 
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -303,7 +303,7 @@ Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *De
 
 
 
-È quindi possibile stampare il PDF e copiarlo sulle chiavette USB.
+È quindi possibile stampare il PDF e copiarlo sulla tua chiavetta USB.
 
 
 
@@ -311,7 +311,7 @@ Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *De
 
 
 
-Registreremo anche questo *Descrittore* sul Coldcard (se ne usate uno nella vostra configurazione). Ciò consentirà al Coldcard di verificare che ogni transazione firmata in seguito corrisponda al Wallet originale: xpub corretto, formato Address corretto, percorso di derivazione corretto... Senza questo *Descrittore* importato, Coldcard non può confermare che gli indirizzi Exchange non siano stati dirottati o che il PSBT non sia stato manomesso.
+Registra anche questo *Descriptor* sul Coldcard (se ne usi uno nella tua configurazione). Ciò consentirà al Coldcard di verificare che ogni transazione firmata in seguito corrisponda al Wallet originale: xpub corretto, formato Address corretto, percorso di derivazione corretto... Senza questo *Descriptor* importato, Coldcard non può confermare che gli indirizzi Exchange non siano stati dirottati o che il PSBT non sia stato manomesso.
 
 
 
@@ -319,7 +319,7 @@ Questo è ciò che rende Coldcard così interessante in un Multisig: offre contr
 
 
 
-In Sparrow, accedere al menu "*Settings*", quindi fare clic su "*Export...*".
+In Sparrow, accedi al menu "*Settings*", quindi fai clic su "*Export...*".
 
 
 
@@ -327,7 +327,7 @@ In Sparrow, accedere al menu "*Settings*", quindi fare clic su "*Export...*".
 
 
 
-Accanto all'opzione "*Coldcard Multisig*", fare clic su "*Export file...*" e salvare il file di testo sulla scheda Micro SD.
+Accanto all'opzione "*Coldcard Multisig*", fai clic su "*Export file...*" e salva il file di testo sulla scheda Micro SD.
 
 
 
@@ -335,7 +335,7 @@ Accanto all'opzione "*Coldcard Multisig*", fare clic su "*Export file...*" e sal
 
 
 
-Inserire quindi la scheda nel Coldcard. Andare al menu "*Settings*", quindi "*Multisig Wallet*" e selezionare "*Import from SD*".
+Inserisci quindi la scheda nel Coldcard. Vai al menu "*Settings*", quindi "*Multisig Wallet*" e seleziona "*Import from SD*".
 
 
 
@@ -343,7 +343,7 @@ Inserire quindi la scheda nel Coldcard. Andare al menu "*Settings*", quindi "*Mu
 
 
 
-Selezionare il file appropriato e confermare l'importazione.
+Seleziona il file appropriato e conferma l'importazione.
 
 
 
@@ -351,7 +351,7 @@ Selezionare il file appropriato e confermare l'importazione.
 
 
 
-Fare clic sul nome del nuovo Multisig importato.
+Fai clic sul nome del nuovo Multisig importato.
 
 
 
@@ -359,7 +359,7 @@ Fare clic sul nome del nuovo Multisig importato.
 
 
 
-Controllare i parametri di configurazione del Multisig, quindi confermare la registrazione.
+Controlla i parametri di configurazione del Multisig, quindi conferma la registrazione.
 
 
 
@@ -367,31 +367,31 @@ Controllare i parametri di configurazione del Multisig, quindi confermare la reg
 
 
 
-Il Multisig è ora correttamente salvato sul Coldcard. Se si dispone di più Coldcard nello stesso Multisig, ripetere questa procedura per ciascuna di esse.
+Il Multisig è ora correttamente salvato sul Coldcard. Se disponi di più Coldcard nello stesso Multisig, ripeti questa procedura per ciascuna di esse.
 
 
 
-Oltre a salvare il *Descrittore*, non dimenticate di prestare particolare attenzione al salvataggio delle frasi Mnemonic per ciascuno dei vostri dispositivi di firma. Se siete alle prime armi, vi consiglio di consultare quest'altra guida per imparare a salvarle e gestirle correttamente:
+Oltre a salvare il *Descriptor*, non dimentica di prestare particolare attenzione al salvataggio delle frasi Mnemonic per ciascuno dei tuoi dispositivi di firma. Se sei alle prime armi, ti consiglio di consultare quest'altra guida per imparare a salvarle e gestirle correttamente:
 
 
 
 https://planb.network/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-Prima di ricevere i primi Bitcoin sul Multisig, **vi consiglio vivamente di eseguire un test di ripristino a vuoto**. Annotare alcune informazioni di riferimento, come la prima ricezione dell'Address, quindi ripristinare gli Hardware Wallet mentre il Wallet è ancora vuoto. Successivamente, provare a ripristinare il Multisig Wallet sui portafogli Hardware utilizzando i backup cartacei della frase Mnemonic, mentre su Sparrow utilizzando il *Descrittore*. Verificare che il primo Address generato dopo il ripristino corrisponda a quello scritto originariamente. Se così fosse, si può essere certi che i backup cartacei sono affidabili.
+Quando ancora non hai ricevuto fondi sul Multisig, **ti consiglio vivamente di eseguire un test di ripristino con il wallet vuoto**. Annota alcune informazioni di riferimento, come il primo indirizzo di ricezione, quindi ripristina gli Hardware Wallet mentre il wallet è ancora vuoto. Successivamente, prova a ripristinare il Multisig Wallet sui portafogli Hardware utilizzando i backup cartacei della frase Mnemonic, mentre su Sparrow fai la stessa cosa utilizzando il *Descriptor*. Verifica che il primo indirizzo di ricezione generato dopo il ripristino corrisponda a quello scritto originariamente. Se così fosse, puoi essere certo che i backup cartacei sono affidabili.
 
 
 
-Per saperne di più su come eseguire un test di ripristino, vi suggerisco di consultare quest'altra guida:
+Per saperne di più su come eseguire un test di ripristino, ti suggerisco di consultare quest'altra guida:
 
 
 
 https://planb.network/tutorials/wallet/backup/recovery-test-5a75db51-a6a1-4338-a02a-164a8d91b895
 
-## Ricevere Bitcoin sul vostro Multisig
+## Ricevere bitcoin sul tuo Multisig
 
 
 
-Il vostro Wallet è ora pronto a ricevere Bitcoin. In Sparrow, fare clic sulla scheda "*Receive*".
+Il tuo Wallet è ora pronto a ricevere bitcoin. In Sparrow, fai clic sulla scheda "*Receive*".
 
 
 
@@ -399,11 +399,11 @@ Il vostro Wallet è ora pronto a ricevere Bitcoin. In Sparrow, fare clic sulla s
 
 
 
-Prima di utilizzare l'Address generato da Sparrow Wallet, prendetevi il tempo di verificarlo direttamente sullo schermo dei vostri Hardware Wallet. In questo modo vi assicurerete che l'Address non sia stato alterato e che i vostri dispositivi possiedano le chiavi private necessarie per spendere i fondi associati. Questo aiuta a proteggersi da una serie di vettori di attacco.
+Prima di utilizzare l'Address, ovvero l'indirizzo di ricezione, generato da Sparrow Wallet, prenditi del tempo per verificarlo direttamente sullo schermo dei tuoi Hardware Wallet. Questo ti assicurerà che l'Address non è stato alterato e che i tuoi dispositivi possiedono le chiavi private necessarie per spendere i fondi associati. Questo aiuta a proteggerti da una serie di vettori di attacco.
 
 
 
-A tal fine, fare clic su "*Display Address*" per visualizzare l'Address sul Trezor o sul Ledger, se collegato via cavo.
+A tal fine, fai clic su "*Display Address*" per visualizzare l'Address sul Trezor o sul Ledger, se collegato via cavo.
 
 
 
@@ -411,7 +411,7 @@ A tal fine, fare clic su "*Display Address*" per visualizzare l'Address sul Trez
 
 
 
-Con Coldcard, questa verifica può essere effettuata senza alcuna interazione con Sparrow. È sufficiente aprire il menu "*Address Explorer*" e selezionare il proprio Multisig in basso.
+Con Coldcard, questa verifica può essere effettuata senza alcuna interazione con Sparrow. Semplicemente apri il menu "*Address Explorer*" e seleziona il tuo Multisig in basso.
 
 
 
@@ -419,7 +419,7 @@ Con Coldcard, questa verifica può essere effettuata senza alcuna interazione co
 
 
 
-Si vedranno quindi gli indirizzi di ricezione generati dal Multisig.
+Vedrai quindi gli indirizzi di ricezione generati dal Multisig.
 
 
 
@@ -427,11 +427,11 @@ Si vedranno quindi gli indirizzi di ricezione generati dal Multisig.
 
 
 
-Verificare che l'Address visualizzato su ogni Hardware Wallet corrisponda esattamente a quello del Wallet di Sparrow. È consigliabile eseguire questa operazione appena prima di condividere l'Address con il pagatore, per essere sicuri della sua integrità.
+Verifica che l'Address visualizzato su ogni Hardware Wallet corrisponda esattamente a quello del Wallet di Sparrow. Ti consiglio di eseguire questa operazione prima di condividere l'Address con il pagatore, per essere sicuro della sua integrità.
 
 
 
-È quindi possibile assegnare un "Label" (etichetta) a questo Address, per indicare l'origine dei Bitcoin ricevuti. Questo è un buon modo per organizzare la gestione dei vostri UTXO.
+Puoi quindi assegnare una "Etichetta"  a questo Address, per indicare l'origine dei bitcoin ricevuti. Questo è un buon modo per organizzare la gestione dei tuoi UTXO.
 
 
 
@@ -439,7 +439,7 @@ Verificare che l'Address visualizzato su ogni Hardware Wallet corrisponda esatta
 
 
 
-Una volta verificato, è possibile utilizzare l'Address per ricevere Bitcoin.
+Una volta verificato, puoi utilizzare l'Address per ricevere bitcoin.
 
 
 
@@ -447,11 +447,11 @@ Una volta verificato, è possibile utilizzare l'Address per ricevere Bitcoin.
 
 
 
-## Inviare Bitcoin con il vostro Multisig
+## Inviare bitcoin con il tuo Multisig
 
 
 
-Ora che avete ricevuto i primi Sats sul vostro Multisig Wallet, potete anche spenderli! In Sparrow, vai alla scheda "*Send*" per creare una nuova transazione.
+Ora che hai ricevuto i primi Sats sul tuo Multisig Wallet, puoi anche spenderli! Su Sparrow, vai alla scheda "*Send*" per creare una nuova transazione.
 
 
 
@@ -459,7 +459,7 @@ Ora che avete ricevuto i primi Sats sul vostro Multisig Wallet, potete anche spe
 
 
 
-Se si desidera utilizzare il *Coin Control*, ossia la selezione manualmente gli UTXO da spendere, andare alla scheda "*UTXO*". Scegliete gli UTXO che desiderate spendere, quindi cliccate su "*Send Selected*". Si verrà automaticamente reindirizzati alla scheda "*Send*", con gli UTXO già precompilati.
+Se vuoi utilizzare il *Coin Control*, ossia la selezione manuale degli UTXO da spendere, vai sulla scheda "*UTXO*". Scegli gli UTXO che desideri spendere, quindi clicca su "*Send Selected*". Verrai automaticamente reindirizzato sulla scheda "*Send*", con gli UTXO già selezionati.
 
 
 
@@ -467,7 +467,7 @@ Se si desidera utilizzare il *Coin Control*, ossia la selezione manualmente gli 
 
 
 
-Inserire la destinazione dell'Address. È possibile aggiungere più indirizzi facendo clic su "*+ Aggiungi*".
+Inserisci l'indirizzo di destinazione. Puoi aggiungere più indirizzi facendo clic su "*+ Aggiungi*".
 
 
 
@@ -475,7 +475,7 @@ Inserire la destinazione dell'Address. È possibile aggiungere più indirizzi fa
 
 
 
-Aggiungere una "*Label*" (Etichetta) per descrivere lo scopo di questa spesa, così da facilitare la tracciabilità delle transazioni.
+Aggiungi una "*Etichetta*" per descrivere lo scopo di questa transazione, così da facilitarne la tracciabilità.
 
 
 
@@ -483,7 +483,7 @@ Aggiungere una "*Label*" (Etichetta) per descrivere lo scopo di questa spesa, co
 
 
 
-Inserire l'importo da inviare all'Address selezionato.
+Inserisci l'importo da inviare all'Address selezionato.
 
 
 
@@ -491,11 +491,11 @@ Inserire l'importo da inviare all'Address selezionato.
 
 
 
-Regolare la quantità di fees in base alle condizioni attuali della rete. Ad esempio, consultare [Mempool.space](https://Mempool.space/) per selezionare una fee adeguata.
+Regola la quantità di fees in base alle condizioni attuali della rete. Ad esempio, consulta [Mempool.space](https://Mempool.space/) per selezionare una fee adeguata.
 
 
 
-Dopo aver controllato tutti i parametri della transazione, fare clic su "*Create Transaction*".
+Dopo aver controllato tutti i parametri della transazione, fai clic su "*Create Transaction*".
 
 
 
@@ -503,7 +503,7 @@ Dopo aver controllato tutti i parametri della transazione, fare clic su "*Create
 
 
 
-Se siete soddisfatti di tutto, fate clic su "*Finalize Transaction for Signing*".
+Se sei soddisfatto di tutto, fai clic su "*Finalize Transaction for Signing*".
 
 
 
@@ -511,7 +511,7 @@ Se siete soddisfatti di tutto, fate clic su "*Finalize Transaction for Signing*"
 
 
 
-Nella parte inferiore dello schermo, vedrete che Sparrow è in attesa di 2 firme. Questo è normale: il Wallet usato qui è un Multisig 2-di-3.
+Nella parte inferiore dello schermo, vedrai che Sparrow è in attesa di 2 firme. Questo è normale: il Wallet usato qui è un Multisig 2-di-3.
 
 
 
@@ -519,7 +519,7 @@ Nella parte inferiore dello schermo, vedrete che Sparrow è in attesa di 2 firme
 
 
 
-Inizio a firmare con il mio Coldcard. A tal fine, inserisco una scheda Micro SD nel computer, quindi faccio clic su "*Save Transaction*".
+Inizia a firmare con il tuo Coldcard. A tal fine, inserisci una scheda Micro SD nel computer, quindi fai clic su "*Save Transaction*".
 
 
 
@@ -527,11 +527,11 @@ Inizio a firmare con il mio Coldcard. A tal fine, inserisco una scheda Micro SD 
 
 
 
-Esistono 3 modi per trasmettere la transazione dal firmare all'Hardware Wallet e poi recuperarla da Sparrow. Il primo è utilizzare una scheda Micro SD, come faremo qui per Coldcard. Il secondo è tramite una connessione via cavo, che utilizzeremo per la seconda firma (Ledger e Trezor). Infine, è possibile utilizzare la comunicazione tramite codice QR, per i dispositivi dotati di fotocamera come Coldcard Q, Jade Plus o Passport V2.
+Esistono 3 modi per trasmettere la transazione da firmare all'Hardware Wallet e poi recuperarla da Sparrow. Il primo è utilizzare una scheda Micro SD, come vedrai qui con Coldcard. Il secondo è tramite una connessione via cavo, che utilizzerai per la seconda firma (Ledger e Trezor). Infine, puoi utilizzare la comunicazione tramite codice QR, per i dispositivi dotati di fotocamera come Coldcard Q, Jade Plus o Passport V2.
 
 
 
-Una volta salvato il PSBT (*Partially Signed Bitcoin Transaction*) sulla Micro SD, lo inserisco nel Coldcard MK3, quindi seleziono il menu "*Ready To Sign*".
+Una volta che hai salvato il PSBT (*Partially Signed Bitcoin Transaction*) sulla Micro SD, inseriscilo nel Coldcard MK3, quindi seleziona il menu "*Ready To Sign*".
 
 
 
@@ -539,7 +539,7 @@ Una volta salvato il PSBT (*Partially Signed Bitcoin Transaction*) sulla Micro S
 
 
 
-Sullo schermo dell'Hardware Wallet, controllare attentamente i parametri della transazione: l'Address del destinatario, l'importo inviato e le spese. Una volta confermata la transazione, convalidare per procedere alla firma.
+Sullo schermo dell'Hardware Wallet, controlla attentamente i parametri della transazione: l'Address del destinatario, l'importo inviato e le fees. Una volta confermata la transazione, convalida per procedere alla firma.
 
 
 
@@ -547,7 +547,7 @@ Sullo schermo dell'Hardware Wallet, controllare attentamente i parametri della t
 
 
 
-Riportare quindi la Micro SD sul computer e fare clic su "*Load Transaction*" su Sparrow. Selezionate il PSBT firmato su Coldcard dai vostri file.
+Quindi torna al tuo computer con la Micro SD e su Sparrow clicca su "*Load Transaction*". Seleziona il PSBT firmato su Coldcard dai tuoi file.
 
 
 
@@ -555,7 +555,7 @@ Riportare quindi la Micro SD sul computer e fare clic su "*Load Transaction*" su
 
 
 
-Si può notare che la firma Coldcard è stata aggiunta. Ora utilizzerò un secondo dispositivo, in questo caso il Ledger, per eseguire la seconda firma richiesta. Lo collego, lo sblocco e poi faccio clic su "*Sign*" su Sparrow.
+Puoi vedere che la firma Coldcard è stata aggiunta. Devi ora usare un secondo dispositivo, in questo esempio il Ledger, per eseguire la seconda firma richiesta. Collegalo, sbloccalo e poi fai clic su "*Sign*" su Sparrow.
 
 
 
@@ -563,7 +563,7 @@ Si può notare che la firma Coldcard è stata aggiunta. Ora utilizzerò un secon
 
 
 
-Fare clic su "*Sign*" accanto al nome del proprio Hardware Wallet.
+Fai clic su "*Sign*" accanto al nome del proprio Hardware Wallet.
 
 
 
@@ -571,7 +571,7 @@ Fare clic su "*Sign*" accanto al nome del proprio Hardware Wallet.
 
 
 
-La prima volta che si utilizza Ledger con questo Multisig, Sparrow chiederà di verificare le chiavi pubbliche estese (xpub) dei cofirmatari. Come nel caso di Coldcard, questo passaggio impedisce di firmare alla cieca in seguito. Per convalidare queste informazioni, confrontare le xpub visualizzate sullo schermo del Ledger con quelle fornite direttamente dagli altri Hardware Wallet.
+La prima volta che usi Ledger con questo Multisig, Sparrow chiederà di verificare le chiavi pubbliche estese (xpub) dei cofirmatari. Come nel caso di Coldcard, questo passaggio impedisce di firmare alla cieca in seguito. Per convalidare queste informazioni, confronta le xpub visualizzate sullo schermo del Ledger con quelle fornite direttamente dagli altri Hardware Wallet.
 
 
 
@@ -579,7 +579,7 @@ La prima volta che si utilizza Ledger con questo Multisig, Sparrow chiederà di 
 
 
 
-Controllare l'Address del destinatario, l'importo trasferito e la tariffa della transazione, quindi firmare la transazione.
+Controlla l'Address del destinatario, l'importo trasferito e la fee della transazione, quindi firma la transazione.
 
 
 
@@ -587,7 +587,7 @@ Controllare l'Address del destinatario, l'importo trasferito e la tariffa della 
 
 
 
-Toccare sullo schermo per firmare.
+Tocca sullo schermo per firmare.
 
 
 
@@ -595,7 +595,7 @@ Toccare sullo schermo per firmare.
 
 
 
-Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portafoglio Multisig. Controllate la transazione un'ultima volta e, se tutto va bene, fate clic su "*Broadcast Transaction*" per trasmetterla in rete.
+Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portafoglio Multisig. Controlla la transazione un'ultima volta e, se tutto va bene, fai clic su "*Broadcast Transaction*" per trasmetterla in rete.
 
 
 
@@ -611,11 +611,11 @@ Questa transazione si trova nella scheda "*Transactions*" di Sparrow Wallet.
 
 
 
-Congratulazioni, ora sapete come impostare e utilizzare un Wallet a firma multipla su Sparrow. Se avete trovato utile questa guida, vi sarei grato se lasciaste un pollice verde qui sotto. Non esitate a condividere questo articolo sui vostri social network. Grazie per la condivisione!
+Congratulazioni, ora sai come impostare e utilizzare un Wallet a firma multipla su Sparrow. Se hai trovato utile questa guida, ti sarei grato se lasciassi un pollice verde qui sotto. Non esitare a condividere questo articolo sui tuoi social network. Grazie per la condivisione!
 
 
 
-Per andare oltre, vi consiglio di consultare questo tutorial su un altro metodo per aumentare la sicurezza del vostro Bitcoin Wallet, il passphrase BIP39:
+Per andare avanti, ti consiglio di consultare questo tutorial su un altro metodo per aumentare la sicurezza del tuo Bitcoin Wallet, il passphrase BIP39:
 
 
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -1,12 +1,12 @@
 ---
-Name: Sparrow - Multisig
-Description: Creare un wallet multi-firma su Sparrow
+name: Sparrow - multisig
+description: Creare un wallet multi-firma su Sparrow
 ---
 ![cover](assets/cover.webp)
 
 
 
-Un wallet multi-firma (spesso chiamato "*Multisig*") è un contratto Bitcoin che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un [UTXO](https://planb.network/resources/glossary/utxo), il Multisig si basa su un modello **m-di-n**: delle _n_ chiavi associate al wallet, _m_ devono imperativamente co-firmare ogni transazione.
+Un wallet multi-firma (spesso chiamato "*multisig*") è un contratto Bitcoin che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un [UTXO](https://planb.network/resources/glossary/utxo), il multisig si basa su un modello **m-di-n**: delle _n_ chiavi associate al wallet, _m_ devono imperativamente co-firmare ogni transazione.
 
 
 
@@ -18,17 +18,17 @@ Questo meccanismo consente di suddividere il controllo di un wallet tra più ent
 
 
 
-Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un Multisig wallet richiede la protezione di diverse frasi Mnemonic (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un wallet Multisig 2-di-3, per recuperare il wallet è necessario disporre di tutte e tre le frasi Mnemonic o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai bitcoin che proteggono.
+Tuttavia, questa maggiore sicurezza comporta una maggiore complessità. La configurazione di un multisig wallet richiede la protezione di diverse frasi mnemoniche (una per fattore di firma) e di chiavi pubbliche estese ("*xpub*"). Infatti, se si utilizza un wallet multisig 2-di-3, per recuperare il wallet è necessario disporre di tutte e tre le frasi mnemoniche o di almeno due delle tre frasi. Ma se si dispone solo di due delle tre frasi, è necessario accedere anche alle tre *xpub*, senza le quali sarà impossibile recuperare le chiavi pubbliche necessarie per accedere ai bitcoin che proteggono.
 
 
 
-In sintesi, per recuperare un wallet Multisig, è necessario :
+In sintesi, per recuperare un wallet multisig, è necessario:
 
 
 
 
-- Accedere a tutte le frasi Mnemonic associate a ciascun fattore di firma;
-- Oppure avere il numero minimo di frasi Mnemonic richiesto dalla soglia per poter firmare, e anche avere accesso alle xpub di tutti gli intestatari del wallet per recuperare le chiavi pubbliche necessarie.
+- Accedere a tutte le frasi mnemoniche associate a ciascun fattore di firma;
+- Oppure avere il numero minimo di frasi mnemoniche richiesto dalla soglia per poter firmare, e anche avere accesso alle xpub di tutti gli intestatari del wallet per recuperare le chiavi pubbliche necessarie.
 
 
 
@@ -36,11 +36,11 @@ In sintesi, per recuperare un wallet Multisig, è necessario :
 
 
 
-La gestione dei backup del wallet Multisig è facilitata da *[Output Script Descriptors](https://planb.network/resources/glossary/output-script-descriptors)*, che raggruppano tutti i dati pubblici necessari per accedere ai fondi. Tuttavia, questa funzionalità non è ancora implementata in tutti i software di gestione del wallet.
+La gestione dei backup del wallet multisig è facilitata dagli *[Output Script Descriptors](https://planb.network/resources/glossary/output-script-descriptors)*, che raggruppano tutti i dati pubblici necessari per accedere ai fondi. Tuttavia, questa funzionalità non è ancora implementata in tutti i software di gestione del wallet.
 
 
 
-Un wallet Multisig è particolarmente adatto ai bitcoiners che cercano una maggiore sicurezza o una gestione collettiva dei fondi: aziende, associazioni, famiglie o singoli utenti che detengono una quantità significativa di bitcoin. Può essere utilizzato per creare schemi di governance decentralizzati, ad esempio per distribuire l'autorità di firma tra diversi manager o membri del team.
+Un wallet multisig è particolarmente adatto ai bitcoiners che cercano una maggiore sicurezza o una gestione collettiva dei fondi: aziende, associazioni, famiglie o singoli utenti che detengono una quantità significativa di bitcoin. Può essere utilizzato per creare schemi di governance decentralizzati, ad esempio per distribuire l'autorità di firma tra diversi manager o membri del team.
 
 
 
@@ -54,13 +54,13 @@ https://planb.network/tutorials/wallet/desktop/liana-306ef457-700c-4fdd-b07a-8fb
 
 
 
-In questa esercitazione ti mostrerò come creare un Multisig con [Sparrow](https://sparrowwallet.com/download/). Se non hai ancora installato questo software, fallo subito. Se hai bisogno di aiuto, abbiamo anche un tutorial dettagliato sulla configurazione di Sparrow:
+In questa esercitazione ti mostrerò come creare un multisig con [Sparrow](https://sparrowwallet.com/download/). Se non l'hai ancora installato e ti serve aiuto, abbiamo anche un tutorial dettagliato sulla configurazione di Sparrow:
 
 
 
 https://planb.network/tutorials/wallet/desktop/sparrow-c674e2ac-d46f-4c82-92a7-7d1b0e262f5d
 
-Per configurare un wallet multi-firma, sono necessari diversi hardware wallet. Per un Multisig 2-di-3, ad esempio, si possono utilizzare:
+Per configurare un wallet multi-firma, sono necessari diversi hardware wallet. Per un multisig 2-di-3, ad esempio, si possono utilizzare:
 
 
 
@@ -75,7 +75,7 @@ Per configurare un wallet multi-firma, sono necessari diversi hardware wallet. P
 
 
 
-È una buona idea utilizzare diverse marche di Hardware Wallet nella configurazione Multisig. In questo modo hai la garanzia che se un modello specifico presenta un problema grave, questo non influisce sulla sicurezza complessiva del Multisig. Inoltre, ciò ti consente di beneficiare dei vantaggi specifici di ciascun dispositivo. Ad esempio, nella mia configurazione:
+È una buona idea utilizzare diverse marche di Hardware wallet nella configurazione multisig. In questo modo hai la garanzia che se un modello specifico presenta un problema grave, questo non influisce sulla sicurezza complessiva del multisig. Inoltre, ciò ti consente di beneficiare dei vantaggi specifici di ciascun dispositivo. Ad esempio, nella mia configurazione:
 
 
 
@@ -97,7 +97,7 @@ Per configurare un wallet multi-firma, sono necessari diversi hardware wallet. P
 
 
 
-Prima di configurare il Multisig Wallet, assicurati che ogni Hardware Wallet sia configurato correttamente (generazione e salvataggio delle frasi Mnemonic, definizione del PIN). Per istruzioni dettagliate, puoi consultare i nostri tutorial per ogni Hardware Wallet, ad esempio :
+Prima di configurare il multisig wallet, assicurati che ogni Hardware wallet sia configurato correttamente (generazione e salvataggio delle frasi mnemonichehe, definizione del PIN). Per istruzioni dettagliate, puoi consultare i nostri tutorial per ogni Hardware wallet, ad esempio:
 
 
 
@@ -107,15 +107,15 @@ https://planb.network/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.network/tutorials/wallet/hardware/coldcard-q-73e86d1a-6fe6-4d8b-bb15-8690298020e3
 
-Come vedrai più avanti in questo tutorial, è anche possibile integrare nella configurazione del Multisig un fattore che non è associato a un Hardware Wallet, ma le cui chiavi private sono memorizzate sul tuo PC. Questo metodo è ovviamente meno sicuro dell'uso esclusivo con Hardware Wallet, ma può essere rilevante in alcuni casi. Ad esempio, per un Multisig 2-di-3, si potrebbe optare per due Hardware Wallet e un Software Wallet.
+Come vedrai più avanti in questo tutorial, è anche possibile integrare nella configurazione del multisig un fattore che non è associato a un Hardware wallet, ma le cui chiavi private sono memorizzate sul tuo PC. Questo metodo è ovviamente meno sicuro dell'uso esclusivo con Hardware wallet, ma può essere rilevante in alcuni casi. Ad esempio, per un multisig 2-di-3, si potrebbe optare per due Hardware wallet e un Software wallet.
 
 
 
-## Creare un portafoglio Multisig
+## Creare un portafoglio multisig
 
 
 
-Apri Sparrow, fai clic sulla scheda "*File*", quindi seleziona "*New Wallet*".
+Apri Sparrow, fai clic sulla scheda "*File*", quindi seleziona "*New wallet*".
 
 
 
@@ -123,7 +123,7 @@ Apri Sparrow, fai clic sulla scheda "*File*", quindi seleziona "*New Wallet*".
 
 
 
-Assegna un nome al wallet multisig, quindi clicca su "*Create Wallet*" per confermare.
+Assegna un nome al wallet multisig, quindi clicca su "*Create wallet*" per confermare.
 
 
 
@@ -139,7 +139,7 @@ Nel menu a discesa "*Policy Type*", seleziona l'opzione "*Multi Signature*".
 
 
 
-Nell'angolo in alto a destra puoi definire il numero totale di chiavi nel Multisig e il numero di cofirmatari necessari per autorizzare una transazione. Nel mio esempio, si tratta di uno schema 2 di 3.
+Nell'angolo in alto a destra puoi definire il numero totale di chiavi nel multisig e il numero di cofirmatari necessari per autorizzare una transazione. Nel mio esempio, si tratta di uno schema 2 di 3.
 
 
 
@@ -147,11 +147,11 @@ Nell'angolo in alto a destra puoi definire il numero totale di chiavi nel Multis
 
 
 
-Nella parte inferiore della finestra, Sparrow visualizza tre "*Keystore*". Ognuno di essi rappresenta un set di chiavi. Qui sto usando tre Hardware Wallet, quindi ogni "*Keystore*" corrisponde a uno di essi. Ora li configureremo.
+Nella parte inferiore della finestra, Sparrow visualizza tre "*Keystore*". Ognuno di essi rappresenta un set di chiavi. Qui sto usando tre Hardware wallet, quindi ogni "*Keystore*" corrisponde a uno di essi. Ora li configureremo.
 
 
 
-Inizio con il Coldcard. Nella scheda "*Keystore 1*", scelgo l'opzione "*Airgapped Hardware Wallet*".
+Inizio con il Coldcard. Nella scheda "*Keystore 1*", scelgo l'opzione "*Airgapped Hardware wallet*".
 
 
 
@@ -159,7 +159,7 @@ Inizio con il Coldcard. Nella scheda "*Keystore 1*", scelgo l'opzione "*Airgappe
 
 
 
-Sul Coldcard, una volta sbloccato il dispositivo, vado al menu "*Settings*", quindi a "*Multisig Wallets*".
+Sul Coldcard, una volta sbloccato il dispositivo, vado al menu "*Settings*", quindi a "*multisig wallets*".
 
 
 
@@ -167,7 +167,7 @@ Sul Coldcard, una volta sbloccato il dispositivo, vado al menu "*Settings*", qui
 
 
 
-Questo menù consente di gestire i Multisig Wallet in cui partecipa Coldcard. Se voglio crearne uno nuovo, seleziono "*Esport XPUB*".
+Questo menù consente di gestire i multisig wallet in cui partecipa Coldcard. Se voglio crearne uno nuovo, seleziono "*Esport XPUB*".
 
 
 
@@ -191,7 +191,7 @@ La scheda Coldcard ti mostra quindi un file contenente la tua xpub appena genera
 
 
 
-Inserisci la Micro SD nel computer. Su Sparrow, fai clic sul pulsante "*Import file...*" accanto a "*Coldcard Multisig*", quindi seleziona il file creato dal Coldcard sulla scheda.
+Inserisci la Micro SD nel computer. Su Sparrow, fai clic sul pulsante "*Import file...*" accanto a "*Coldcard multisig*", quindi seleziona il file creato dal Coldcard sulla scheda.
 
 
 
@@ -199,7 +199,7 @@ Inserisci la Micro SD nel computer. Su Sparrow, fai clic sul pulsante "*Import f
 
 
 
-Il tuo xpub è stato importato con successo. Ora ripeti la procedura con gli altri due Hardware Wallet.
+Il tuo xpub è stato importato con successo. Ora ripeti la procedura con gli altri due Hardware wallet.
 
 
 
@@ -207,7 +207,7 @@ Il tuo xpub è stato importato con successo. Ora ripeti la procedura con gli alt
 
 
 
-Per il Ledger Flex, seleziona "*Keystore 2*", quindi fai clic su "*Connected Hardware Wallet*". Assicurati che il Ledger sia collegato al computer, sbloccato e che l'applicazione Bitcoin sia aperta.
+Per il Ledger Flex, seleziona "*Keystore 2*", quindi fai clic su "*Connected Hardware wallet*". Assicurati che il Ledger sia collegato al computer, che sia sbloccato, e che l'applicazione Bitcoin sia aperta.
 
 
 
@@ -223,7 +223,7 @@ Quindi fai clic sul pulsante "*Scan...*".
 
 
 
-Accanto al nome dell'Hardware Wallet, fai clic su "*Import Keystore*".
+Accanto al nome dell'Hardware wallet, fai clic su "*Import Keystore*".
 
 
 
@@ -239,7 +239,7 @@ Il secondo firmatario è ora correttamente registrato su Sparrow.
 
 
 
-Ripeti esattamente la stessa procedura con il Trezor One per finalizzare la configurazione del Multisig.
+Ripeti esattamente la stessa procedura con il Trezor One per finalizzare la configurazione del multisig.
 
 
 
@@ -247,11 +247,11 @@ Ripeti esattamente la stessa procedura con il Trezor One per finalizzare la conf
 
 
 
-Nella mia configurazione non è contemplato questo caso, ma se desideri includere una firma tramite un Software Wallet in Sparrow (Hot Wallet) all'interno del proprio Multisig, è sufficiente fare clic sul pulsante "*New or Imported Software Wallet*".
+Nella mia configurazione non è contemplato questo caso, ma se desideri includere una firma tramite un Software wallet in Sparrow (Hot wallet) all'interno del proprio multisig, è sufficiente fare clic sul pulsante "*New or Imported Software wallet*".
 
 
 
-Ora che tutti i dispositivi di firma sono stati importati su Sparrow, è possibile finalizzare la creazione di Multisig facendo clic su "*Apply*".
+Ora che tutti i dispositivi di firma sono stati importati su Sparrow, è possibile finalizzare la creazione di multisig facendo clic su "*Apply*".
 
 
 
@@ -271,31 +271,31 @@ Ricorda di salvare la password in un luogo sicuro, ad esempio in un gestore di p
 
 
 
-## Backup di un Multisig Wallet
+## Backup di un multisig wallet
 
 
 
-Ora salva il tuo *Output Script Descriptors* sul Coldcard (questo vale solo per gli utenti che hanno un Coldcard nel loro Multisig) e, soprattutto, tieni una copia di backup su un supporto indipendente.
+Ora salva il tuo *Output Script Descriptors* sul Coldcard (questo vale solo per gli utenti che hanno un Coldcard nel loro multisig) e, soprattutto, tieni una copia di backup su un supporto indipendente.
 
 
 
-Il *Descriptor* contiene tutte le xpub del Multisig Wallet, nonché i percorsi di derivazione utilizzati per generate le chiavi. Ricorda quanto visto nella Parte 1: per ripristinare un Multisig Wallet, è necessario avere **tutte** le frasi Mnemonic, oppure solo il numero minimo richiesto per raggiungere la soglia di firma. Tuttavia, in quest'ultimo caso, è essenziale avere anche **gli xpub** dei firmatari mancanti. Il *Descriptor* contiene tutte le xpub del Multisig.
+Il *Descriptor* contiene tutte le xpub del multisig wallet, nonché i percorsi di derivazione utilizzati per generate le chiavi. Ricorda quanto visto nella Parte 1: per ripristinare un multisig wallet, è necessario avere **tutte** le frasi mnemoniche, oppure solo il numero minimo richiesto per raggiungere la soglia di firma. Tuttavia, in quest'ultimo caso, è essenziale avere anche **le xpub** dei firmatari mancanti. Il *Descriptor* contiene tutte le xpub del multisig.
 
 
 
-Se non è chiaro, ricorda solo questo: per recuperare un Multisig, è necessario il numero minimo di frasi Mnemonic per ogni Hardware Wallet utilizzato, a seconda della soglia (nel mio caso: 2 frasi), oltre al *Descriptor*.
+Se non è chiaro, ricorda solo questo: per recuperare un multisig, è necessario il numero minimo di frasi mnemoniche per ogni Hardware wallet utilizzato, a seconda della soglia (nel mio caso: 2 frasi), oltre al *Descriptor*.
 
 
 
-Questo *Descriptor* non contiene chiavi private, ma solo chiavi pubbliche. Ciò significa che non dà accesso ai fondi. Non è quindi critico come le frasi Mnemonic, che danno pieno accesso ai bitcoin. Il rischio del *Descriptor* è legato esclusivamente alla riservatezza: in caso di compromissione, una terza parte potrebbe osservare tutte le tue transazioni, ma non potrebbe spendere i tuoi fondi.
+Questo *Descriptor* non contiene chiavi private, ma solo chiavi pubbliche. Ciò significa che non dà accesso ai fondi. Non è quindi critico come le frasi mnemoniche, che danno pieno accesso ai bitcoin. Il rischio del *Descriptor* è legato esclusivamente alla riservatezza: in caso di compromissione, una terza parte potrebbe osservare tutte le tue transazioni, ma non potrebbe spendere i tuoi fondi.
 
 
 
-Ti consiglio vivamente di creare diverse copie di questo *Descriptor* e di conservarle con ciascun dispositivo di firma del Multisig. Ad esempio, nel mio caso, stampo il *Descriptor* su carta e ne conservo una copia nello stesso luogo dove ripongo il Coldcard, un'altra insieme al Trezor e una insieme al Ledger. Inoltre, salvo questo *Descriptor* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno degli Hardware Wallet. In questo modo, massimizzo le possibilità di non perdere mai questo *Descriptor* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
+Ti consiglio vivamente di creare diverse copie di questo *Descriptor* e di conservarle con ciascun dispositivo di firma del multisig. Ad esempio, nel mio caso, stampo il *Descriptor* su carta e ne conservo una copia nello stesso luogo dove ripongo il Coldcard, un'altra insieme al Trezor e una insieme al Ledger. Inoltre, salvo questo *Descriptor* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno degli Hardware wallet. In questo modo, massimizzo le possibilità di non perdere mai questo *Descriptor* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
 
 
 
-Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *Descriptor*. Fai clic sul pulsante "*SavePDF...*" per salvarlo sia come testo che come codice QR.
+Una volta creato il multisig wallet, Sparrow fornisce automaticamente questo *Descriptor*. Fai clic sul pulsante "*SavePDF...*" per salvarlo sia come testo che come codice QR.
 
 
 
@@ -311,11 +311,10 @@ Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *De
 
 
 
-Registra anche questo *Descriptor* sul Coldcard (se ne usi uno nella tua configurazione). Ciò consentirà al Coldcard di verificare che ogni transazione firmata in seguito corrisponda al Wallet originale: xpub corretto, formato Address corretto, percorso di derivazione corretto... Senza questo *Descriptor* importato, Coldcard non può confermare che gli indirizzi Exchange non siano stati dirottati o che il PSBT (Partially Signed Bitcoin Transaction) non sia stato manomesso.
+Registra anche questo *Descriptor* sul Coldcard (se ne usi uno nella tua configurazione). Ciò consentirà al Coldcard di verificare che ogni transazione firmata in seguito corrisponda al wallet originale: xpub corretto, formato di indirizzo corretto, percorso di derivazione corretto... Se non viene importato il *Descriptor*, Coldcard non può confermare che non sia avvenuta la manomissione degli indirizzi di cambio o della PSBT (Partially Signed Bitcoin Transaction).
 
 
-
-Questo è ciò che rende Coldcard così interessante in un Multisig: offre controlli aggiuntivi contro alcuni attacchi sofisticati, che altri Hardware Wallet non consentono (a condizione, ovviamente, che lo si usi per firmare).
+Questo è ciò che rende Coldcard così interessante nella creazione di un multisig: offre controlli aggiuntivi contro alcuni attacchi sofisticati, che altri Hardware wallet non offrono (a condizione, ovviamente, che lo si usi per firmare).
 
 
 
@@ -327,7 +326,7 @@ In Sparrow, accedi al menu "*Settings*", quindi fai clic su "*Export...*".
 
 
 
-Accanto all'opzione "*Coldcard Multisig*", fai clic su "*Export file...*" e salva il file di testo sulla scheda Micro SD.
+Accanto all'opzione "*Coldcard multisig*", fai clic su "*Export file...*" e salva il file di testo sulla scheda Micro SD.
 
 
 
@@ -335,7 +334,7 @@ Accanto all'opzione "*Coldcard Multisig*", fai clic su "*Export file...*" e salv
 
 
 
-Inserisci quindi la scheda nel Coldcard. Vai al menu "*Settings*", quindi "*Multisig Wallet*" e seleziona "*Import from SD*".
+Inserisci quindi la scheda nel Coldcard. Vai al menu "*Settings*", quindi "*multisig wallet*" e seleziona "*Import from SD*".
 
 
 
@@ -351,7 +350,7 @@ Seleziona il file appropriato e conferma l'importazione.
 
 
 
-Fai clic sul nome del nuovo Multisig importato.
+Fai clic sul nome del nuovo multisig importato.
 
 
 
@@ -359,7 +358,7 @@ Fai clic sul nome del nuovo Multisig importato.
 
 
 
-Controlla i parametri di configurazione del Multisig, quindi conferma la registrazione.
+Controlla i parametri di configurazione del multisig, quindi conferma la registrazione.
 
 
 
@@ -367,17 +366,17 @@ Controlla i parametri di configurazione del Multisig, quindi conferma la registr
 
 
 
-Il Multisig è ora correttamente salvato sul Coldcard. Se disponi di più Coldcard nello stesso Multisig, ripeti questa procedura per ciascuna di esse.
+Il multisig è ora correttamente salvato sul Coldcard. Se disponi di più Coldcard nello stesso multisig, ripeti questa procedura per ciascuna di esse.
 
 
 
-Oltre a salvare il *Descriptor*, non dimenticare di prestare particolare attenzione al salvataggio delle frasi Mnemonic per ciascuno dei tuoi dispositivi di firma. Se sei alle prime armi, ti consiglio di consultare quest'altra guida per imparare a salvarle e gestirle correttamente:
+Oltre a salvare il *Descriptor*, non dimenticare di prestare particolare attenzione al salvataggio delle frasi mnemoniche per ciascuno dei tuoi dispositivi di firma. Se sei alle prime armi, ti consiglio di consultare quest'altra guida per imparare a salvarle e gestirle correttamente:
 
 
 
 https://planb.network/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-Quando ancora non hai ricevuto fondi sul Multisig, **ti consiglio vivamente di eseguire un test di ripristino con il wallet vuoto**. Annota alcune informazioni di riferimento, come il primo indirizzo di ricezione, quindi ripristina gli Hardware Wallet mentre il wallet è ancora vuoto. Successivamente, prova a ripristinare il Multisig Wallet sui portafogli Hardware utilizzando i backup cartacei della frase Mnemonic, mentre su Sparrow fai la stessa cosa utilizzando il *Descriptor*. Verifica che il primo indirizzo di ricezione generato dopo il ripristino corrisponda a quello scritto originariamente. Se così fosse, puoi essere certo che i backup cartacei sono affidabili.
+Quando ancora non hai ricevuto fondi sul multisig, **ti consiglio vivamente di eseguire un test di ripristino con il wallet vuoto**. Annota alcune informazioni di riferimento, come il primo indirizzo di ricezione, quindi ripristina gli Hardware wallet mentre il wallet è ancora vuoto. Successivamente, prova a ripristinare il multisig sugli Hardware wallet utilizzando i backup cartacei della frasi mnemoniche, mentre su Sparrow fai la stessa cosa utilizzando il *Descriptor*. Verifica che il primo indirizzo di ricezione generato dopo il ripristino corrisponda a quello scritto originariamente. Se così fosse, puoi essere certo che i backup cartacei sono affidabili.
 
 
 
@@ -387,11 +386,11 @@ Per saperne di più su come eseguire un test di ripristino, ti suggerisco di con
 
 https://planb.network/tutorials/wallet/backup/recovery-test-5a75db51-a6a1-4338-a02a-164a8d91b895
 
-## Ricevere bitcoin sul tuo Multisig
+## Ricevere bitcoin sul tuo multisig
 
 
 
-Il tuo Wallet è ora pronto a ricevere bitcoin. In Sparrow, fai clic sulla scheda "*Receive*".
+Il tuo wallet è ora pronto a ricevere bitcoin. In Sparrow, fai clic sulla scheda "*Receive*".
 
 
 
@@ -399,11 +398,11 @@ Il tuo Wallet è ora pronto a ricevere bitcoin. In Sparrow, fai clic sulla sched
 
 
 
-Prima di utilizzare l'Address, ovvero l'indirizzo di ricezione, generato da Sparrow Wallet, prenditi del tempo per verificarlo direttamente sullo schermo dei tuoi Hardware Wallet. Questo ti assicurerà che l'Address non è stato alterato e che i tuoi dispositivi possiedono le chiavi private necessarie per spendere i fondi associati. Questo aiuta a proteggerti da una serie di vettori di attacco.
+Prima di utilizzare l'indirizzo di ricezione generato da Sparrow wallet, prenditi del tempo per verificarlo direttamente sullo schermo dei tuoi Hardware wallet. Questo ti assicurerà che l'indirizzo non sia stato alterato e che i tuoi dispositivi possiedano le chiavi private necessarie per spendere i fondi associati. Questo aiuta a proteggerti da una serie di vettori di attacco.
 
 
 
-A tal fine, fai clic su "*Display Address*" per visualizzare l'Address sul Trezor o sul Ledger, se collegato via cavo.
+A tal fine, fai clic su "*Display address*" per visualizzare l'indirizzo sul Trezor o sul Ledger, se collegato via cavo.
 
 
 
@@ -411,7 +410,7 @@ A tal fine, fai clic su "*Display Address*" per visualizzare l'Address sul Trezo
 
 
 
-Con Coldcard, questa verifica può essere effettuata senza alcuna interazione con Sparrow. Semplicemente apri il menu "*Address Explorer*" e seleziona il tuo Multisig in basso.
+Con Coldcard, questa verifica può essere effettuata senza alcuna interazione con Sparrow. Puoi semplicemente aprire il menu "*address Explorer*" e selezionare il tuo multisig in basso.
 
 
 
@@ -419,7 +418,7 @@ Con Coldcard, questa verifica può essere effettuata senza alcuna interazione co
 
 
 
-Vedrai quindi gli indirizzi di ricezione generati dal Multisig.
+Vedrai quindi gli indirizzi di ricezione generati dal multisig.
 
 
 
@@ -427,11 +426,11 @@ Vedrai quindi gli indirizzi di ricezione generati dal Multisig.
 
 
 
-Verifica che l'Address visualizzato su ogni Hardware Wallet corrisponda esattamente a quello del Wallet di Sparrow. Ti consiglio di eseguire questa operazione prima di condividere l'Address con il pagatore, per essere sicuro della sua integrità.
+Verifica che l'indirizzo visualizzato su ogni Hardware wallet corrisponda esattamente a quello del wallet di Sparrow. Ti consiglio di eseguire questa operazione prima di condividere l'indirizzo con il pagatore, per essere sicuro della sua integrità.
 
 
 
-Puoi quindi assegnare una "Etichetta"  a questo Address, per indicare l'origine dei bitcoin ricevuti. Questo è un buon modo per organizzare la gestione dei tuoi UTXO.
+Puoi quindi assegnare una "Etichetta"  a questo indirizzo, per indicare l'origine dei bitcoin ricevuti. Questo è un buon modo per organizzare e gestire i tuoi UTXO.
 
 
 
@@ -439,7 +438,7 @@ Puoi quindi assegnare una "Etichetta"  a questo Address, per indicare l'origine 
 
 
 
-Una volta verificato, puoi utilizzare l'Address per ricevere bitcoin.
+Una volta verificato, puoi utilizzare l'indirizzo per ricevere bitcoin.
 
 
 
@@ -447,11 +446,11 @@ Una volta verificato, puoi utilizzare l'Address per ricevere bitcoin.
 
 
 
-## Inviare bitcoin con il tuo Multisig
+## Inviare bitcoin con il tuo multisig
 
 
 
-Ora che hai ricevuto i primi Sats sul tuo Multisig Wallet, puoi anche spenderli! Su Sparrow, vai alla scheda "*Send*" per creare una nuova transazione.
+Ora che hai ricevuto i primi Sats sul tuo multisig wallet, puoi anche spenderli! Su Sparrow, vai alla scheda "*Send*" per creare una nuova transazione.
 
 
 
@@ -483,7 +482,7 @@ Aggiungi una "*Etichetta*" per descrivere lo scopo di questa transazione, così 
 
 
 
-Inserisci l'importo da inviare all'Address selezionato.
+Inserisci l'importo da inviare all'indirizzo selezionato.
 
 
 
@@ -491,7 +490,7 @@ Inserisci l'importo da inviare all'Address selezionato.
 
 
 
-Regola la quantità di fees in base alle condizioni attuali della rete. Ad esempio, consulta [Mempool.space](https://Mempool.space/) per selezionare una fee adeguata.
+Regola la quantità di fee in base alle condizioni attuali della rete. Ad esempio, consulta [Mempool.space](https://Mempool.space/) per selezionare una fee adeguata.
 
 
 
@@ -511,7 +510,7 @@ Se sei soddisfatto di tutto, fai clic su "*Finalize Transaction for Signing*".
 
 
 
-Nella parte inferiore dello schermo, vedrai che Sparrow è in attesa di 2 firme. Questo è normale: il Wallet usato qui è un Multisig 2-di-3.
+Nella parte inferiore dello schermo, vedrai che Sparrow è in attesa di 2 firme. Questo è normale: il wallet usato qui è un multisig 2-di-3.
 
 
 
@@ -527,7 +526,7 @@ Inizia a firmare con il tuo Coldcard. A tal fine, inserisci una scheda Micro SD 
 
 
 
-Esistono 3 modi per trasmettere la transazione da firmare all'Hardware Wallet e poi recuperarla da Sparrow. Il primo è utilizzare una scheda Micro SD, come vedrai qui con Coldcard. Il secondo è tramite una connessione via cavo, che utilizzerai per la seconda firma (Ledger e Trezor). Infine, puoi utilizzare la comunicazione tramite codice QR, per i dispositivi dotati di fotocamera come Coldcard Q, Jade Plus o Passport V2.
+Esistono 3 modi per trasmettere la transazione da firmare all'Hardware wallet e poi recuperarla da Sparrow. Il primo è utilizzare una scheda Micro SD, come vedrai qui con Coldcard. Il secondo è tramite una connessione via cavo, che utilizzerai per la seconda firma (Ledger e Trezor). Infine, puoi utilizzare la comunicazione tramite codice QR, per i dispositivi dotati di fotocamera come Coldcard Q, Jade Plus o Passport V2.
 
 
 
@@ -539,7 +538,7 @@ Una volta che hai salvato il PSBT (*Partially Signed Bitcoin Transaction*) sulla
 
 
 
-Sullo schermo dell'Hardware Wallet, controlla attentamente i parametri della transazione: l'Address del destinatario, l'importo inviato e le fees. Una volta confermata la transazione, convalida per procedere alla firma.
+Sullo schermo dell'Hardware wallet, controlla attentamente i parametri della transazione: l'indirizzo del destinatario, l'importo inviato e le fee. Una volta confermata la transazione, convalida per procedere alla firma.
 
 
 
@@ -563,7 +562,7 @@ Puoi vedere che la firma Coldcard è stata aggiunta. Devi ora usare un secondo d
 
 
 
-Fai clic su "*Sign*" accanto al nome del proprio Hardware Wallet.
+Fai clic su "*Sign*" accanto al nome del proprio Hardware wallet.
 
 
 
@@ -571,7 +570,7 @@ Fai clic su "*Sign*" accanto al nome del proprio Hardware Wallet.
 
 
 
-La prima volta che usi Ledger con questo Multisig, Sparrow chiederà di verificare le chiavi pubbliche estese (xpub) dei cofirmatari. Come nel caso di Coldcard, questo passaggio impedisce di firmare alla cieca in seguito. Per convalidare queste informazioni, confronta le xpub visualizzate sullo schermo del Ledger con quelle fornite direttamente dagli altri Hardware Wallet.
+La prima volta che usi Ledger con questo multisig, Sparrow chiederà di verificare le chiavi pubbliche estese (xpub) dei cofirmatari. Come nel caso di Coldcard, questo passaggio impedisce di firmare alla cieca in seguito. Per convalidare queste informazioni, confronta le xpub visualizzate sullo schermo del Ledger con quelle fornite direttamente dagli altri Hardware wallet.
 
 
 
@@ -579,7 +578,7 @@ La prima volta che usi Ledger con questo Multisig, Sparrow chiederà di verifica
 
 
 
-Controlla l'Address del destinatario, l'importo trasferito e la fee della transazione, quindi firma la transazione.
+Controlla l'indirizzo del destinatario, l'importo trasferito e la fee della transazione, quindi firma la transazione.
 
 
 
@@ -595,7 +594,7 @@ Tocca sullo schermo per firmare.
 
 
 
-Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portafoglio Multisig. Controlla la transazione un'ultima volta e, se tutto va bene, fai clic su "*Broadcast Transaction*" per trasmetterla in rete.
+Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portafoglio multisig. Controlla la transazione un'ultima volta e, se tutto va bene, fai clic su "*Broadcast Transaction*" per trasmetterla in rete.
 
 
 
@@ -603,7 +602,7 @@ Sparrow dispone ora delle due firme necessarie per rilasciare i fondi dal portaf
 
 
 
-Questa transazione si trova nella scheda "*Transactions*" di Sparrow Wallet.
+Questa transazione si trova nella scheda "*Transactions*" di Sparrow wallet.
 
 
 
@@ -611,11 +610,11 @@ Questa transazione si trova nella scheda "*Transactions*" di Sparrow Wallet.
 
 
 
-Congratulazioni, ora sai come impostare e utilizzare un Wallet a firma multipla su Sparrow. Se hai trovato utile questa guida, ti sarei grato se lasciassi un pollice verde qui sotto. Non esitare a condividere questo articolo sui tuoi social network. Grazie per la condivisione!
+Congratulazioni, ora sai come impostare e utilizzare un wallet a firma multipla su Sparrow. Se hai trovato utile questa guida, ti sarei grato se lasciassi un pollice verde qui sotto. Non esitare a condividere questo articolo sui tuoi social network. Grazie per la condivisione!
 
 
 
-Per andare avanti, ti consiglio di consultare questo tutorial su un altro metodo per aumentare la sicurezza del tuo Bitcoin Wallet, il passphrase BIP39:
+Per andare avanti, ti consiglio di consultare questo tutorial su un altro metodo per aumentare la sicurezza del tuo Bitcoin wallet tramite l'uso della passphrase BIP39:
 
 
 

--- a/tutorials/wallet/sparrow-multisig/it.md
+++ b/tutorials/wallet/sparrow-multisig/it.md
@@ -6,11 +6,11 @@ Description: Creare un wallet multi-firma su Sparrow
 
 
 
-Un wallet multi-firma (spesso chiamato "*Multisig*") è un contratto Bitcoin che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un UTXO, il Multisig si basa su un modello **m-di-n**: delle _n_ chiavi associate al wallet, _m_ devono imperativamente co-firmare ogni transazione.
+Un wallet multi-firma (spesso chiamato "*Multisig*") è un contratto Bitcoin che richiede più firme crittografiche, da chiavi diverse, per autorizzare una spesa. A differenza di un wallet convenzionale ("*singlesig*"), dove una singola chiave privata è sufficiente per sbloccare un [UTXO](https://planb.network/resources/glossary/utxo), il Multisig si basa su un modello **m-di-n**: delle _n_ chiavi associate al wallet, _m_ devono imperativamente co-firmare ogni transazione.
 
 
 
-Questo meccanismo consente di condividere il controllo di un wallet tra più entità o dispositivi. Ad esempio, in una configurazione 2 su 3, vengono generate tre serie di chiavi indipendenti, ma solo due sono necessarie per sbloccare i fondi. Questa architettura riduce drasticamente i rischi associati alla compromissione o alla perdita di una chiave: un ladro che ha accesso a una sola chiave non può svuotare il wallet, e un utente che ne perde una può comunque accedere ai suoi fondi con le altre due.
+Questo meccanismo consente di suddividere il controllo di un wallet tra più entità o dispositivi. Ad esempio, in una configurazione 2 su 3, vengono generate tre serie di chiavi indipendenti, ma solo due sono necessarie per sbloccare i fondi. Questa architettura riduce drasticamente i rischi associati alla compromissione o alla perdita di una chiave: un ladro che ha accesso a una sola chiave non può svuotare il wallet, e un utente che ne perde una può comunque accedere ai suoi fondi con le altre due.
 
 
 
@@ -58,7 +58,7 @@ In questa esercitazione ti mostrerò come creare un Multisig con [Sparrow](https
 
 
 
-https://planb.network/tutorials/wallet/desktop/sparrow-c674e2ac-d46f-4c82-92a7-7d1b0e262f5d)
+https://planb.network/tutorials/wallet/desktop/sparrow-c674e2ac-d46f-4c82-92a7-7d1b0e262f5d
 
 Per configurare un wallet multi-firma, sono necessari diversi hardware wallet. Per un Multisig 2-di-3, ad esempio, si possono utilizzare:
 
@@ -75,7 +75,7 @@ Per configurare un wallet multi-firma, sono necessari diversi hardware wallet. P
 
 
 
-È una buona idea utilizzare diverse marche di Hardware Wallet nella configurazione Multisig. In questo modo si garantisce che se un modello specifico presenta un problema grave, questo non influisce sulla sicurezza complessiva del Multisig. Inoltre, ciò consente di beneficiare dei vantaggi specifici di ciascun dispositivo. Ad esempio, nella mia configurazione:
+È una buona idea utilizzare diverse marche di Hardware Wallet nella configurazione Multisig. In questo modo hai la garanzia che se un modello specifico presenta un problema grave, questo non influisce sulla sicurezza complessiva del Multisig. Inoltre, ciò ti consente di beneficiare dei vantaggi specifici di ciascun dispositivo. Ad esempio, nella mia configurazione:
 
 
 
@@ -139,7 +139,7 @@ Nel menu a discesa "*Policy Type*", seleziona l'opzione "*Multi Signature*".
 
 
 
-Nell'angolo in alto a destra è possibile definire il numero totale di chiavi nel Multisig e il numero di cofirmatari necessari per autorizzare una transazione. Nel mio esempio, si tratta di uno schema 2 di 3.
+Nell'angolo in alto a destra puoi definire il numero totale di chiavi nel Multisig e il numero di cofirmatari necessari per autorizzare una transazione. Nel mio esempio, si tratta di uno schema 2 di 3.
 
 
 
@@ -151,7 +151,7 @@ Nella parte inferiore della finestra, Sparrow visualizza tre "*Keystore*". Ognun
 
 
 
-Inizio con la Coldcard. Nella scheda "*Keystore 1*", scelgo l'opzione "*Airgapped Hardware Wallet*".
+Inizio con il Coldcard. Nella scheda "*Keystore 1*", scelgo l'opzione "*Airgapped Hardware Wallet*".
 
 
 
@@ -291,7 +291,7 @@ Questo *Descriptor* non contiene chiavi private, ma solo chiavi pubbliche. Ciò 
 
 
 
-Consiglio vivamente di creare diverse copie di questo *Descriptor* e di conservarle con ciascun dispositivo di firma del Multisig. Ad esempio, nel mio caso, stampo il *Descriptor* su carta e ne conservo una copia nello stesso luogo dove riponi il Coldcard, un'altra insieme al Trezor e una insieme al Ledger. Inoltre, salvo questo *Descriptor* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno degli Hardware Wallet. In questo modo, massimizzo le possibilità di non perdere mai questo *Descrittore* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
+Ti consiglio vivamente di creare diverse copie di questo *Descriptor* e di conservarle con ciascun dispositivo di firma del Multisig. Ad esempio, nel mio caso, stampo il *Descriptor* su carta e ne conservo una copia nello stesso luogo dove ripongo il Coldcard, un'altra insieme al Trezor e una insieme al Ledger. Inoltre, salvo questo *Descriptor* in formato PDF su tre chiavette USB, ognuna delle quali viene conservata con uno degli Hardware Wallet. In questo modo, massimizzo le possibilità di non perdere mai questo *Descriptor* e sono sicuro di avere due copie (una fisica e una digitale) con ogni dispositivo.
 
 
 
@@ -311,7 +311,7 @@ Una volta creato il Multisig Wallet, Sparrow fornisce automaticamente questo *De
 
 
 
-Registra anche questo *Descriptor* sul Coldcard (se ne usi uno nella tua configurazione). Ciò consentirà al Coldcard di verificare che ogni transazione firmata in seguito corrisponda al Wallet originale: xpub corretto, formato Address corretto, percorso di derivazione corretto... Senza questo *Descriptor* importato, Coldcard non può confermare che gli indirizzi Exchange non siano stati dirottati o che il PSBT non sia stato manomesso.
+Registra anche questo *Descriptor* sul Coldcard (se ne usi uno nella tua configurazione). Ciò consentirà al Coldcard di verificare che ogni transazione firmata in seguito corrisponda al Wallet originale: xpub corretto, formato Address corretto, percorso di derivazione corretto... Senza questo *Descriptor* importato, Coldcard non può confermare che gli indirizzi Exchange non siano stati dirottati o che il PSBT (Partially Signed Bitcoin Transaction) non sia stato manomesso.
 
 
 
@@ -371,7 +371,7 @@ Il Multisig è ora correttamente salvato sul Coldcard. Se disponi di più Coldca
 
 
 
-Oltre a salvare il *Descriptor*, non dimentica di prestare particolare attenzione al salvataggio delle frasi Mnemonic per ciascuno dei tuoi dispositivi di firma. Se sei alle prime armi, ti consiglio di consultare quest'altra guida per imparare a salvarle e gestirle correttamente:
+Oltre a salvare il *Descriptor*, non dimenticare di prestare particolare attenzione al salvataggio delle frasi Mnemonic per ciascuno dei tuoi dispositivi di firma. Se sei alle prime armi, ti consiglio di consultare quest'altra guida per imparare a salvarle e gestirle correttamente:
 
 
 


### PR DESCRIPTION
Come sul Tutorial Sparrow, ho inserito le voci dei menù che fanno riferimento a Sparrow e Coldcard in inglese. In questo modo sono coerenti con le immagini.

Ho corretto molti errori del tipo "il Adress" con "l'Adress".

Più tanti altri refusi di traduzione.

La riga 278 è poco comprensibile ma non saprei come scriverla meglio: "Ora salveremo il nostro *Descrittore script di uscita* sul Coldcard"

Close #2200