### PR TITLE
Fix contributor_names yaml key

### DIFF
--- a/tutorials/exchange/flash/tutorial.yml
+++ b/tutorials/exchange/flash/tutorial.yml
@@ -15,6 +15,7 @@ proofreading:
   - language: fr
     last_contribution_date: 2025-05-03
     urgency: 1
-    contributors_names:
+    contributor_names:
       - heyolaniran
     reward: 0
+

--- a/tutorials/node/lightning-network-daemon-linux/tutorial.yml
+++ b/tutorials/node/lightning-network-daemon-linux/tutorial.yml
@@ -15,7 +15,7 @@ proofreading:
   - language: fr
     last_contribution_date: 2025-04-26
     urgency: 1
-    contributors_names:
+    contributor_names:
       - heyolaniran
     reward: 0
   - language: cs
@@ -113,3 +113,4 @@ proofreading:
     urgency: 1
     contributor_names:
     reward: 6.53
+

--- a/tutorials/privacy/mempool-space/tutorial.yml
+++ b/tutorials/privacy/mempool-space/tutorial.yml
@@ -16,6 +16,7 @@ proofreading:
   - language: fr
     last_contribution_date: 2025-05-06
     urgency: 1
-    contributors_names:
+    contributor_names:
       - heyolaniran
     reward: 0
+

--- a/tutorials/wallet/breez/tutorial.yml
+++ b/tutorials/wallet/breez/tutorial.yml
@@ -15,7 +15,7 @@ proofreading:
   - language: fr
     last_contribution_date: 2025-04-29
     urgency: 1
-    contributors_names:
+    contributor_names:
       - heyolaniran
     reward: 0
   - language: cs
@@ -113,3 +113,4 @@ proofreading:
     urgency: 1
     contributor_names:
     reward: 3.69
+

--- a/tutorials/wallet/misty-breez/tutorial.yml
+++ b/tutorials/wallet/misty-breez/tutorial.yml
@@ -15,7 +15,7 @@ proofreading:
   - language: fr
     last_contribution_date: 2025-05-02
     urgency: 1
-    contributors_names:
+    contributor_names:
       - heyolaniran
     reward: 0
   - language: cs
@@ -113,3 +113,4 @@ proofreading:
     urgency: 1
     contributor_names:
     reward: 3.23
+


### PR DESCRIPTION
There was an extra "s" in the yaml key `contributor_names` in 5 tutorials