### PR TITLE
[DATA] Fix license key

### DIFF
--- a/docs/PBN-template-repo/tutorials/this-folder-is-a-tutorial-category/awesome-tutorial/tutorial.yml
+++ b/docs/PBN-template-repo/tutorials/this-folder-is-a-tutorial-category/awesome-tutorial/tutorial.yml
@@ -83,7 +83,7 @@ license: CC-BY-SA-V4
 # - urgency: level of urgency from 1 (low urgency) to X (high urgency)
 # - contributor_names: list of contributors PBN ids
 # - reward: amount of sats available for reward
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 original_language: en
 proofreading:

--- a/resources/projects/1ml/project.yml
+++ b/resources/projects/1ml/project.yml
@@ -16,7 +16,7 @@ tags:
   - software
   - node
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr

--- a/resources/projects/arkade/project.yml
+++ b/resources/projects/arkade/project.yml
@@ -17,7 +17,7 @@ tags:
   - wallets
   - scalability
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr

--- a/resources/projects/bitbanana/project.yml
+++ b/resources/projects/bitbanana/project.yml
@@ -18,7 +18,7 @@ tags:
   - software
   - lightning
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr

--- a/resources/projects/bitchat/project.yml
+++ b/resources/projects/bitchat/project.yml
@@ -16,7 +16,7 @@ tags:
   - software
   - privacy
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr

--- a/resources/projects/delta-chat/project.yml
+++ b/resources/projects/delta-chat/project.yml
@@ -25,4 +25,4 @@ tags:
 contributor_names:
   - PaoloFoti
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4

--- a/resources/projects/joinstr/project.yml
+++ b/resources/projects/joinstr/project.yml
@@ -16,7 +16,7 @@ tags:
   - privacy
   - personal-security
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr

--- a/resources/projects/macadamia/project.yml
+++ b/resources/projects/macadamia/project.yml
@@ -16,7 +16,7 @@ tags:
   - offchain
   - software
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr

--- a/resources/projects/matrix/project.yml
+++ b/resources/projects/matrix/project.yml
@@ -17,7 +17,7 @@ tags:
   - privacy
   - personal-security
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr

--- a/resources/projects/silentium/project.yml
+++ b/resources/projects/silentium/project.yml
@@ -16,7 +16,7 @@ tags:
   - software
   - privacy
 
-licence: CC-BY-SA-V4
+license: CC-BY-SA-V4
 
 # Proofreading metadata
 original_language: fr


### PR DESCRIPTION
Spelling correction of the `license:` keys in the metadata YAML files