### PR TITLE
[TUTORIAL] Fix Bittr title

### DIFF
--- a/tutorials/exchange/bittr/cs.md
+++ b/tutorials/exchange/bittr/cs.md
@@ -1,6 +1,6 @@
 ---
-name: Jak si koupit Bitcoin do vlastního Wallet pomocí Bittr
-description: Jednoduchý průvodce krok za krokem pro nákupy Bitcoin ve vlastní péči
+name: Bittr
+description: Jak si koupit Bitcoin do vlastního Wallet pomocí Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/de.md
+++ b/tutorials/exchange/bittr/de.md
@@ -1,6 +1,6 @@
 ---
-name: Wie Sie mit Bittr Bitcoin in Ihr eigenes Wallet umwandeln
-description: Eine einfache Schritt-für-Schritt-Anleitung für Bitcoin-Käufe in Eigenregie
+name: Bittr
+description: Wie Sie mit Bittr Bitcoin in Ihr eigenes Wallet umwandeln
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/en.md
+++ b/tutorials/exchange/bittr/en.md
@@ -1,6 +1,6 @@
 ---
-name: How to buy Bitcoin into your own Wallet with Bittr
-description: A simple step-by-step guide for self custody Bitcoin purchases
+name: Bittr
+description: How to buy Bitcoin into your own Wallet with Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/es.md
+++ b/tutorials/exchange/bittr/es.md
@@ -1,6 +1,6 @@
 ---
-name: Cómo convertir Bitcoin en tu propia Wallet con Bittr
-description: Una sencilla guía paso a paso para las compras de Bitcoin en régimen de autocustodia
+name: Bittr
+description: Cómo convertir Bitcoin en tu propia Wallet con Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/et.md
+++ b/tutorials/exchange/bittr/et.md
@@ -1,6 +1,6 @@
 ---
-name: Kuidas osta Bitcoin oma Wallet-ks koos Bittriga
-description: Lihtne samm-sammuline juhend Bitcoin ostude eestkostmiseks iseenda eestkostel
+name: Bittr
+description: Kuidas osta Bitcoin oma Wallet-ks koos Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/fa.md
+++ b/tutorials/exchange/bittr/fa.md
@@ -1,6 +1,6 @@
 ---
-name: نحوه خرید Bitcoin به Wallet خودتان با Bittr
-description: راهنمای ساده گام به گام برای خریدهای Bitcoin با نگهداری شخصی
+name: Bittr
+description: نحوه خرید Bitcoin به Wallet خودتان با Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/fi.md
+++ b/tutorials/exchange/bittr/fi.md
@@ -1,12 +1,12 @@
 ---
-name: Kuinka ostaa Bitcoin omaksi Wallet:ksi Bittrin avulla?
-description: Yksinkertainen vaiheittainen opas Bitcoin:n omahuoltajuushankintoja varten
+name: Bittr
+description: Kuinka ostaa Bitcoin omaksi Wallet:ksi Bittr avulla?
 ---
 
 ![cover](assets/cover.webp)
 
 
-### Johdanto Bittriin
+### Johdanto Bittr
 
 
 Bittr on suoraviivainen työkalu kaikille, jotka haluavat kasvattaa säästöjään Bitcoin:ssa - ilman monimutkaista sovellusta, henkilöllisyystarkastuksia tai kolmannen osapuolen säilytystä. Se on suunniteltu ihmisille, jotka haluavat yksinkertaisuutta, yksityisyyttä ja täydellistä rahojensa hallintaa.

--- a/tutorials/exchange/bittr/fr.md
+++ b/tutorials/exchange/bittr/fr.md
@@ -1,6 +1,6 @@
 ---
-name: Comment acheter un Bitcoin pour en faire un Wallet avec Bittr ?
-description: Un guide simple, étape par étape, pour l'achat d'une Bitcoin en autodétention
+name: Bittr
+description: Comment acheter du bitcoin directement dans votre wallet avec Bittr ?
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/hi.md
+++ b/tutorials/exchange/bittr/hi.md
@@ -1,6 +1,6 @@
 ---
-name: बिटर के साथ अपने Wallet में Bitcoin कैसे खरीदें
-description: स्व-संरक्षित Bitcoin खरीद के लिए एक सरल चरण-दर-चरण मार्गदर्शिका
+name: Bittr
+description: बिटर के साथ अपने Wallet में Bitcoin कैसे खरीदें
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/id.md
+++ b/tutorials/exchange/bittr/id.md
@@ -1,6 +1,6 @@
 ---
-name: Cara membeli Bitcoin menjadi Wallet Anda sendiri dengan Bittr
-description: Panduan langkah demi langkah sederhana untuk pembelian Bitcoin dengan penitipan mandiri
+name: Bittr
+description: Cara membeli Bitcoin menjadi Wallet Anda sendiri dengan Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/it.md
+++ b/tutorials/exchange/bittr/it.md
@@ -1,6 +1,6 @@
 ---
-name: Come acquistare il Bitcoin per trasformarlo nel proprio Wallet con Bittr
-description: Una semplice guida passo-passo per l'acquisto di Bitcoin in autocustodia
+name: Bittr
+description: Come acquistare il Bitcoin per trasformarlo nel proprio Wallet con Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/ja.md
+++ b/tutorials/exchange/bittr/ja.md
@@ -1,6 +1,6 @@
 ---
-name: BittrでBitcoinを自分のWalletに買い換える方法
-description: Bitcoin購入のための簡単なステップ・バイ・ステップ・ガイド
+name: Bittr
+description: BittrでBitcoinを自分のWalletに買い換える方法
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/nb-NO.md
+++ b/tutorials/exchange/bittr/nb-NO.md
@@ -1,6 +1,6 @@
 ---
-name: Slik kjøper du Bitcoin til din egen Wallet med Bittr
-description: En enkel trinn-for-trinn-veiledning for kjøp av Bitcoin i egen forvaring
+name: Bittr
+description: Slik kjøper du Bitcoin til din egen Wallet med Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/nl.md
+++ b/tutorials/exchange/bittr/nl.md
@@ -1,6 +1,6 @@
 ---
-name: Hoe Bitcoin kopen in je eigen Wallet met Bittr
-description: Een eenvoudige stap-voor-stap handleiding voor het zelf in bewaring nemen van Bitcoin aankopen
+name: Bittr
+description: Hoe Bitcoin kopen in je eigen Wallet met Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/pl.md
+++ b/tutorials/exchange/bittr/pl.md
@@ -1,6 +1,6 @@
 ---
-name: Jak kupić Bitcoin do własnego Wallet za pomocą Bittr
-description: Prosty przewodnik krok po kroku dotyczący samodzielnego zakupu Bitcoin
+name: Bittr
+description: Jak kupić Bitcoin do własnego Wallet za pomocą Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/pt.md
+++ b/tutorials/exchange/bittr/pt.md
@@ -1,6 +1,6 @@
 ---
-name: Como comprar Bitcoin para o seu próprio Wallet com Bittr
-description: Um guia simples passo-a-passo para a compra de Bitcoin em regime de guarda pessoal
+name: Bittr
+description: Como comprar Bitcoin para o seu próprio Wallet com Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/ru.md
+++ b/tutorials/exchange/bittr/ru.md
@@ -1,6 +1,6 @@
 ---
-name: Как купить Bitcoin в свой собственный Wallet с помощью Bittr
-description: Простое пошаговое руководство по самостоятельному приобретению Bitcoin
+name: Bittr
+description: Как купить Bitcoin в свой собственный Wallet с помощью Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/sr-Latn.md
+++ b/tutorials/exchange/bittr/sr-Latn.md
@@ -1,6 +1,6 @@
 ---
-name: Kako kupiti Bitcoin u svoj Wallet sa Bittr
-description: Jednostavan vodič korak po korak za samostalno čuvanje Bitcoin kupovina
+name: Bittr
+description: Kako kupiti Bitcoin u svoj Wallet sa Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/sv.md
+++ b/tutorials/exchange/bittr/sv.md
@@ -1,6 +1,6 @@
 ---
-name: Hur man köper Bitcoin till din egen Wallet med Bittr
-description: En enkel steg-för-steg-guide för Bitcoin-köp med egen vårdnad
+name: Bittr
+description: Hur man köper Bitcoin till din egen Wallet med Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/sw.md
+++ b/tutorials/exchange/bittr/sw.md
@@ -1,6 +1,6 @@
 ---
-name: Jinsi ya kununua Bitcoin kwenye Wallet yako mwenyewe na Bittr
-description: Mwongozo rahisi wa hatua kwa hatua wa ununuzi wa Bitcoin wa kujilinda
+name: Bittr
+description: Jinsi ya kununua Bitcoin kwenye Wallet yako mwenyewe na Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/vi.md
+++ b/tutorials/exchange/bittr/vi.md
@@ -1,6 +1,6 @@
 ---
-name: Cách mua Bitcoin vào Wallet của riêng bạn bằng Bittr
-description: Hướng dẫn từng bước đơn giản để tự mua Bitcoin
+name: Bittr
+description: Cách mua Bitcoin vào Wallet của riêng bạn bằng Bittr
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/zh-Hans.md
+++ b/tutorials/exchange/bittr/zh-Hans.md
@@ -1,6 +1,6 @@
 ---
-name: 如何使用 Bittr 将 Bitcoin 购买成自己的 Wallet
-description: 自我监护 Bitcoin 购买的简单分步指南
+name: Bittr
+description: 如何使用 Bittr 将 Bitcoin 购买成自己的 Wallet
 ---
 
 ![cover](assets/cover.webp)

--- a/tutorials/exchange/bittr/zh-Hant.md
+++ b/tutorials/exchange/bittr/zh-Hant.md
@@ -1,6 +1,6 @@
 ---
-name: 如何使用 Bittr 將 Bitcoin 購買成自己的 Wallet
-description: 自行保管 Bitcoin 購買的簡易步驟指南
+name: Bittr
+description: 如何使用 Bittr 將 Bitcoin 購買成自己的 Wallet
 ---
 
 ![cover](assets/cover.webp)


### PR DESCRIPTION
The tutorial title was too long (it was a description), whereas we usually only put the tool name as the title. Corrected in all languages.

Tuto issue #2707 