### PR TITLE
[DOCS] Add hardware-wallet-ready tag

### DIFF
--- a/docs/50-planb-tags.md
+++ b/docs/50-planb-tags.md
@@ -4,50 +4,51 @@
  2. software: regarding programs, services you use after being installed on servers, PCs and smartphones
  3. mining: all topics related to BTC mining
  4. fees: aspects referring to every cost when it comes to send BTC value (in any way)
- 5. hardware: every hardware-related topic
- 6. wallets: every tool allowing to manage or spend bitcoin
- 7. investment: bitcoin is an investment, but in which way it's up to the topic of the content
- 8. keys: every topic regarding storage of the secrets to spend bitcoin
- 9. market-trends: the market rules everything, and we may indentify some trends
-10. finance: addresses all aspects regarding how money and financial system work
-11. onchain: aspects referring to Bitcoin blockchain only
-12. offchain: every aspect referring to Bitcoin, with the exclusion of the blockchain
-13. lightning: everything that is about Lightining Network
-14. decentralization: aspects referring to one of Bitcoin's most important feature
-15. smart-contracts: regarding a self-executing contract with the terms of the agreement directly written into code
-16. DIY: do it yourself, stands for every hardware porject you can build on your own, with some raw material
-17. node: every software agent that validates and relays information, contributing to the functionality of that specific network
-18. backup: explore ways how to improve redundacy of secret keys storage
-19. guides: step-to-step explanation to do something
-20. use-case: openly and directly addressing specific use cases for something
-21. user-friendly: when a topic shows content with the goal of being easily understandable by beginner and intermediate bitcoiners
-22. historical: content telling about historical bitcoin facts and data. It may also be intended for both general and economic history when dealing with Bitcoin's origin
-23. scalability: topics regarding difficulty to scale one of bitcoin-related networks
-24. protocols: whenever topics regard separate sets of rules, where each one governs how participants interact and maintain consensus
-25. layers: different protocols can lay on different levels between each other and versus Bitcoin mainnet
-26. sidechains: it is about independent blockchains that run parallel and bound to the Bitcoin main chain
-27. personal-security: topics referring to security aspects with focus on threats suitable for physical people
-28. network-security: topics with the focus to security aspects of the network
-29. privacy: main focus here would be to preserve end-user sensitive information that can lead to personal identification
-30. regulation: sometimes talking about laws, compliance, regulation in general is important
-31. risks: highlight potential danger of bitcoin custody and usage
-32. future-outlook: information and hypothesis regarding future happening (and problems) that the network could face
-33. adoption: topics regarding using bitcoin for everyday purchases, its roles such medium-of-exchange and store of value
-34. case-studies: content presented in a way of an "Harvard business case study"
-35. good-practice: suggest specific actions when it comes to do something, and explain why
-36. innovation: it is about new features over the Bitcoin protocol
-37. cypherpunk: refers to content promoting, explaining and applicating any cypherpunk value
-38. self-sovereignty: different from cypherpunk, it links content that are still focused on the individual without requiring him/her to be a cryptographic/tech expert. This concept's boundary is laying more on a day-to-day physical level.
-39. DIY-IT: do it yourself, stands for every software project you can develop on your own, with some examples and guidance from a reliable source
-40. consensus: topics referring to security of the network facing incentive mechanisms that bring order over chaos
-41. development: discussion on potential features that may be useful, really experienced users may invest energy into this topic
-42. interoperability: topics facing the possibility of mutual interation between parts of network
-43. technical-analysis: aspects analyzed from perspective of their technical feasibility
-44. update: tracks the presence of updates on tutos and courses over time
-45. legacy: meta-tag that identifies old procedures and resources not available anymore
-46. deep-dive: the selected tag explains something deep, regardless of its actual bitcoin-grade content
-47. high-level: opposite of deep-dive
-48. easy-explain: describe if a content needs simplified writing style
-49. experimental: meta-tag that addresses features, ideas, concepts that are still not available for immediate use, but that will be better known in the next future
-50. business: about companies and startup in the Bitcoin ecosystem
-51. evaluation: the content, whatever it would be, is about assessing the skills and abilities of its users
+ 5. hardware: every hardware-related topic, mutually exclusive with the hardware-wallet-ready tag
+ 6. hardware-wallet-ready: content compatible with hardware wallets, mutually exclusive with the hardware tag
+ 7. wallets: every tool allowing to manage or spend bitcoin
+ 8. investment: bitcoin is an investment, but in which way it's up to the topic of the content
+ 9. keys: every topic regarding storage of the secrets to spend bitcoin
+ 10. market-trends: the market rules everything, and we may indentify some trends
+11. finance: addresses all aspects regarding how money and financial system work
+12. onchain: aspects referring to Bitcoin blockchain only
+13. offchain: every aspect referring to Bitcoin, with the exclusion of the blockchain
+14. lightning: everything that is about Lightining Network
+15. decentralization: aspects referring to one of Bitcoin's most important feature
+16. smart-contracts: regarding a self-executing contract with the terms of the agreement directly written into code
+17. DIY: do it yourself, stands for every hardware porject you can build on your own, with some raw material
+18. node: every software agent that validates and relays information, contributing to the functionality of that specific network
+19. backup: explore ways how to improve redundacy of secret keys storage
+20. guides: step-to-step explanation to do something
+21. use-case: openly and directly addressing specific use cases for something
+22. user-friendly: when a topic shows content with the goal of being easily understandable by beginner and intermediate bitcoiners
+23. historical: content telling about historical bitcoin facts and data. It may also be intended for both general and economic history when dealing with Bitcoin's origin
+24. scalability: topics regarding difficulty to scale one of bitcoin-related networks
+25. protocols: whenever topics regard separate sets of rules, where each one governs how participants interact and maintain consensus
+26. layers: different protocols can lay on different levels between each other and versus Bitcoin mainnet
+27. sidechains: it is about independent blockchains that run parallel and bound to the Bitcoin main chain
+28. personal-security: topics referring to security aspects with focus on threats suitable for physical people
+29. network-security: topics with the focus to security aspects of the network
+30. privacy: main focus here would be to preserve end-user sensitive information that can lead to personal identification
+31. regulation: sometimes talking about laws, compliance, regulation in general is important
+32. risks: highlight potential danger of bitcoin custody and usage
+33. future-outlook: information and hypothesis regarding future happening (and problems) that the network could face
+34. adoption: topics regarding using bitcoin for everyday purchases, its roles such medium-of-exchange and store of value
+35. case-studies: content presented in a way of an "Harvard business case study"
+36. good-practice: suggest specific actions when it comes to do something, and explain why
+37. innovation: it is about new features over the Bitcoin protocol
+38. cypherpunk: refers to content promoting, explaining and applicating any cypherpunk value
+39. self-sovereignty: different from cypherpunk, it links content that are still focused on the individual without requiring him/her to be a cryptographic/tech expert. This concept's boundary is laying more on a day-to-day physical level.
+40. DIY-IT: do it yourself, stands for every software project you can develop on your own, with some examples and guidance from a reliable source
+41. consensus: topics referring to security of the network facing incentive mechanisms that bring order over chaos
+42. development: discussion on potential features that may be useful, really experienced users may invest energy into this topic
+43. interoperability: topics facing the possibility of mutual interation between parts of network
+44. technical-analysis: aspects analyzed from perspective of their technical feasibility
+45. update: tracks the presence of updates on tutos and courses over time
+46. legacy: meta-tag that identifies old procedures and resources not available anymore
+47. deep-dive: the selected tag explains something deep, regardless of its actual bitcoin-grade content
+48. high-level: opposite of deep-dive
+49. easy-explain: describe if a content needs simplified writing style
+50. experimental: meta-tag that addresses features, ideas, concepts that are still not available for immediate use, but that will be better known in the next future
+51. business: about companies and startup in the Bitcoin ecosystem
+52. evaluation: the content, whatever it would be, is about assessing the skills and abilities of its users


### PR DESCRIPTION
after this merge, I'll try this new tag on one desktop and one mobile wallet tutorials. if it's going to be too big, we'll find another naming. second best option for such tag name: `hardware-wallet-ok`