### PR TITLE
[SCRIPT] Fix translation script issues

### DIFF
--- a/resources/glossary/addrdat/rn.md
+++ b/resources/glossary/addrdat/rn.md
@@ -1,5 +1,5 @@
 ---
-term: ADDR.DAT.
+term: ADDR.DAT
 
 ---
 

--- a/resources/glossary/ancestor-mining/rn.md
+++ b/resources/glossary/ancestor-mining/rn.md
@@ -1,5 +1,5 @@
 ---
-term: UMUSOGOKURU Mining.
+term: UMUSOGOKURU Mining
 ---
 
 Irindi zina rimwe na rimwe rikoreshwa kuri CPFP (*Umwana-Ariha-Umuvyeyi*). Ancestor Mining ni ingingo ngenderwako aho Miner idahitamwo igikorwa ishingiye gusa ku mafaranga y’ibikorwa vyayo, ariko kandi ikazirikana amafaranga y’ibikorwa vy’umuvyeyi.

--- a/resources/glossary/anchorsdat/rn.md
+++ b/resources/glossary/anchorsdat/rn.md
@@ -1,5 +1,5 @@
 ---
-term: ANCHORS.DAT.
+term: ANCHORS.DAT
 
 ---
 

--- a/resources/glossary/assume-utxo/rn.md
+++ b/resources/glossary/assume-utxo/rn.md
@@ -1,5 +1,5 @@
 ---
-term: Twiyumvire ko UTXO.
+term: Twiyumvire ko UTXO
 ---
 
 Igiharuro c’imiterere mu mukiriya wa Bitcoin core kiremerera urudodo rushasha rwatangujwe (urutarakora Initial Block Download, canke IBD) gusubiramwo igenzura ry’ibikorwa n’itegeko rya UTXO imbere y’ifoto yatanzwe. Iciyumviro gishingiye ku gukoresha umugwi wa UTXO (urutonde rw’ama UTXO yose ariho mu gihe kinaka) yatanzwe na Core kandi yiyumviriwe ko ari ukuri Ivyo bituma urudodo rushobora gukorana ningoga n’uruzitiro rufise igikorwa cirundanijwe cane.

--- a/resources/glossary/blind-merged-mining/rn.md
+++ b/resources/glossary/blind-merged-mining/rn.md
@@ -1,5 +1,5 @@
 ---
-term: IMPUMYI YIFANJE Mining.
+term: IMPUMYI YIFANJE Mining
 ---
 
 Uburyo bwo kwumvikana ku bijanye n’imirongo y’inyuma butuma abacukuzi ba Bitcoin bakora icarimwe ku mirongo nyamukuru no ku mirongo imwe canke myinshi, ata bikorwa vy’ubuhinga vy’inyongera bakora. Udakunze Mining ya kera, ntibisaba abacukuzi gukoresha urudodo kuri Sidechain yose.

--- a/resources/glossary/chaumian-coinjoin/rn.md
+++ b/resources/glossary/chaumian-coinjoin/rn.md
@@ -1,5 +1,5 @@
 ---
-term: UMUGAMBI CoinJoin.
+term: UMUGAMBI CoinJoin
 ---
 
 Itegeko rya CoinJoin rikoresha imikono y’impumyi ya David Chaum na Tor ku bijanye n’uguhanahana amakuru hagati y’abaje mu nama n’umuhuzabikorwa. Intumbero ya Chaumian CoinJoin ni ugutuma abaje mu nama bamenya neza ko umuhuzabikorwa adashobora kwiba ama bitcoins, canke ngo ahuze ivyo yinjiza n’ivyo asohoka.

--- a/resources/glossary/cold-wallet/rn.md
+++ b/resources/glossary/cold-wallet/rn.md
@@ -1,5 +1,5 @@
 ---
-term: Cold Wallet.
+term: Cold Wallet
 ---
 
 Ibisobanuro bimwe na "Hardware Wallet." Hardware Wallet, canke Wallet y’umubiri, ni igikoresho c’ubuhinga bwa none gikoreshwa mu gucungera no gucunga imfunguruzo z’ibanga za Bitcoin Wallet. Ivyo bikoresho vyakozwe kugira ngo bihe umutekano mwiza ugereranije n’ibikoresho vy’amaporogarama biba ku mashini zitandukanye zihuye ata guca ku ruhande na interineti. Ivyuma vy’amafaranga bibika ijambo Mnemonic ritari mu murongo, ku gikoresho gifise ahantu hatoyi cane ho gutera, ivyo bikaba biyitandukanya n’ibidukikije bishobora gutera ingorane. Iyo umuntu akoresheje igikorwa, Hardware Wallet irashira umukono kuri ico gicuruzwa mu gikoresho ubwaco, ata rufunguzo rw’ibanga rugaragajwe hanze. Iyo iyo nzira imaze gusinywa, irarungikwa ku rubuga rwa Bitcoin kugira ngo yemezwe kandi ishirwe muri Blockchain. Mu bikoresho bikundwa cane vy’amasakoshi y’ibikoresho vy’ubuhinga bwa none harimwo: Ledger, Trezor, Coldcard, Pasiporo, BitBox, Satochip, Jade, na SeedSigner (uru rutonde ntiruheza).

--- a/resources/glossary/contrat-rgb/rn.md
+++ b/resources/glossary/contrat-rgb/rn.md
@@ -1,5 +1,5 @@
 ---
-term: Contract RGB.
+term: Contract RGB
 ---
 
 Yerekeza ku burenganzira bushirwa mu ngiro mu buryo bwa digitale hagati y’abakozi benshi biciye ku masezerano ya RGB. Ifise igihugu gikora na Business Logic, isobanurwa na Schema, igaragaza ibikorwa vyemewe (uguhindura, kwongera, n’ibindi). Amategeko agenga ivy'ubuzima n'uburenganzira bwa Contract agaragazwa muri Schema. Igihe cose, Contract iratera imbere gusa bivanye n’ivyo yemerewe n’iyi Schema be n’inyandiko zo kwemeza (run, nk’akarorero, muri AluVM).

--- a/resources/glossary/extra-nonce/rn.md
+++ b/resources/glossary/extra-nonce/rn.md
@@ -1,5 +1,5 @@
 ---
-term: IVYO KWONGERAKO-Nonce.
+term: IVYO KWONGERAKO-Nonce
 ---
 
 Igikoresho gikoreshwa muri `scriptSig` ya Coinbase Transaction y'ibarabara, kigatuma habaho ubushobozi bwinshi bwo kugerageza kugira ngo hagire Hash iri hasi y'intumbero y'ingorane, ushizwmwo Nonce ya kera, iboneka ataco ihinduye mu mutwe w'ibarabara rimwe rimwe.

--- a/resources/glossary/fibre/it.md
+++ b/resources/glossary/fibre/it.md
@@ -1,5 +1,5 @@
 ---
-term: FIBRA
+term: FIBRE
 
 ---
 Acronimo di "*Fast Internet Bitcoin Relay Engine*". È un protocollo progettato da Matt Corallo nel 2016 per accelerare la distribuzione dei blocchi di Bitcoin in tutto il mondo. Il suo obiettivo era quello di ridurre i ritardi di propagazione il più vicino possibile ai limiti fisici. FIBRE mirava a garantire una distribuzione più equa delle opportunità di mining, facendo in modo che la percentuale di blocchi minati da un partecipante riflettesse accuratamente il suo contributo in termini di potenza di calcolo, indipendentemente dalla sua posizione nella rete.

--- a/resources/glossary/green-address/rn.md
+++ b/resources/glossary/green-address/rn.md
@@ -1,5 +1,5 @@
 ---
-term: Green Address.
+term: Green Address
 ---
 
 Uwahoze ari porogaramu ya Bitcoin Wallet yaronswe muri Nyakanga 2016 na Blockstream kugira ngo ikore porogaramu y’ubu, Green Wallet.

--- a/resources/glossary/green-wallet/rn.md
+++ b/resources/glossary/green-wallet/rn.md
@@ -1,5 +1,5 @@
 ---
-term: Green Wallet.
+term: Green Wallet
 ---
 
 Porogaramu ya Bitcoin Wallet iboneka kuri PC, Android, na iOS yakozwe na Blockstream inyuma y’aho igurishije porogaramu ya Green Address mu 2016. Irimwo ibintu vyinshi nk’uburinzi bw’imikono myinshi n’ukwemeza ko umuntu ari uwundi. Ihuye kandi n’ibikoresho vyinshi vy’amasakoshi. Iyi ni porogaramu ishobora gukoreshwa n’abatangura.

--- a/resources/glossary/invoice-rgb/rn.md
+++ b/resources/glossary/invoice-rgb/rn.md
@@ -1,5 +1,5 @@
 ---
-term: Invoice RGB.
+term: Invoice RGB
 ---
 
 Mu masezerano ya RGB, Invoice ifata uburyo bwa URL ikozwe muri base58, ishiramwo amakuru asabwa n'uwutanga kugira ngo yubake State Transition. Mu bikorwa, iyi ni Invoice ishoboza uwufatanya na generate guhindura bikwiye kugira ngo yimure umutungo canke guhindura ikibanza ca Contract.

--- a/resources/glossary/magical-bitcoin/rn.md
+++ b/resources/glossary/magical-bitcoin/rn.md
@@ -1,5 +1,5 @@
 ---
-term: IVY'AMAJAMBO Bitcoin.
+term: IVY'AMAJAMBO Bitcoin
 ---
 
 Izina rya kera ry'ibikoresho n'amasomero y'abahinguzi BDK.

--- a/resources/glossary/master-chain-code/rn.md
+++ b/resources/glossary/master-chain-code/rn.md
@@ -1,5 +1,5 @@
 ---
-term: UMUHEBUZI chain code.
+term: UMUHEBUZI chain code
 ---
 
 Yerekeza kuri chain code ifatanye n’urufunguzo nyamukuru rwa Wallet, ikaba ari yo shingiro ry’igiti c’inkomoko y’urufunguzo rwose.

--- a/resources/glossary/merged-mining/rn.md
+++ b/resources/glossary/merged-mining/rn.md
@@ -1,5 +1,5 @@
 ---
-term: BIHUZWE Mining.
+term: BIHUZWE Mining
 ---
 
 Uburyo bwo kwumvikana ku bijanye n’imirongo y’inyuma butuma abacukuzi ba Bitcoin bakora icarimwe ku mirongo nyamukuru no ku mirongo imwe canke myinshi, ataco bakeneye gutanga c’inyongera ku bikorwa vy’ibarabara. Ivyo birimwo gusubira gukoresha Proof of Work ya Bitcoin ku bikorwa vy’abandi. Ariko rero, Mining ihuriweko irafise akaga gakomeye kuri Miner: isaba gushiramwo no gukoresha porogarama yihariye y’ibihimba vy’umubiri kuri Sidechain yose kugira ngo ishobore gusubira gukoresha Proof of Work yayo. Ikindi kandi, impembo ya Mining a Sidechain irihwa kuri iyo Sidechain atari mu buryo butaziguye muri BTC kuri Blockchain nyamukuru.

--- a/resources/glossary/nakamoto-satoshi/rn.md
+++ b/resources/glossary/nakamoto-satoshi/rn.md
@@ -1,5 +1,5 @@
 ---
-term: NAKAMOTO Satoshi.
+term: NAKAMOTO Satoshi
 ---
 
 Izina ry’uruyeri ry’umuntu canke umugwi waremye Bitcoin ukandika igitabu caco cera c’intango mu 2008 (Igitabu cera). Nakamoto, yavugana n’abandi kuri Internet gusa, amaherezo yarazimiye mu 2011.

--- a/resources/glossary/natural-fork/rn.md
+++ b/resources/glossary/natural-fork/rn.md
@@ -1,5 +1,5 @@
 ---
-term: Fork Y'IBIMENYETSO.
+term: Fork Y'IBIMENYETSO
 ---
 
 Ugutandukanya kw’igihe gito kwa Blockchain kwavuye mu gutangaza hafi icarimwe amabuye menshi n’abacukuzi batandukanye bari ku burebure bumwe. Ivyo bishika iyo amabuye abiri, yitwa $A$ na $B$, abonetse hafi igihe kimwe, bikaba bituma urubuga rugabanywa mu gihe gito. Kubera ko urudodo rumwe rumwe rubona ko igice ca mbere rwaronse ari co gifise akamaro, ariko si bose babanza kwakira igice kimwe, igice c’urudodo gikurikira uruzitiro rurimwo igice $A$, mu gihe ikindi gice gikurikira ico gifise igice $B$. Iyi Fork itorerwa umuti iyo imwe muri izo nzira zibiri zihiganwa irengeye iyindi mu bijanye n’ibikorwa vyirundanijwe. Iciyo gihe, utugingo ngengabuzima twose turi muri iyo nzira tuca twemeranya ku ruhererekane rurerure (rufise igikorwa cirundanirijwe cane), ivyo bikaba ari ibintu bizwi kw’izina ry’ugusubira gutunganya canke gusubira gukorana. Ivyo bice vy'umubiri ni vyo bimenyerewe mu bikorwa vya Bitcoin. Birasanzwe kandi birahera ubwavyo inyuma y’ibice bikeyi (kenshi na kenshi ni kimwe gusa). Ariko rero, iyo zishitse kenshi cane, izo nkoko zirashobora kuba zigitera ingorane, kuko zituma ububasha bwo gukoresha ubuhinga bwo guharura butakazwa kw’ishami rizoheza rikabura ico rikora.

--- a/resources/glossary/nested-segwit/rn.md
+++ b/resources/glossary/nested-segwit/rn.md
@@ -1,5 +1,5 @@
 ---
-term: IVYASHITSIWE SegWit.
+term: IVYASHITSIWE SegWit
 ---
 
 Inyandiko ikoreshwa mu gupfuka inyandiko za SegWit mu nyandiko ya P2SH. Ivyanditswe vya Nested SegWit vyavumbuwe igihe SegWit yatanguzwa kugira ngo bishobore gukoreshwa neza. Biremeza gukoresha iyo ngingo nshasha, mbere n'ibikorwa canke amasakoshi atarahuye na SegWit. Ikora nk’ubwoko bw’inyandiko y’uguhinduka yerekeza ku rugero rushasha. Ubu rero, ntibigikenewe cane gukoresha ubwo bwoko bw'inyandiko za SegWit zizingiwe, kuko ama wallet menshi yashize mu ngiro SegWit y'akavukire.

--- a/resources/glossary/p2p-transport-v2/rn.md
+++ b/resources/glossary/p2p-transport-v2/rn.md
@@ -1,5 +1,5 @@
 ---
-term: P2P IVYITWARA V2.
+term: P2P IVYITWARA V2
 ---
 
 Verisiyo nshasha y’umurongo w’ivy’ugutwara abantu n’ibintu Bitcoin P2P ushiramwo ubuhinga bwo gukingira amakuru kugira ngo haboneke ubuzima bwite n’umutekano w’ivy’itumanaho hagati y’ibice. Iryo terambere rigamije Address ibibazo vyinshi bifise verisiyo y’ishimikiro y’amasezerano ya P2P, cane cane mu gutuma amakuru ahindurwa adashobora gutandukanywa n’umuntu yihweza ataco akora (nk’uwutanga ubuhinga bwa interineti), gutyo bikagabanya ingorane zo gucengera n’ibitero biciye mu kumenya uburyo bumwe bumwe buri mu mapakete y’amakuru.

--- a/resources/glossary/p2shp2wpkh/rn.md
+++ b/resources/glossary/p2shp2wpkh/rn.md
@@ -1,5 +1,5 @@
 ---
-term: P2SH-P2WPKH.
+term: P2SH-P2WPKH
 ---
 
 P2SH-P2WPKH bisobanura *Ishura Inyandiko Hash - Ishura Icabona Urufunguzo rwa bose Hash*. Ni urugero rw'inyandiko rusanzwe rukoreshwa mu gushinga ivyangombwa vyo gukoresha kuri UTXO, izwi kandi nka "Nested SegWit".

--- a/resources/glossary/paper-wallet/rn.md
+++ b/resources/glossary/paper-wallet/rn.md
@@ -1,5 +1,5 @@
 ---
-term: URUPAPURO Wallet.
+term: URUPAPURO Wallet
 ---
 
 Uburyo bwo kubika ibintu bitari mu murongo bujanye no gucapura canke kwandika imfunguruzo zibiri zitanga uburenganzira bwo gukoresha amafaranga y’ibiceri ku mpapuro (canke kumbure uwundi murongo w’umubiri) gusa. Amasakoshi y’impapuro afatwa nk’uburyo bwo kubika ibintu Cold, kuko adahuye na Internet, igihe gusa yakozwe n’amaboko kandi atacapwe. Umutekano wabo ushingiye ku kurindwa kw’umubiri kw’impapuro kugira ngo ntizitakare, ntizisambuke canke ntizibe. Muri iki gihe, akenshi zibonwa ko zitagikoreshwa, kuko zitanga uburyo bwo gucungera umutekano buke kuruta inyishu zo muri iki gihe. Ikindi, gukoresha vyavyo akenshi birimwo gusubira gukoresha urufunguzo rwa bose rumwe, ivyo bikaba bitera ingorane nyinshi ku mabanga y’abakoresha.

--- a/resources/glossary/receiving-address/rn.md
+++ b/resources/glossary/receiving-address/rn.md
@@ -1,5 +1,5 @@
 ---
-term: KWAKIRA Address.
+term: KWAKIRA Address
 ---
 
 Amakuru akoreshwa mu kwakira ama bitcoins. Address akenshi yubakwa hakoreshejwe urufunguzo rwa bose, hakoreshejwe `SHA256` na `RIMPEMD160`, no kwongerako amakuru y'imbere muri iki gitabu. Imfunguruzo za bose zikoreshwa mu kwubaka Address yakira ni igice ca Wallet y'ukoresha kandi rero zikomoka kuri seed yabo. Nk’akarorero, amaderesi ya SegWit agizwe n’amakuru akurikira:

--- a/resources/glossary/samourai-wallet/rn.md
+++ b/resources/glossary/samourai-wallet/rn.md
@@ -1,5 +1,5 @@
 ---
-term: SAMOURAI Wallet.
+term: SAMOURAI Wallet
 ---
 
 Bitcoin Porogarama ya Wallet y’ibikoresho vy’amatelefone ngendanwa vy’i Android yibanze ku buzima bwite. Itanga ibintu biteye imbere nk’ibice vy’amahera vya Whirlpool, ivyuma vy’amabuye, ivyuma vy’amabuyeX2, ivyuma vy’amabuye, n’ivyuma vy’amabuye (PayJoin). Samourai kandi ishira mu ngiro uburinzi bwinshi kugira ngo ifashe abakoresha kurinda ubuzima bwite bwabo ku bijanye n’ugusesangura uruhererekane.

--- a/resources/glossary/selfish-mining/rn.md
+++ b/resources/glossary/selfish-mining/rn.md
@@ -1,5 +1,5 @@
 ---
-term: UBWIKUNDA Mining.
+term: UBWIKUNDA Mining
 ---
 
 Ingamba (canke igitero) muri Mining, aho Miner canke umugwi w’abacukuzi bafata n’ibigirankana amabuye afise Proof of Work ibereye ataco baciye bayarekura ku rubuga. Intumbero ni uguguma imbere y’abandi bacukuzi mu bijanye na Proof of Work, bikaba bishobora kubashoboza gukora Miner amabuye menshi akurikiranye maze bakayasohora yose icarimwe, gutyo bakaronka inyungu nyinshi. Mu yandi majambo, uwo mugwi w’abacukuzi batera ntucukura ku gice ca nyuma cemejwe n’urubuga rwose, ahubwo ucukura ku gice bo ubwabo baremye, kikaba gitandukanye n’ico cemejwe n’urubuga.

--- a/resources/glossary/static-address/rn.md
+++ b/resources/glossary/static-address/rn.md
@@ -1,5 +1,5 @@
 ---
-term: GUHAGAZA Address.
+term: GUHAGAZA Address
 ---
 
 Mu bijanye n’Ivyishyurwa Bicereje, vyerekeye ikimenyetso kidasanzwe gishobora kwakira ivyishyurwa ata Address isubira gukoreshwa, ata gukorana, kandi ata n’ihuriro riboneka rya On-Chain hagati y’ivyishyurwa bitandukanye na Address idahinduka. Ubwo buryo burakuraho ivy’uko umuntu akeneye gutanga amaderesi mashasha, atakoreshwa yo kwakira generate ku bijanye n’ugucuruza kwose, gutyo hakaba umuntu yirinda imigenderanire isanzwe muri Bitcoin aho uwuronka ategerezwa gutanga Address nshasha ku muntu ariha. Ni nk'uko bingana n'itegeko ry'ukwishura rishobora gusubirwamwo mu bijanye na BIP47.

--- a/resources/glossary/stonewall-x2/rn.md
+++ b/resources/glossary/stonewall-x2/rn.md
@@ -1,5 +1,5 @@
 ---
-term: URUGOME RW'AMABUYE X2.
+term: URUGOME RW'AMABUYE X2
 ---
 
 Uburyo bwihariye bw’ugucuruza Bitcoin bugamije kwongerera ubuzima bwite bw’abakoresha mu gihe c’ugukoresha amahera, mu gukorana n’uwundi muntu atagira uruhara mu gukoresha amahera. Ubwo buryo bwigana mini-CoinJoin hagati y’abantu babiri bari muri iyo nama, mu gihe bariko bariha uwundi muntu. Ivy’ugucuruza vya Stonewall x2 biraboneka kuri porogarama ya Samourai Wallet no kuri porogarama ya Sparrow wallet (vyompi birakorana).

--- a/resources/glossary/wasabi-wallet/rn.md
+++ b/resources/glossary/wasabi-wallet/rn.md
@@ -1,5 +1,5 @@
 ---
-term: WASABI Wallet.
+term: WASABI Wallet
 ---
 
 Bitcoin Wallet yibanze ku buzima bwite, itanga ibintu nka CoinJoin.

--- a/scripts/auto-translate/translation_logic/glossary.yml
+++ b/scripts/auto-translate/translation_logic/glossary.yml
@@ -1,707 +1,808 @@
 non_translatable:
-  #  - second layer
-  - ADDR
-  - ADDR.DAT
-  - ADDRV2
-  - Alice
-  - AML/CTF
-  - ASIC
-  - Address
-  - off chain
-  - off-chain
-  - Altcoin
-  - AluVM
-  - Anchor
-  - ANCHORS.DAT
-  - AOPP
-  - API
-  - Aqua
-  - ARK
-  - ASCII
-  - ASMAP
-  - Assignment
-  - ATH
-  - ATLC
-  - Sybil Attack
-  - BANLIST.DAT
-  - BANLIST.JSON
-  - BARE-Multisig
-  - BARE-MULTISIG
-  - BASE58CHECK
-  - BECH32
-  - BECH32M
-  - B-CERT
-  - BDK
-  - BIP
-  - BIPs
-  - Bitchat
-  - Bitcoin
-  - Bitcoin core
-  - Bitcoin Dev Kit
-  - Bitcoin Fog
-  - BITCOIN FOG
-  - Bitcoin Game Show
-  - Bitcoin Knots
-  - Bitcoin Satoshi Vision
-  - Bitcoin.conf
-  - Bitcoin-dev
-  - BITCOIN-DEV
-  - bitcoin.conf
-  - BITCOIN.CONF
-  - "BitcoinVoucherBot P2P"
-  - BitcoinVN
-  - Bit gold
-  - BIT GOLD
-  - Biz School
-  - Blind signature
-  - Blinding key
-  - Blinded ranges
-  - BLK*.DAT
-  - BLKINDEX.DAT
-  - "BLKTREE/"
-  - BLOCK
-  - Block explorer
-  - Block reward
-  - Blockchain
-  - BLOCKSIZE WAR
-  - BLOCKSTREAM
-  - Blockstream Green
-  - Bob
-  - Bolt
-  - BTCPAY SERVER
-  - BUIDL
-  - Business Logic
-  - B-MONEY
-  - CGMINER
-  - chain code
-  - "CHAINSTATE/"
-  - CLI
-  - CPFP
-  - Child pay for parent
-  - Child-pay-for-parent
-  - Client-side Validation
-  - CoinJoin
-  - Coinjoin
-  - Coin
-  - Coinbase Transaction
-  - "COINS/"
-  - Cold
-  - Cold Wallet
-  - COLD WALLET
-  - "COOKIE (.COOKIE)"
-  - Commitment
-  - Commitment Transaction
-  - Confidential Transactions
-  - Confidential Address
-  - Consignment
-  - Consignment Endpoint
-  - Contract
-  - Contract Operation
-  - Contract Participant
-  - Contract Rights
-  - Contract State
-  - Cypherpunk
-  - "DATABASE/"
-  - DB.LOG
-  - DEBUG.LOG
-  - Debugger
-  - Decouvre Bitcoin
-  - Descriptor
-  - Descriptor Wallets
-  - Deterministic Bitcoin Commitment
-  - "DIGEST (HASH)"
-  - Directed Acyclic Graph
-  - Double-spending
-  - Dust
-  - DUST LIMIT
-  - DUSTING ATTACK
-  - Découvre Bitcoin
-  - ECASH
-  - ECLAIR
-  - ELECTRS
-  - Electrs
-  - ELECTRUM
-  - Electrum
-  - ELECTRUM SERVER
-  - Electrum Server
-  - Elements
-  - ELTOO
-  - Eltoo
-  - Engraving Extra Transaction Proof
-  - Exchange
-  - Faucet
-  - Federated 2-Way Peg
-  - FEDIMINT
-  - Fedimint
-  - FIBRE
-  - FINNEY HAL
-  - Fork
-  - Full node
-  - Full-node
-  - Genesis
-  - Global State
-  - Green
-  - Hal Finney
-  - Halving
-  - Hard Fork
-  - Hardware Wallet
-  - Hash
-  - HASHCASH
-  - HashCash
-  - Hasher
-  - Hashrate
-  - HODL
-  - Hot
-  - HTLC
-  - INDEXES/TXINDEX/
-  - Interface
-  - Interface Implementation
-  - Invoice
-  - IP_ASN.MAP
-  - Issued Assets
-  - JoinMarket
-  - JOINMARKET
-  - Joinstr
-  - Keysend
-  - LEVELDB
-  - LIBSECP256K1
-  - LIGHTNING NODE
-  - LIGHTNING SERVICE PROVIDER
-  - LN
-  - LND
-  - LNURL-Withdraw
-  - Layer
-  - Ledger
-  - Liana
-  - Lightning Network
-  - Lightning Network Daemon
-  - Liquid
-  - Liquid Network
-  - LIQUIDITY
-  - LOCK (.LOCK)
-  - Mainnet
-  - Maximalist
-  - MAX_BLOCK_SIZE
-  - MEMPOOL.DAT
-  - Mempool
-  - Merkle Root
-  - Merkle Tree
-  - Miner
-  - MINER
-  - Mining
-  - mining
-  - Mining Farm
-  - Mining Pool
-  - Mnemonic
-  - Multi Protocol Commitment
-  - Multisig
-  - MyNode
-  - M-OF-N
-  - NLOCKTIME
-  - Nonce
-  - NO2X
-  - nSequence
-  - NSEQUENCE
-  - nVersion
-  - ONION_PRIVATE_KEY
-  - ONION_V3_PRIVATE_KEY
-# operators
-  - OP_CODE
-  - OP_RETURN
-  - OP_0NOTEQUAL
-  - OP_1ADD
-  - OP_1NEGATE
-  - OP_1SUB
-  - OP_2 TO OP_16
-  - OP_2 TO OP_16 (0X52 TO 0X60)
-  - OP_2DROP
-  - OP_2OVER
-  - OP_2ROT
-  - OP_2SWAP
-  - OP_ADD
-  - OP_BOOLAND
-  - OP_BOOLOR
-  - OP_CAT
-  - OP_CHECKHASHVERIFY
-  - OP_CHECKLOCKTIMEVERIFY
-  - OP_CHECKMULTISIG
-  - OP_CHECKMULTISIGVERIFY
-  - OP_CHECKSEQUENCEVERIFY
-  - OP_CHECKSIG
-  - OP_CHECKSIGADD
-  - OP_CHECKSIGVERIFY
-  - OP_CODESEPARATOR
-  - OP_DEPTH
-  - OP_DROP
-  - OP_DUP
-  - OP_ELSE
-  - OP_ENDIF
-  - OP_EQUAL
-  - OP_EQUALVERIFY
-  - OP_EVAL
-  - OP_FALSE
-  - OP_FROMALTSTACK
-  - OP_GREATERTHAN
-  - OP_GREATERTHANOREQUAL
-  - OP_HASH160
-  - OP_HASH256
-  - OP_IF
-  - OP_LESSTHAN
-  - OP_LESSTHANOREQUAL
-  - OP_NEGATE
-  - OP_NIP
-  - OP_NOP
-  - OP_NOT
-  - OP_NOTIF
-  - OP_NUMEQUAL
-  - OP_NUMEQUALVERIFY
-  - OP_NUMNOTEQUAL
-  - OP_OVER
-  - OP_PICK
-  - OP_PUSHDATA1
-  - OP_PUSHDATA2
-  - OP_PUSHDATA4
-  - OP_RIPEMD160
-  - OP_ROLL
-  - OP_ROT
-  - OP_SHA1
-  - OP_SHA256
-  - OP_SIZE
-  - OP_SUB
-  - OP_SUCCESS
-  - OP_SWAP
-  - OP_TOALTSTACK
-  - OP_TRUE
-  - OP_TUCK
-  - OP_VERIFY
-  - OP_WITHIN
-  - OVERCLOCKING
-  - OVERCLOCK
-  - On-Chain
-  - Orphan block
-  - Owned State
-  - Ownership
-  - P2P
-  - P2SH
-  - P2TR
-  - P2WPKH
-  - PATOSHI
-  - PAYNYM
-  - PEERS.DAT
-  - Phoenix
-  - Phoenixd
-  - PHOENIXD
-  - POOL
-  - PSBT
-  - Partially Signed Bitcoin Transaction
-  - Pay-to-Script-Hash
-  - Pay-to-Taproot
-  - Pay-to-Witness-Public-Key-Hash
-  - Payjoin
-  - Pedersen commitment
-  - Plan ₿
-  - Plan ₿ Hangouts
-  - Plan ₿ Labs
-  - Plan ₿ Network
-  - Plan ₿ Academy
-  - POOL HOPPING
-  - Proof of Work
-  - Proof-of-Work
-  - pruned
-  - QUBIT
-  - RBF
-  - RGB
-  - RPC
-  - Redeem
-  - Replace by fee
-  - Replace-by-fee
-  - RICOCHET
-  - Rust
-  - Satoshi
-  - Sats
-  - Schema
-  - Seal
-  - Seal Definition
-  - SegWit
-  - SEGWIT2X
-  - Shard
-  - Shitcoin
-  - Sidechain
-  # Sighash
-  - SIGHASH_ALL
-  - SIGHASH_ALL/SIGHASH_ACP
-  - SIGHASH_ANYPREVOUT
-  - SIGHASH_ANYPREVOUTANYSCRIPT
-  - SIGHASH_NONE
-  - SIGHASH_NONE/SIGHASH_ACP
-  - SIGHASH_SINGLE
-  - SIGHASH_SINGLE/SIGHASH_ACP
-  - SIGNET
-  - Silentium
-  - SILK ROAD
-  - Single-Use Seal
-  - SLIP
-  - Smart contract
-  - Sparrow
-  - Sparrow wallet
-  - Soft
-  - Soft Fork
-  - Software Wallet
-  - STABLECOIN
-  - Stash
-  - State Extension
-  - State Transition
-  - STONEWALL
-  - STRATUM
-  - Strong Federation
-  - Supply
-  - Taproot
-  - Tech School
-  - Terminal Consignment
-  - Testnet
-  - TIDES
-  - TIMELOCK
-  - Timestamp
-  - Transition Bundle
-  - Trustless
-  - Unconfidential address
-  - UTXO
-  - Valency
-  - WABISABI
-  - Wallet
-  - WALLET.DAT
-  - WALLETS/DB.LOG
-  - Watch Tower
-  - Watch Towers
-  - watch towers
-  - watch tower
-  - Watch-only wallet
-  - Watchtower
-  - Whirlpool
-  - WHITE PAPER
-  - Witness Transaction
-  - ZEROCONF
-  - ZEROSYNC
-  - \langle
-  - \ldots
-  - \rangle
-  - anyone-can-spend
-  - b-cli
-  - bitcoin-cli
-  - bitcoind
-  - blinded
-  - block signer
-  - block signing
-  - block size war
-  - claimpegin
-  - combineblocksigs
-  - commitment transaction
-  - con_max_block_sig_size
-  - daemon
-  - default asset
-  - destroyamount
-  - double-spending
-  - dumpprivkey
-  - dynafed
-  - elements-cli
-  - elementsd
-  - federated peg
-  - federated peg script
-  - fork
-  - full node
-  - generate
-  - generate
-  - getnewaddress
-  - getnewblockhex
-  - getpeginaddress
-  - getrawtransaction
-  - gettransaction
-  - gettxoutproof
-  - getwalletinfo
-  - hashrate
-  - importaddress
-  - importprivkey
-  - issueasset
-  - listissuances
-  - mainchain
-  - mainnet
-  - merkle path
-  - multi-sig
-  - on chain
-  - on-chain
-  - output descriptor
-  - passphrase
-  - pegged asset
-  - proof of work
-  - proof-of-work
-  - redeemscript
-  - reissuance token
-  - reissueasset
-  - satoshi
-  - sats
-  - secure element
-  - script reedem
-  - seed
-  - seedphrase
-  - sendtoaddress
-  - sendtomainchain
-  - signblock
-  - signblockscript
-  - submitblock
-  - token
-  - transaction ID
-  - txid
-  - unblinded
-  - wallet
-  - watchmen
-  - ₿-CERT
-  - "be-BOP"
-  - "Breez - POS"
-  - "BTC Map"
-  - "BTCPay Server - Umbrel"
-  - "BTCPay Server - USDT"
-  - Coinos
-  - LNbits
-  - "LNbits Server"
-  - "Open Node"
-  - "Flash - POS"
-  - "Speed Wallet - POS"
-  - "Swiss Bitcoin Pay"
-  - "Wallet of Satoshi - POS"
-  - "Aegis Authenticator"
-  - "Alias Vault"
-  - "Angry IP Scanner"
-  - "Arch Linux"
-  - "Aurora Store"
-  - "Authy 2FA"
-  - Bitwarden
-  - Cryptomator
-  - Debian
-  - DietPi
-  - "Elementary OS"
-  - "Ente Auth"
-  - "F-Droid"
-  - Fedora
-  - Firefox
-  - GrapheneOS
-  - Graylog
-  - GnuPG
-  - IVPN
-  - Jami
-  - KeePass
-  - Keet
-  - "Ledger U2F & FIDO2"
-  - FIDO2
-  - LibreWolf
-  - LineageOS
-  - "Linux Mint"
-  - "LN VPN"
-  - LUKS
-  - Lynis
-  - Manjaro
-  - "Mozilla VPN"
-  - "Mullvad VPN"
-  - "Mullvad Browser"
-  - Nmap
-  - Ntopng
-  - Olvid
-  - OPNsense
-  - "Orion Browser"
-  - PearPass
-  - Pears
-  - pfSense
-  - "Pi-Hole"
-  - Picocrypt
-  - "Proton Authenticator"
-  - "Proton Drive"
-  - "Proton Mail"
-  - PureOS
-  - Qubes
-  - "Raspberry Pi Zero"
-  - "YubiKey 2FA"
-  - "Seedkeeper - Password Manager"
-  - Session
-  - Signal
-  - "Simple Login"
-  - "SimpleX Chat"
-  - Tails
-  - Tailscale
-  - Telegram
-  - Threema
-  - Thunderbird
-  - "Tor Browser"
-  - Tox
-  - "Trezor U2F & FIDO2"
-  - Ubuntu
-  - VeraCrypt
-  - VirtualBox
-  - Whonix
-  - WireGuard
-  - "Zen Browser"
-  - "GitHub Account"
-  - "GitHub Desktop"
-  - "Plan ₿ Academy - Pears App"
-  - Banxaas
-  - Bisq
-  - "Bisq 2"
-  - Bitfeed
-  - Bitfinex
-  - Bitika
-  - Bitrefill
-  - BitSpenda
-  - Bitstack
-  - Bitstamp
-  - Bittr
-  - Boltz
-  - "Bull Bitcoin"
-  - Coincards
-  - Debifi
-  - Flash
-  - "Hodl Hodl"
-  - Kraken
-  - LNP2PBot
-  - Moon
-  - Mostro
-  - Paymium
-  - Peach
-  - Relai
-  - Robosats
-  - StackinSat
-  - SwapMarket
-  - Tando
-  - "The Bitcoin Company"
-  - Vexl
-  - "Zeus Swap"
-  - Attakaï
-  - Bitaxe
-  - "Braiins Mini Miner"
-  - "Braiins Pool"
-  - "Canaan Avalon Mini 3"
-  - "Canaan Avalon Nano 3S"
-  - "NerdAxe Gamma"
-  - Nerdminer
-  - NerdQaxe
-  - "Ocean Mining"
-  - "Public Pool"
-  - "Alby Hub"
-  - Amboss
-  - "Bitcoin Core (Linux)"
-  - "Bitcoin Core (macOS & Windows)"
-  - Dojo
-  - "Lightning App"
-  - "Lightning Network Daemon (Linux)"
-  - Lightning Smoke Machine
-  - "My Node"
-  - Nakamochi
-  - Neutrino
-  - NOSTR
-  - Nostr
-  - RaspiBlitz
-  - "RGB CLI"
-  - "Ride The Lightning (RTL)"
-  - "RGB Lightning Node"
-  - RoninDojo
-  - "RoninDojo v2"
-  - "Start9"
-  - ThunderHub
-  - Umbrel
-  - "Umbrel LND"
-  - "Umbrel Nostr"
-  - "Lightning Watchtower"
-  - "Ashigaru Terminal"
-  - "Ashigaru Ricochet"
-  - "Ashigaru - Ricochet"
-  - "Ashigaru - Stonewall"
-  - "Ashigaru - Stonewall x2"
-  - "Ashigaru - Stowaway"
-  - "Blockstream Explorer"
-  - "Coin Control"
-  - "Remix - Whirlpool"
-  - "Labelling UTXO"
-  - Alby
-  - "Alby Go"
-  - Ashigaru
-  - Bacca
-  - "BIP-85"
-  - BitBox02
-  - "Bitcoin Keeper"
-  - Bitkey
-  - "Bitkit Wallet"
-  - Blink
-  - "Blitz Wallet"
-  - "Blixt Wallet"
-  - "Blockstream App - Desktop"
-  - "Blockstream App - Liquid"
-  - "Blockstream App - Onchain"
-  - "Blockstream App - Watch-Only"
-  - "Blockstream Green - 2FA"
-  - "Blue Wallet"
-  - Breez
-  - "Bull Bitcoin Wallet"
-  - "Cake Wallet"
-  - "Dana Wallet"
-  - Cashu.me
-  - "COLDCARD Mk"
-  - "COLDCARD - Co-Sign"
-  - "COLDCARD Q"
-  - "COLDCARD Q - Key Teleport"
-  - "Electrum Airgap"
-  - "Electrum OP_RETURN"
-  - Envoy
-  - Fedi
-  - Frostsnap
-  - "Ginger Wallet"
-  - Jade
-  - "Jade DIY"
-  - "Jade Plus - Green"
-  - "Jade Plus - Sparrow"
-  - Krux
-  - "Ledger Nano S"
-  - "Ledger Flex"
-  - "Ledger Nano S Plus"
-  - Lipa
-  - Machankura
-  - "Minibits Wallet"
-  - "Misty Breez"
-  - Muun
-  - "SAFU Ninja"
-  - Nunchuk
-  - OPENDIME
-  - "Passport Core"
-  - Portal
-  - "Proton Wallet"
-  - "Rumble Wallet"
-  - Satochip
-  - Satodime
-  - Satscard
-  - Sats.mobi
-  - Seedkeeper
-  - "Seedkeeper x SeedSigner"
-  - SeedSigner
-  - "Satochip x SeedSigner"
-  - Sentinel
-  - "Sparrow Wallet - Multisig"
-  - "Specter Desktop"
-  - "Specter DIY"
-  - "Speed Wallet"
-  - StashPay
-  - Tapsigner
-  - "Trezor Model One"
-  - "Trezor Safe 3"
-  - "Trezor Safe 5"
-  - "Trezor Shamir Backup"
-  - "Wallet of Satoshi"
-  - "Wasabi Wallet"
-  - "Zeus Embedded"
-  - KaleidoSwap
-  - Kali
-  - "Kali Linux"
-  - "Pop!_OS"
-  - "LN Markets"
-  - Windows 11
-  - Giacomo Zucco
-  - Voltz
-  - SMS4Sats
-  - "White Noise"
-  - 1ML
-  - Macadamia
+- ADDR
+- ADDR.DAT
+- ADDRV2
+- Alice
+- AML/CTF
+- ASIC
+- Address
+- off chain
+- off-chain
+- Altcoin
+- AluVM
+- Anchor
+- ANCHORS.DAT
+- AOPP
+- API
+- Aqua
+- ARK
+- ASCII
+- ASMAP
+- Assignment
+- ATH
+- ATLC
+- Sybil Attack
+- BANLIST.DAT
+- BANLIST.JSON
+- BARE-Multisig
+- BARE-MULTISIG
+- BASE58CHECK
+- BECH32
+- BECH32M
+- B-CERT
+- BDK
+- BIP
+- BIPs
+- Bitchat
+- Bitcoin
+- Bitcoin core
+- Bitcoin Dev Kit
+- Bitcoin Fog
+- BITCOIN FOG
+- Bitcoin Game Show
+- Bitcoin Knots
+- Bitcoin Satoshi Vision
+- Bitcoin.conf
+- Bitcoin-dev
+- BITCOIN-DEV
+- bitcoin.conf
+- BITCOIN.CONF
+- BitcoinVoucherBot P2P
+- BitcoinVN
+- Bit gold
+- BIT GOLD
+- Biz School
+- Blind signature
+- Blinding key
+- Blinded ranges
+- BLK*.DAT
+- BLKINDEX.DAT
+- BLKTREE/
+- BLOCK
+- Block explorer
+- Block reward
+- Blockchain
+- BLOCKSIZE WAR
+- BLOCKSTREAM
+- Blockstream Green
+- Bob
+- Bolt
+- BTCPAY SERVER
+- BUIDL
+- Business Logic
+- B-MONEY
+- CGMINER
+- chain code
+- CHAINSTATE/
+- CLI
+- CPFP
+- Child pay for parent
+- Child-pay-for-parent
+- Client-side Validation
+- CoinJoin
+- Coinjoin
+- Coin
+- Coinbase Transaction
+- COINS/
+- Cold
+- Cold Wallet
+- COLD WALLET
+- COOKIE (.COOKIE)
+- Commitment
+- Commitment Transaction
+- Confidential Transactions
+- Confidential Address
+- Consignment
+- Consignment Endpoint
+- Contract
+- Contract Operation
+- Contract Participant
+- Contract Rights
+- Contract State
+- Cypherpunk
+- DATABASE/
+- DB.LOG
+- DEBUG.LOG
+- Debugger
+- Decouvre Bitcoin
+- Descriptor
+- Descriptor Wallets
+- Deterministic Bitcoin Commitment
+- DIGEST (HASH)
+- Directed Acyclic Graph
+- Double-spending
+- Dust
+- DUST LIMIT
+- DUSTING ATTACK
+- Découvre Bitcoin
+- ECASH
+- ECLAIR
+- ELECTRS
+- Electrs
+- ELECTRUM
+- Electrum
+- ELECTRUM SERVER
+- Electrum Server
+- Elements
+- ELTOO
+- Eltoo
+- Engraving Extra Transaction Proof
+- Exchange
+- Faucet
+- Federated 2-Way Peg
+- FEDIMINT
+- Fedimint
+- FIBRE
+- FINNEY HAL
+- Fork
+- Full node
+- Full-node
+- Genesis
+- Global State
+- Green
+- Hal Finney
+- Halving
+- Hard Fork
+- Hardware Wallet
+- Hash
+- HASHCASH
+- HashCash
+- Hasher
+- Hashrate
+- HODL
+- Hot
+- HTLC
+- INDEXES/TXINDEX/
+- Interface
+- Interface Implementation
+- Invoice
+- IP_ASN.MAP
+- Issued Assets
+- JoinMarket
+- JOINMARKET
+- Joinstr
+- Keysend
+- LEVELDB
+- LIBSECP256K1
+- LIGHTNING NODE
+- LIGHTNING SERVICE PROVIDER
+- LN
+- LND
+- LNURL-Withdraw
+- Layer
+- Ledger
+- Liana
+- Lightning Network
+- Lightning Network Daemon
+- Liquid
+- Liquid Network
+- LIQUIDITY
+- LOCK (.LOCK)
+- Mainnet
+- Maximalist
+- MAX_BLOCK_SIZE
+- MEMPOOL.DAT
+- Mempool
+- Merkle Root
+- Merkle Tree
+- Miner
+- MINER
+- Mining
+- mining
+- Mining Farm
+- Mining Pool
+- Mnemonic
+- Multi Protocol Commitment
+- Multisig
+- MyNode
+- M-OF-N
+- NLOCKTIME
+- Nonce
+- NO2X
+- nSequence
+- NSEQUENCE
+- nVersion
+- ONION_PRIVATE_KEY
+- ONION_V3_PRIVATE_KEY
+- OP_CODE
+- OP_RETURN
+- OP_0NOTEQUAL
+- OP_1ADD
+- OP_1NEGATE
+- OP_1SUB
+- OP_2 TO OP_16
+- OP_2 TO OP_16 (0X52 TO 0X60)
+- OP_2DROP
+- OP_2OVER
+- OP_2ROT
+- OP_2SWAP
+- OP_ADD
+- OP_BOOLAND
+- OP_BOOLOR
+- OP_CAT
+- OP_CHECKHASHVERIFY
+- OP_CHECKLOCKTIMEVERIFY
+- OP_CHECKMULTISIG
+- OP_CHECKMULTISIGVERIFY
+- OP_CHECKSEQUENCEVERIFY
+- OP_CHECKSIG
+- OP_CHECKSIGADD
+- OP_CHECKSIGVERIFY
+- OP_CODESEPARATOR
+- OP_DEPTH
+- OP_DROP
+- OP_DUP
+- OP_ELSE
+- OP_ENDIF
+- OP_EQUAL
+- OP_EQUALVERIFY
+- OP_EVAL
+- OP_FALSE
+- OP_FROMALTSTACK
+- OP_GREATERTHAN
+- OP_GREATERTHANOREQUAL
+- OP_HASH160
+- OP_HASH256
+- OP_IF
+- OP_LESSTHAN
+- OP_LESSTHANOREQUAL
+- OP_NEGATE
+- OP_NIP
+- OP_NOP
+- OP_NOT
+- OP_NOTIF
+- OP_NUMEQUAL
+- OP_NUMEQUALVERIFY
+- OP_NUMNOTEQUAL
+- OP_OVER
+- OP_PICK
+- OP_PUSHDATA1
+- OP_PUSHDATA2
+- OP_PUSHDATA4
+- OP_RIPEMD160
+- OP_ROLL
+- OP_ROT
+- OP_SHA1
+- OP_SHA256
+- OP_SIZE
+- OP_SUB
+- OP_SUCCESS
+- OP_SWAP
+- OP_TOALTSTACK
+- OP_TRUE
+- OP_TUCK
+- OP_VERIFY
+- OP_WITHIN
+- OVERCLOCKING
+- OVERCLOCK
+- On-Chain
+- Orphan block
+- Owned State
+- Ownership
+- P2P
+- P2SH
+- P2TR
+- P2WPKH
+- PATOSHI
+- PAYNYM
+- PEERS.DAT
+- Phoenix
+- Phoenixd
+- PHOENIXD
+- POOL
+- PSBT
+- Partially Signed Bitcoin Transaction
+- Pay-to-Script-Hash
+- Pay-to-Taproot
+- Pay-to-Witness-Public-Key-Hash
+- Payjoin
+- Pedersen commitment
+- Plan ₿
+- Plan ₿ Hangouts
+- Plan ₿ Labs
+- Plan ₿ Network
+- Plan ₿ Academy
+- POOL HOPPING
+- Proof of Work
+- Proof-of-Work
+- pruned
+- QUBIT
+- RBF
+- RGB
+- RPC
+- Redeem
+- Replace by fee
+- Replace-by-fee
+- RICOCHET
+- Rust
+- Satoshi
+- Sats
+- Schema
+- Seal
+- Seal Definition
+- SegWit
+- SEGWIT2X
+- Shard
+- Shitcoin
+- Sidechain
+- SIGHASH_ALL
+- SIGHASH_ALL/SIGHASH_ACP
+- SIGHASH_ANYPREVOUT
+- SIGHASH_ANYPREVOUTANYSCRIPT
+- SIGHASH_NONE
+- SIGHASH_NONE/SIGHASH_ACP
+- SIGHASH_SINGLE
+- SIGHASH_SINGLE/SIGHASH_ACP
+- SIGNET
+- Silentium
+- SILK ROAD
+- Single-Use Seal
+- SLIP
+- Smart contract
+- Sparrow
+- Sparrow wallet
+- Soft
+- Soft Fork
+- Software Wallet
+- STABLECOIN
+- Stash
+- State Extension
+- State Transition
+- STONEWALL
+- STRATUM
+- Strong Federation
+- Supply
+- Taproot
+- Tech School
+- Terminal Consignment
+- Testnet
+- TIDES
+- TIMELOCK
+- Timestamp
+- Transition Bundle
+- Trustless
+- Unconfidential address
+- UTXO
+- Valency
+- WABISABI
+- Wallet
+- WALLET.DAT
+- WALLETS/DB.LOG
+- Watch Tower
+- Watch Towers
+- watch towers
+- watch tower
+- Watch-only wallet
+- Watchtower
+- Whirlpool
+- WHITE PAPER
+- Witness Transaction
+- ZEROCONF
+- ZEROSYNC
+- \langle
+- \ldots
+- \rangle
+- anyone-can-spend
+- b-cli
+- bitcoin-cli
+- bitcoind
+- blinded
+- block signer
+- block signing
+- block size war
+- claimpegin
+- combineblocksigs
+- commitment transaction
+- con_max_block_sig_size
+- daemon
+- default asset
+- destroyamount
+- double-spending
+- dumpprivkey
+- dynafed
+- elements-cli
+- elementsd
+- federated peg
+- federated peg script
+- fork
+- full node
+- generate
+- getnewaddress
+- getnewblockhex
+- getpeginaddress
+- getrawtransaction
+- gettransaction
+- gettxoutproof
+- getwalletinfo
+- hashrate
+- importaddress
+- importprivkey
+- issueasset
+- listissuances
+- mainchain
+- mainnet
+- merkle path
+- multi-sig
+- on chain
+- on-chain
+- output descriptor
+- passphrase
+- pegged asset
+- proof of work
+- proof-of-work
+- redeemscript
+- reissuance token
+- reissueasset
+- satoshi
+- sats
+- secure element
+- script reedem
+- seed
+- seedphrase
+- sendtoaddress
+- sendtomainchain
+- signblock
+- signblockscript
+- submitblock
+- token
+- transaction ID
+- txid
+- unblinded
+- wallet
+- watchmen
+- ₿-CERT
+- be-BOP
+- Breez - POS
+- BTC Map
+- BTCPay Server - Umbrel
+- BTCPay Server - USDT
+- Coinos
+- LNbits
+- LNbits Server
+- Open Node
+- Flash - POS
+- Speed Wallet - POS
+- Swiss Bitcoin Pay
+- Wallet of Satoshi - POS
+- Aegis Authenticator
+- Alias Vault
+- Angry IP Scanner
+- Arch Linux
+- Aurora Store
+- Authy 2FA
+- Bitwarden
+- Cryptomator
+- Debian
+- DietPi
+- Elementary OS
+- Ente Auth
+- F-Droid
+- Fedora
+- Firefox
+- GrapheneOS
+- Graylog
+- GnuPG
+- IVPN
+- Jami
+- KeePass
+- Keet
+- Ledger U2F & FIDO2
+- FIDO2
+- LibreWolf
+- LineageOS
+- Linux Mint
+- LN VPN
+- LUKS
+- Lynis
+- Manjaro
+- Mozilla VPN
+- Mullvad VPN
+- Mullvad Browser
+- Nmap
+- Ntopng
+- Olvid
+- OPNsense
+- Orion Browser
+- PearPass
+- Pears
+- pfSense
+- Pi-Hole
+- Picocrypt
+- Proton Authenticator
+- Proton Drive
+- Proton Mail
+- PureOS
+- Qubes
+- Raspberry Pi Zero
+- YubiKey 2FA
+- Seedkeeper - Password Manager
+- Session
+- Signal
+- Simple Login
+- SimpleX Chat
+- Tails
+- Tailscale
+- Telegram
+- Threema
+- Thunderbird
+- Tor Browser
+- Tox
+- Trezor U2F & FIDO2
+- Ubuntu
+- VeraCrypt
+- VirtualBox
+- Whonix
+- WireGuard
+- Zen Browser
+- GitHub Account
+- GitHub Desktop
+- Plan ₿ Academy - Pears App
+- Banxaas
+- Bisq
+- Bisq 2
+- Bitfeed
+- Bitfinex
+- Bitika
+- Bitrefill
+- BitSpenda
+- Bitstack
+- Bitstamp
+- Bittr
+- Boltz
+- Bull Bitcoin
+- Coincards
+- Debifi
+- Flash
+- Hodl Hodl
+- Kraken
+- LNP2PBot
+- Moon
+- Mostro
+- Paymium
+- Peach
+- Relai
+- Robosats
+- StackinSat
+- SwapMarket
+- Tando
+- The Bitcoin Company
+- Vexl
+- Zeus Swap
+- Attakaï
+- Bitaxe
+- Braiins Mini Miner
+- Braiins Pool
+- Canaan Avalon Mini 3
+- Canaan Avalon Nano 3S
+- NerdAxe Gamma
+- Nerdminer
+- NerdQaxe
+- Ocean Mining
+- Public Pool
+- Alby Hub
+- Amboss
+- Bitcoin Core (Linux)
+- Bitcoin Core (macOS & Windows)
+- Dojo
+- Lightning App
+- Lightning Network Daemon (Linux)
+- Lightning Smoke Machine
+- My Node
+- Nakamochi
+- Neutrino
+- NOSTR
+- Nostr
+- RaspiBlitz
+- RGB CLI
+- Ride The Lightning (RTL)
+- RGB Lightning Node
+- RoninDojo
+- RoninDojo v2
+- Start9
+- ThunderHub
+- Umbrel
+- Umbrel LND
+- Umbrel Nostr
+- Lightning Watchtower
+- Ashigaru Terminal
+- Ashigaru Ricochet
+- Ashigaru - Ricochet
+- Ashigaru - Stonewall
+- Ashigaru - Stonewall x2
+- Ashigaru - Stowaway
+- Blockstream Explorer
+- Coin Control
+- Remix - Whirlpool
+- Labelling UTXO
+- Alby
+- Alby Go
+- Ashigaru
+- Bacca
+- BIP-85
+- BitBox02
+- Bitcoin Keeper
+- Bitkey
+- Bitkit Wallet
+- Blink
+- Blitz Wallet
+- Blixt Wallet
+- Blockstream App - Desktop
+- Blockstream App - Liquid
+- Blockstream App - Onchain
+- Blockstream App - Watch-Only
+- Blockstream Green - 2FA
+- Blue Wallet
+- Breez
+- Bull Bitcoin Wallet
+- Cake Wallet
+- Dana Wallet
+- Cashu.me
+- COLDCARD Mk
+- COLDCARD - Co-Sign
+- COLDCARD Q
+- COLDCARD Q - Key Teleport
+- Electrum Airgap
+- Electrum OP_RETURN
+- Envoy
+- Fedi
+- Frostsnap
+- Ginger Wallet
+- Jade
+- Jade DIY
+- Jade Plus - Green
+- Jade Plus - Sparrow
+- Krux
+- Ledger Nano S
+- Ledger Flex
+- Ledger Nano S Plus
+- Lipa
+- Machankura
+- Minibits Wallet
+- Misty Breez
+- Muun
+- SAFU Ninja
+- Nunchuk
+- OPENDIME
+- Passport Core
+- Portal
+- Proton Wallet
+- Rumble Wallet
+- Satochip
+- Satodime
+- Satscard
+- Sats.mobi
+- Seedkeeper
+- Seedkeeper x SeedSigner
+- SeedSigner
+- Satochip x SeedSigner
+- Sentinel
+- Sparrow Wallet - Multisig
+- Specter Desktop
+- Specter DIY
+- Speed Wallet
+- StashPay
+- Tapsigner
+- Trezor Model One
+- Trezor Safe 3
+- Trezor Safe 5
+- Trezor Shamir Backup
+- Wallet of Satoshi
+- Wasabi Wallet
+- Zeus Embedded
+- KaleidoSwap
+- Kali
+- Kali Linux
+- Pop!_OS
+- LN Markets
+- Windows 11
+- Giacomo Zucco
+- Voltz
+- SMS4Sats
+- White Noise
+- 1ML
+- Macadamia
+- ASICBoost
+- BerkeleyDB
+- BIP0001
+- BIP0002
+- BIP0008
+- BIP0009
+- BIP0010
+- BIP0011
+- BIP0012
+- BIP0013
+- BIP0014
+- BIP0016
+- BIP0017
+- BIP0021
+- BIP0022
+- BIP0023
+- BIP0030
+- BIP0031
+- BIP0032
+- BIP0034
+- BIP0035
+- BIP0037
+- BIP0038
+- BIP0039
+- BIP0042
+- BIP0043
+- BIP0044
+- BIP0047
+- BIP0049
+- BIP0050
+- BIP0061
+- BIP0065
+- BIP0066
+- BIP0068
+- BIP0070
+- BIP0071
+- BIP0072
+- BIP0075
+- BIP0078
+- BIP0084
+- BIP0085
+- BIP0086
+- BIP0090
+- BIP0091
+- BIP0093
+- BIP0094
+- BIP0101
+- BIP0102
+- BIP0109
+- BIP0111
+- BIP0112
+- BIP0113
+- BIP0118
+- BIP0119
+- BIP0123
+- BIP0125
+- BIP0137
+- BIP0141
+- BIP0143
+- BIP0144
+- BIP0145
+- BIP0147
+- BIP0148
+- BIP0149
+- BIP0150
+- BIP0151
+- BIP0152
+- BIP0155
+- BIP0156
+- BIP0173
+- BIP0322
+- BIP0324
+- BIP0326
+- BIP0330
+- BIP0352
+- BIP0380
+- BIP0381
+- BIP0382
+- BIP0383
+- BIP0384
+- BIP0385
+- BIP0386
+- BITCOINTALK
+- BTC
+- CLN
+- COVENANT
+- DLC
+- ECDSA
+- JSON
+- MAST
+- RIPEMD160
+- Schnorr
+- ScriptPubKey
+- ScriptSig
+- ScriptWitness
+- secp256k1
+- secp256r1
+- SHA1
+- SHA256
+- SHA512
+- TCP
+- UDP
+- WIF
+- XBT
+- nLockTime

--- a/scripts/auto-translate/translation_logic/translate_json.py
+++ b/scripts/auto-translate/translation_logic/translate_json.py
@@ -49,12 +49,14 @@ class GlossaryManager:
     def prepare_text(self, text: str) -> Tuple[str, Dict[str, str]]:
         working_text = text
         local_replacements = {}
-        
-        
+
+
         sorted_terms = sorted(self.glossary_terms, key=len, reverse=True)
-        
+
         for term in sorted_terms:
-            pattern = re.compile(r'\b' + re.escape(term) + r'\b')
+            # Use word boundary only at start to handle terms ending with punctuation
+            # The trailing \b fails for terms ending with ), ], etc.
+            pattern = re.compile(r'\b' + re.escape(term))
             if pattern.search(working_text):
                 replacement = self._create_replacement_token()
                 working_text = pattern.sub(replacement, working_text)
@@ -68,10 +70,39 @@ class GlossaryManager:
             result = result.replace(token, original)
         return result
 
+    def detect_failed_restorations(self, text: str) -> List[Tuple[str, str]]:
+        """
+        Detect tokens that weren't properly restored (appear in transliterated form).
+        Returns list of (pattern_found, likely_script) tuples.
+        """
+        import re
+        failed_tokens = []
+
+        # Pattern definitions for different scripts
+        patterns = [
+            (r'जीडब्ल्यू-\d+', 'Devanagari (Hindi)'),       # Hindi: जीडब्ल्यू = GW
+            (r'ГВ-\d+', 'Cyrillic'),                         # Russian/Bulgarian: ГВ = GW
+            (r'GW-\d+', 'Latin (untranslated)'),            # Original token still present
+            (r'ج[يی]دبليو-\d+', 'Arabic/Farsi'),           # Arabic script
+            (r'จีดับเบิลยู-\d+', 'Thai'),                   # Thai
+            (r'ジーダブリュー-\d+', 'Japanese Katakana'),   # Japanese
+            (r'지더블유-\d+', 'Korean'),                    # Korean
+            (r'GW-\d+', 'Vietnamese'),                       # Vietnamese (likely stays Latin)
+        ]
+
+        for pattern, script_name in patterns:
+            matches = re.findall(pattern, text)
+            if matches:
+                for match in matches:
+                    failed_tokens.append((match, script_name))
+
+        return failed_tokens
+
 class TranslationProcessor:
     def __init__(self, translator: 'BaseTranslator'):
         self.translator = translator
         self.glossary_manager = GlossaryManager()
+        self.failed_restorations = []  # Track all failed restorations
 
     def process_text(self, text: str) -> str:
         if not text or not text.strip():
@@ -80,8 +111,49 @@ class TranslationProcessor:
         prepared_text, replacements = self.glossary_manager.prepare_text(text)
         translated_text = self.translator.translate_text(prepared_text)
         final_text = self.glossary_manager.restore_text(translated_text, replacements)
-        
+
+        # Detect failed restorations
+        failed = self.glossary_manager.detect_failed_restorations(final_text)
+        if failed:
+            # Store for summary report
+            self.failed_restorations.append({
+                'original': text[:100],
+                'translated': final_text[:100],
+                'failed_tokens': failed,
+                'expected_replacements': replacements
+            })
+            # Also print immediate warning
+            print(f"\n⚠️  WARNING: Failed token restorations detected!")
+            print(f"   Original text: {text[:100]}...")
+            print(f"   Translated text: {final_text[:100]}...")
+            for token, script in failed:
+                print(f"   - Found '{token}' in {script}")
+            if replacements:
+                print(f"   Expected replacements: {replacements}")
+
         return final_text
+
+    def get_failed_restorations_summary(self) -> Dict[str, Any]:
+        """Get summary of all failed restorations."""
+        if not self.failed_restorations:
+            return {'total_failures': 0}
+
+        scripts_affected = {}
+        total_tokens = 0
+
+        for failure in self.failed_restorations:
+            for token, script in failure['failed_tokens']:
+                total_tokens += 1
+                if script not in scripts_affected:
+                    scripts_affected[script] = []
+                scripts_affected[script].append(token)
+
+        return {
+            'total_failures': len(self.failed_restorations),
+            'total_tokens': total_tokens,
+            'scripts_affected': scripts_affected,
+            'details': self.failed_restorations
+        }
 
 class BaseTranslator(ABC):
     @abstractmethod
@@ -229,7 +301,7 @@ class GoogleTranslator(BaseTranslator):
     def translate_text(self, text: str) -> str:
         if not text or not text.strip():
             return text
-        
+
         current_time = time.time()
         time_since_last_request = current_time - self.last_request_time
         if time_since_last_request < self.min_request_interval:
@@ -246,7 +318,14 @@ class GoogleTranslator(BaseTranslator):
                     "target_language_code": self.target_lang,
                 }
             )
-            return response.translations[0].translated_text
+            translated = response.translations[0].translated_text
+
+            # Fix: Google Translate adds trailing periods to short technical terms
+            # Remove trailing period if original text didn't have one
+            if not text.rstrip().endswith('.') and translated.rstrip().endswith('.'):
+                translated = translated.rstrip()[:-1] + translated[len(translated.rstrip()):]
+
+            return translated
         except Exception as e:
             print(f"\nError translating text: {text}")
             print(f"Error: {e}")
@@ -384,10 +463,29 @@ class FileTranslator:
             
             with open(output_path, 'w', encoding='utf-8') as f:
                 json.dump(translated_content, f, ensure_ascii=False, indent=2)
-            
+
             print(f"\nTranslation completed: {output_path}")
             print(f"Processed {total_objects} objects")
-            
+
+            # Print summary of failed restorations
+            summary = self.translator.get_failed_restorations_summary()
+            if summary['total_failures'] > 0:
+                print(f"\n" + "="*60)
+                print(f"🚨 GLOSSARY RESTORATION FAILURE SUMMARY")
+                print(f"="*60)
+                print(f"Total failed restorations: {summary['total_failures']}")
+                print(f"Total failed tokens: {summary['total_tokens']}")
+                print(f"\nScripts affected:")
+                for script, tokens in summary['scripts_affected'].items():
+                    unique_tokens = set(tokens)
+                    print(f"  - {script}: {len(tokens)} occurrences ({len(unique_tokens)} unique tokens)")
+                    print(f"    Tokens: {', '.join(list(unique_tokens)[:5])}")
+                print(f"\nThis indicates that glossary terms were transliterated instead of preserved.")
+                print(f"See warnings above for details on each failed restoration.")
+                print(f"="*60)
+            else:
+                print(f"\n✅ All glossary tokens restored successfully!")
+
         except Exception as e:
             print(f"\nError processing file {input_path}")
             print(f"Error: {e}")


### PR DESCRIPTION
This script attempts to fix part of the issues listed here #3684. In particular:

1. All the hi.md files have the name: जीडब्ल्यू-0 -> the issue was related to the wrong restoration of the token used in json files -> 
				**FIX**: adding a Detection Method (detect_failed_restorations) to the script, which 
				tracks all failed restorations across the entire file after translation and fixes the wrong 
				parts

2. ride-the-lightning tuto has the name field still translated -> Issue; The regex pattern used word boundaries on both sides: `\b{term}\b`; The trailing `\b` fails when a term ends with punctuation like `)` because:
  - `)` is a non-word character
  - `\b` requires a transition between word/non-word characters
- After `)`, there's no such transition (end of string or space
				**FIX**: Changed pattern to use word boundary only at the start: `\b{term}`

3. Glossary issues: In all languages the word term: is being translated; some titles had a full stop (.) after the title -> issue: Google Translate (used for Rundi) automatically adds sentence-ending punctuation when translating short text fragments. It treats technical terms as sentences and adds periods.
				**FIX**: fix the present issues; The GoogleTranslator now automatically removes 
				unwanted trailing periods so this issue won't occur in future translations for ANY
				language using Google Translate

4. I added many Glossary terms to the glossary.yml files, so they won't be translated.

Next steps: address the other issues in the issue #3684 and modify glossary to include two version of every word (if necessary), with upper case letter and lower case letter.