### PR TITLE
[TUTORIAL] Remove Ledger Nano S Legacy links

### DIFF
--- a/tutorials/wallet/bacca/bg.md
+++ b/tutorials/wallet/bacca/bg.md
@@ -137,7 +137,7 @@ cargo run -p ledger_manager_gui
 Преди да започнете, ако вашият Ledger е нов, уверете се, че сте настроили ПИН кода и сте запазили фразата за възстановяване. За тези първоначални стъпки не е необходимо да използвате Ledger Live. Просто свържете вашия Ledger чрез USB кабела, за да го захраните. Ако не сте сигурни как да продължите с тези две стъпки, можете да се обърнете към началото на ръководството, специфично за вашия модел:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/cs.md
+++ b/tutorials/wallet/bacca/cs.md
@@ -98,7 +98,7 @@ Nyní máte přístup k rozhraní softwaru.
 
 Pokud je váš Ledger nový, ujistěte se, že jste nastavili kód PIN a uložili frázi pro obnovení. Pro tyto úvodní kroky nepotřebujete Ledger Live. Jednoduše připojte Ledger přes USB kabel a napájejte jej. Pokud si nejste jisti, jak postupovat v těchto dvou krocích, můžete se podívat na začátek návodu specifického pro váš model:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/de.md
+++ b/tutorials/wallet/bacca/de.md
@@ -98,7 +98,7 @@ Sie haben nun Zugriff auf die Softwareoberfläche.
 
 Wenn Ihr Ledger neu ist, müssen Sie zunächst den PIN-Code einrichten und die Wiederherstellungsphrase speichern. Für diese ersten Schritte benötigen Sie Ledger Live nicht. Schließen Sie Ihren Ledger einfach über das USB-Kabel an, um ihn mit Strom zu versorgen. Wenn Sie sich nicht sicher sind, wie Sie mit diesen beiden Schritten vorgehen sollen, können Sie am Anfang der Anleitung für Ihr Modell nachlesen:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/en.md
+++ b/tutorials/wallet/bacca/en.md
@@ -98,7 +98,7 @@ You now have access to the software interface.
 
 Before you start, if your Ledger is new, make sure you have set up the PIN code and saved the recovery phrase. You don't need Ledger Live for these initial steps. Simply connect your Ledger via the USB cable to power it. If you're not sure how to proceed with these two steps, you can refer to the beginning of the tutorial specific to your model:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/es.md
+++ b/tutorials/wallet/bacca/es.md
@@ -98,7 +98,7 @@ Ahora tiene acceso a la interfaz del software.
 
 Antes de empezar, si su Ledger es nuevo, asegúrese de haber configurado el código PIN y guardado la frase de recuperación. No necesita Ledger Live para estos pasos iniciales. Simplemente conecta tu Ledger a través del cable USB para encenderlo. Si no estás seguro de cómo proceder con estos dos pasos, puedes consultar el principio del tutorial específico para tu modelo:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/et.md
+++ b/tutorials/wallet/bacca/et.md
@@ -98,7 +98,7 @@ Nüüd on teil juurdepääs tarkvaraliidesele.
 
 Kui teie Ledger on uus, veenduge enne alustamist, et olete seadistanud PIN-koodi ja salvestanud taastamislauset. Nende esialgsete sammude jaoks ei ole teil vaja Ledger Live'i. Lihtsalt ühendage oma Ledger USB-kaabli kaudu, et see saaks voolu. Kui te ei ole kindel, kuidas nende kahe sammuga edasi minna, võite vaadata oma mudelile vastava õpetuse algust:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/fa.md
+++ b/tutorials/wallet/bacca/fa.md
@@ -137,7 +137,7 @@ cargo run -p ledger_manager_gui
 قبل از شروع، اگر Ledger شما جدید است، مطمئن شوید که کد PIN را تنظیم کرده و عبارت بازیابی را ذخیره کرده‌اید. برای این مراحل اولیه نیازی به Ledger Live ندارید. کافی است Ledger خود را از طریق کابل USB به برق متصل کنید. اگر مطمئن نیستید که چگونه با این دو مرحله پیش بروید، می‌توانید به ابتدای آموزش مخصوص مدل خود مراجعه کنید:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/fi.md
+++ b/tutorials/wallet/bacca/fi.md
@@ -98,7 +98,7 @@ Sinulla on nyt pääsy ohjelmiston käyttöliittymään.
 
 Jos Ledger on uusi, varmista ennen aloittamista, että olet määrittänyt PIN-koodin ja tallentanut palautuslausekkeen. Et tarvitse Ledger Liveä näihin alkuvaiheisiin. Kytke Ledgeriin virta USB-kaapelilla. Jos et ole varma, miten edetä näissä kahdessa vaiheessa, voit tutustua malliasi koskevan ohjeen alkuun:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/fr.md
+++ b/tutorials/wallet/bacca/fr.md
@@ -100,7 +100,7 @@ Vous avez maintenant accès à l'interface du logiciel.
 
 Avant de commencer, si votre Ledger est neuf, assurez-vous d'avoir configuré le code PIN et sauvegardé la phrase de récupération. Vous n'avez pas besoin de Ledger Live pour ces étapes initiales. Il suffit de connecter votre Ledger via le câble USB pour l'alimenter. Si vous n'êtes pas sûr de savoir comment procéder pour ces deux étapes, vous pouvez consulter le début du tutoriel spécifique à votre modèle :
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/hi.md
+++ b/tutorials/wallet/bacca/hi.md
@@ -137,7 +137,7 @@ cargo run -p ledger_manager_gui
 शुरू करने से पहले, अगर आपका Ledger नया है, तो सुनिश्चित करें कि आपने पिन कोड सेट कर लिया है और रिकवरी वाक्यांश सहेज लिया है। इन शुरुआती चरणों के लिए आपको Ledger लाइव की ज़रूरत नहीं है। बस अपने Ledger को USB केबल के ज़रिए कनेक्ट करें ताकि उसे पावर मिल सके। अगर आपको नहीं पता कि इन दो चरणों को कैसे आगे बढ़ाया जाए, तो आप अपने मॉडल के लिए खास ट्यूटोरियल की शुरुआत देख सकते हैं:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/id.md
+++ b/tutorials/wallet/bacca/id.md
@@ -98,7 +98,7 @@ Anda sekarang memiliki akses ke antarmuka perangkat lunak.
 
 Sebelum memulai, jika Ledger Anda masih baru, pastikan Anda telah mengatur kode PIN dan menyimpan frasa pemulihan. Anda tidak memerlukan Ledger Live untuk langkah awal ini. Cukup sambungkan Ledger Anda melalui kabel USB untuk menyalakannya. Jika Anda tidak yakin bagaimana cara melanjutkan kedua langkah ini, Anda dapat merujuk ke awal tutorial khusus untuk model Anda:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/it.md
+++ b/tutorials/wallet/bacca/it.md
@@ -98,7 +98,7 @@ Ora si ha accesso all'interfaccia del software.
 
 Prima di iniziare, se il vostro Ledger è nuovo, assicuratevi di aver impostato il codice PIN e salvato la frase di recupero. Per queste fasi iniziali non è necessario Ledger Live. È sufficiente collegare il Ledger tramite il cavo USB per alimentarlo. Se non si è sicuri di come procedere con questi due passaggi, si può fare riferimento all'inizio del tutorial specifico per il proprio modello:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/ja.md
+++ b/tutorials/wallet/bacca/ja.md
@@ -98,7 +98,7 @@ cargo run -p ledger_manager_gui
 
 始める前に、Ledgerが新しい場合は、PINコードを設定し、リカバリーフレーズを保存していることを確認してください。これらの初期ステップにはLedger Liveは必要ありません。USBケーブルでLedgerを接続し、電源を入れるだけです。この2つのステップの進め方がわからない場合は、お使いのモデルに特化したチュートリアルの冒頭を参照してください：
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/ko.md
+++ b/tutorials/wallet/bacca/ko.md
@@ -137,7 +137,7 @@ cargo run -p ledger_manager_gui
 시작하기 전에 Ledger를 처음 사용하는 경우 PIN 코드를 설정하고 복구 문구를 저장했는지 확인하세요. 이러한 초기 단계에는 Ledger Live가 필요하지 않습니다. USB 케이블을 통해 Ledger를 연결하여 전원을 공급하기만 하면 됩니다. 이 두 단계를 어떻게 진행해야 할지 잘 모르겠다면 사용 중인 모델에 맞는 튜토리얼의 시작 부분을 참조하세요:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/nb-NO.md
+++ b/tutorials/wallet/bacca/nb-NO.md
@@ -98,7 +98,7 @@ Du har nå tilgang til programvaregrensesnittet.
 
 Hvis du har en ny Ledger, må du sørge for at du har satt opp PIN-koden og lagret gjenopprettingsfrasen før du starter. Du trenger ikke Ledger Live for disse innledende trinnene. Du trenger bare å koble til Ledger via USB-kabelen for å gi den strøm. Hvis du ikke er sikker på hvordan du går frem med disse to trinnene, kan du se begynnelsen av veiledningen som er spesifikk for din modell:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/nl.md
+++ b/tutorials/wallet/bacca/nl.md
@@ -137,7 +137,7 @@ Je hebt nu toegang tot de software Interface.
 Voordat u begint, als uw Ledger nieuw is, moet u ervoor zorgen dat u de pincode hebt ingesteld en de herstelzin hebt opgeslagen. Je hebt Ledger Live niet nodig voor deze eerste stappen. Sluit uw Ledger gewoon aan via de USB-kabel om hem van stroom te voorzien. Als je niet zeker weet hoe je verder moet gaan met deze twee stappen, kun je het begin van de handleiding voor jouw model raadplegen:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/pl.md
+++ b/tutorials/wallet/bacca/pl.md
@@ -137,7 +137,7 @@ Masz teraz dostęp do oprogramowania Interface.
 Przed rozpoczęciem, jeśli Ledger jest nowy, upewnij się, że skonfigurowałeś kod PIN i zapisałeś frazę odzyskiwania. Nie potrzebujesz Ledger Live do wykonania tych początkowych kroków. Wystarczy podłączyć Ledger za pomocą kabla USB, aby go zasilić. Jeśli nie masz pewności, jak wykonać te dwa kroki, możesz zapoznać się z początkiem samouczka dotyczącego Twojego modelu:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/pt.md
+++ b/tutorials/wallet/bacca/pt.md
@@ -98,7 +98,7 @@ Tem agora acesso à interface do software.
 
 Antes de começar, se o seu Ledger for novo, certifique-se de que configurou o código PIN e guardou a frase de recuperação. Não precisa do Ledger Live para estes passos iniciais. Basta ligar o Ledger através do cabo USB para o alimentar. Se não tiver a certeza de como proceder com estes dois passos, pode consultar o início do tutorial específico para o seu modelo:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/rn.md
+++ b/tutorials/wallet/bacca/rn.md
@@ -137,7 +137,7 @@ Ubu urashobora gukoresha porogarama Interface.
 Imbere y’uko utangura, nimba Ledger yawe ari nshasha, urabe neza ko washizeho kode ya PIN kandi ukabika ijambo ry’ugusubirana. Ntukeneye Ledger Live kuri izo ntambwe z’intango. Gusa n’ushobora gufatanya Ledger yawe biciye ku nzira ya USB kugira ngo uyihe ubushobozi. Niba utazi neza ingene wogenda muri izo ntambwe zibiri, ushobora kuraba intango y'inyigisho yihariye ku citegererezo cawe:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/ru.md
+++ b/tutorials/wallet/bacca/ru.md
@@ -98,7 +98,7 @@ cargo run -p ledger_manager_gui
 
 Прежде чем начать, если ваш Ledger новый, убедитесь, что вы настроили PIN-код и сохранили фразу восстановления. Для этих начальных шагов вам не нужна программа Ledger Live. Просто подключите Ledger к питанию через USB-кабель. Если вы не знаете, как выполнить эти два шага, обратитесь к началу руководства по конкретной модели:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/sr-Latn.md
+++ b/tutorials/wallet/bacca/sr-Latn.md
@@ -137,7 +137,7 @@ Sada imate pristup softveru Interface.
 Pre nego što počnete, ako je vaš Ledger nov, uverite se da ste postavili PIN kod i sačuvali frazu za oporavak. Za ove početne korake vam nije potreban Ledger Live. Jednostavno povežite vaš Ledger putem USB kabla da biste ga napajali. Ako niste sigurni kako da nastavite sa ova dva koraka, možete se obratiti početku tutorijala specifičnog za vaš model:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/sv.md
+++ b/tutorials/wallet/bacca/sv.md
@@ -137,7 +137,7 @@ Du har nu tillgång till programvaran Interface.
 Innan du börjar, om din Ledger är ny, se till att du har ställt in PIN-koden och sparat återställningsfrasen. Du behöver inte Ledger Live för dessa inledande steg. Anslut helt enkelt din Ledger via USB-kabeln för att driva den. Om du inte är säker på hur du ska gå vidare med dessa två steg kan du hänvisa till början av den handledning som är specifik för din modell:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/sw.md
+++ b/tutorials/wallet/bacca/sw.md
@@ -137,7 +137,7 @@ Sasa unaweza kufikia programu ya Interface.
 Kabla ya kuanza, ikiwa Ledger yako ni mpya, hakikisha kuwa umeweka msimbo wa PIN na kuhifadhi maneno ya kurejesha akaunti. Huhitaji Ledger Live kwa hatua hizi za mwanzo. Unganisha tu Ledger yako kupitia kebo ya USB ili kuiwasha. Ikiwa huna uhakika jinsi ya kuendelea na hatua hizi mbili, unaweza kurejelea mwanzo wa mafunzo maalum kwa mfano wako:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/th.md
+++ b/tutorials/wallet/bacca/th.md
@@ -137,7 +137,7 @@ cargo run -p ledger_manager_gui
 ก่อนที่คุณจะเริ่ม หาก Ledger ของคุณเป็นเครื่องใหม่ ตรวจสอบให้แน่ใจว่าคุณได้ตั้งค่ารหัส PIN และบันทึกวลีการกู้คืนแล้ว คุณไม่จำเป็นต้องใช้ Ledger Live สำหรับขั้นตอนเริ่มต้นเหล่านี้ เพียงเชื่อมต่อ Ledger ของคุณผ่านสาย USB เพื่อจ่ายไฟให้กับมัน หากคุณไม่แน่ใจว่าจะดำเนินการสองขั้นตอนนี้อย่างไร คุณสามารถดูที่จุดเริ่มต้นของบทแนะนำเฉพาะสำหรับรุ่นของคุณ:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/tr.md
+++ b/tutorials/wallet/bacca/tr.md
@@ -137,7 +137,7 @@ Artık Interface yazılımına erişiminiz var.
 Başlamadan önce, Ledger'unuz yeniyse PIN kodunu ayarladığınızdan ve kurtarma cümlesini kaydettiğinizden emin olun. Bu ilk adımlar için Ledger Live'a ihtiyacınız yoktur. Ledger'unuza güç vermek için USB kablosuyla bağlamanız yeterlidir. Bu iki adımda nasıl ilerleyeceğinizden emin değilseniz, modelinize özgü eğitimin başına bakabilirsiniz:
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/vi.md
+++ b/tutorials/wallet/bacca/vi.md
@@ -98,7 +98,7 @@ You now have access to the software interface.
 
 Before you start, if your Ledger is new, make sure you have set up the PIN code and saved the recovery phrase. You don't need Ledger Live for these initial steps. Simply connect your Ledger via the USB cable to power it. If you're not sure how to proceed with these two steps, you can refer to the beginning of the tutorial specific to your model:
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/zh-Hans.md
+++ b/tutorials/wallet/bacca/zh-Hans.md
@@ -98,7 +98,7 @@ cargo run -p ledger_manager_gui
 
 开始之前，如果你的 Ledger 是新的，请确保你已经设置了 PIN 码并保存了恢复短语。这些初始步骤不需要 Ledger Live。只需通过 USB 电缆连接 Ledger，为其供电即可。如果你不确定如何进行这两个步骤，可以参考针对你的型号的教程开头部分：
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/bacca/zh-Hant.md
+++ b/tutorials/wallet/bacca/zh-Hant.md
@@ -137,7 +137,7 @@ cargo run -p ledger_manager_gui
 在您開始之前，如果您的 Ledger 是新的，請確認您已設定 PIN 碼並儲存復原短語。這些初始步驟不需要 Ledger Live。只要透過 USB 傳輸線連接 Ledger 供電即可。如果您不確定如何進行這兩個步驟，您可以參考您機型的特定教學開頭：
 
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 

--- a/tutorials/wallet/liana/it.md
+++ b/tutorials/wallet/liana/it.md
@@ -12,9 +12,9 @@ Nel gennaio 2025, i portafogli hardware compatibili con Liana erano:
 - [Blockstream Jade Plus](https://planb.academy/it/tutorials/wallet/hardware/jade-plus-green-873099a4-35ec-4be8-b31a-6e7cd6a41ec0);
 - [COLDCARD MK4](https://planb.academy/tutorials/wallet/hardware/coldcard-mk4-5d44dd94-423d-4e37-9a8c-3fc38b45ce59);
 - [COLDCARD Q](https://planb.academy/it/tutorials/wallet/hardware/coldcard-q-73e86d1a-6fe6-4d8b-bb15-8690298020e3);
-- [Ledger Nano S](https://planb.academy/it/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88);
+- Ledger Nano S;
 - [Ledger Nano S Plus](https://planb.academy/it/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4);
-- [Ledger Nano X](https://planb.academy/it/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88);
+- Ledger Nano X;
 - [Ledger Flex](https://planb.academy/it/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b39f-bd923700c76a);
 - [Specter DIY](https://planb.academy/it/tutorials/wallet/hardware/specter-diy-87993e31-233e-42f8-9aea-e2128049e2dc).
 

--- a/tutorials/wallet/passphrase-ledger/bg.md
+++ b/tutorials/wallet/passphrase-ledger/bg.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Как да настроите временен passphrase с Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/cs.md
+++ b/tutorials/wallet/passphrase-ledger/cs.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Jak nastavit dočasnou heslovou frázi s Ledgerem?
 

--- a/tutorials/wallet/passphrase-ledger/de.md
+++ b/tutorials/wallet/passphrase-ledger/de.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Wie richtet man eine temporäre Passphrase mit einem Ledger ein?
 

--- a/tutorials/wallet/passphrase-ledger/en.md
+++ b/tutorials/wallet/passphrase-ledger/en.md
@@ -34,7 +34,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## How to set up a temporary passphrase with a Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/es.md
+++ b/tutorials/wallet/passphrase-ledger/es.md
@@ -33,7 +33,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## ¿Cómo configurar una frase de paso temporal con un Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/et.md
+++ b/tutorials/wallet/passphrase-ledger/et.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Kuidas seadistada ajutist paroolilause Ledgeris?
 

--- a/tutorials/wallet/passphrase-ledger/fa.md
+++ b/tutorials/wallet/passphrase-ledger/fa.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## چگونه یک passphrase موقت را با یک Ledger راه‌اندازی کنیم؟
 

--- a/tutorials/wallet/passphrase-ledger/fi.md
+++ b/tutorials/wallet/passphrase-ledger/fi.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Kuinka asettaa väliaikainen salasana Ledgeriin?
 

--- a/tutorials/wallet/passphrase-ledger/fr.md
+++ b/tutorials/wallet/passphrase-ledger/fr.md
@@ -36,7 +36,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Comment mettre en place une passphrase temporaire avec un Ledger ?
 

--- a/tutorials/wallet/passphrase-ledger/hi.md
+++ b/tutorials/wallet/passphrase-ledger/hi.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Ledger के साथ अस्थायी passphrase कैसे स्थापित करें?
 

--- a/tutorials/wallet/passphrase-ledger/id.md
+++ b/tutorials/wallet/passphrase-ledger/id.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Bagaimana cara mengatur passphrase sementara dengan Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/it.md
+++ b/tutorials/wallet/passphrase-ledger/it.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Come impostare una passphrase temporanea con un Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/ja.md
+++ b/tutorials/wallet/passphrase-ledger/ja.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Ledgerで一時的なパスフレーズを設定する方法は？
 

--- a/tutorials/wallet/passphrase-ledger/ko.md
+++ b/tutorials/wallet/passphrase-ledger/ko.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Ledger로 임시 passphrase을 설정하는 방법은 무엇인가요?
 

--- a/tutorials/wallet/passphrase-ledger/nb-NO.md
+++ b/tutorials/wallet/passphrase-ledger/nb-NO.md
@@ -36,7 +36,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Hvordan setter jeg opp en midlertidig passordfrase med en hovedbok?
 

--- a/tutorials/wallet/passphrase-ledger/nl.md
+++ b/tutorials/wallet/passphrase-ledger/nl.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Hoe installeer ik een tijdelijke passphrase met een Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/pl.md
+++ b/tutorials/wallet/passphrase-ledger/pl.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Jak skonfigurować tymczasowy passphrase z Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/pt.md
+++ b/tutorials/wallet/passphrase-ledger/pt.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Como configurar uma frase-senha temporária com uma Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/rn.md
+++ b/tutorials/wallet/passphrase-ledger/rn.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Ni gute woshiraho passphrase y’igihe gito n’iyi Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/ru.md
+++ b/tutorials/wallet/passphrase-ledger/ru.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Как настроить временную парольную фразу с Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/sr-Latn.md
+++ b/tutorials/wallet/passphrase-ledger/sr-Latn.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Kako postaviti privremeni passphrase sa Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/sv.md
+++ b/tutorials/wallet/passphrase-ledger/sv.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Hur sätter man upp en tillfällig passphrase med en Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/sw.md
+++ b/tutorials/wallet/passphrase-ledger/sw.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Jinsi ya kuanzisha passphrase ya muda na Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/th.md
+++ b/tutorials/wallet/passphrase-ledger/th.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## วิธีการตั้งค่า passphrase ชั่วคราวด้วย Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/tr.md
+++ b/tutorials/wallet/passphrase-ledger/tr.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Bir Ledger ile geçici bir passphrase nasıl kurulur?
 

--- a/tutorials/wallet/passphrase-ledger/vi.md
+++ b/tutorials/wallet/passphrase-ledger/vi.md
@@ -32,7 +32,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## Làm thế nào để thiết lập cụm từ bí mật tạm thời với Ledger?
 

--- a/tutorials/wallet/passphrase-ledger/zh-Hans.md
+++ b/tutorials/wallet/passphrase-ledger/zh-Hans.md
@@ -33,7 +33,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## 如何在Ledger上设置临时密码短语？
 

--- a/tutorials/wallet/passphrase-ledger/zh-Hant.md
+++ b/tutorials/wallet/passphrase-ledger/zh-Hant.md
@@ -48,7 +48,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-flex-3728773e-74d4-4177-b
 
 https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e-43e8-862d-ca243b8215a4
 
-https://planb.academy/tutorials/wallet/hardware/ledger-c6fc7d82-91e7-4c74-bad7-cbff7fea7a88
+
 
 ## 如何使用 Ledger 設定臨時 passphrase？
 


### PR DESCRIPTION
All occurrences of the link to the archived tutorial are located alongside links to the Nano S Plus tuto. Therefore there's no need to replace the broken links: I just deleted them. The entire repo has been checked.