### PR TITLE
[PROOFREADING] wallet_section - NL

### DIFF
--- a/tutorials/wallet/alby-go/nl.md
+++ b/tutorials/wallet/alby-go/nl.md
@@ -6,13 +6,13 @@ description: Gids voor Alby Go mobiele app
 ![cover-green](assets/cover.webp)
 
 
-## welkom bij Alby Go - de makkelijkst te gebruiken mobiele Wallet
+## 🚀 Welkom bij Alby Go - de makkelijkst te gebruiken mobiele Wallet
 
 
-**Alby Go** is een open-source, eenvoudig te gebruiken mobiele app, die werkt als een Wallet Interface naar Bitcoin bliksemknooppunten en wallets. Hier lees je hoe je aan de slag gaat en het meeste uit je ervaring haalt.
+**Alby Go** is een open-source, eenvoudig te gebruiken mobiele app, die werkt als een wallet-interface naar Bitcoin Lightning-nodes en wallets. Hier lees je hoe je aan de slag gaat en het meeste uit je ervaring haalt.
 
 
-**✅ Ondersteunde en bekende compatibele portemonnees/knooppunten:**
+**✅ Ondersteunde en bekende compatibele wallets/nodes:**
 
 
 
@@ -23,10 +23,10 @@ description: Gids voor Alby Go mobiele app
 - **Minibits** *(niet getest)*
 
 
-De meeste services met NWC zouden moeten werken. Als u een nieuwe test, laat de community dan uw resultaten weten!
+De meeste services met NWC zouden moeten werken. Als je een nieuwe test, deel je resultaten dan met de community !
 
 
-## installeer Alby Go
+## 📲 Installeer Alby Go
 
 
 Beschikbaar op de belangrijkste platforms:
@@ -40,49 +40,49 @@ Beschikbaar op de belangrijkste platforms:
 
 
 
-## sluit een Wallet aan
+## 🔌 Sluit een wallet aan
 
 
-Alby Go maakt verbinding met je lightning-enabled node of Wallet met behulp van een NWC (Nostr Wallet Connect) geheim. Je kunt een of meer wallets koppelen om gemakkelijk tussen de wallets te wisselen.
+Alby Go maakt verbinding met je Lightning-enabled node of wallet met behulp van een NWC (Nostr Wallet Connect) geheim. Je kunt een of meer wallets koppelen om gemakkelijk tussen de wallets te wisselen.
 
 Stappen:
 
-1. Open Instellingen → Portemonnees → Verbind een Wallet
+1. Open Instellingen (settings) → Wallets → Verbind een wallet
 
 2. Scan een QR-code of plak een NWC-verbindingsgeheim (bijv. nostr+walletconnect://...)
 
 3. Geef je verbinding een aangepaste naam
 
 
-Eenmaal aangesloten is je Wallet of node klaar voor het verzenden en ontvangen van Bitcoin lightning betalingen via Alby Go.
+Eenmaal aangesloten is je wallet of node klaar voor het verzenden en ontvangen van Bitcoin lightning betalingen via Alby Go.
 
 
-tip: Je kunt meerdere portemonnees aansluiten en op elk moment tussen de portemonnees wisselen.
+tip: Je kunt meerdere wallets aansluiten en op elk moment tussen de wallets wisselen.
 
 
 
 
-## gW-9 verzenden
+## ⚡ Bitcoin verzenden
 
 
-Om Sats over de Lightning Network te sturen:
+Om sats over het Lightning Network te sturen:
 
-1. Tik op de grote gele **Verstuur knop**.
+1. Tik op de grote gele **SEND knop**.
 
 2. Kies een van de volgende opties:
 
 
- - Scan een bliksem Invoice QR code
- - Een bliksem Invoice plakken vanaf het klembord
- - Handmatig een bliksem Address invoeren
+ - Scan een Lightning-invoice QR-code
+ - Plak een Lightning-invoice vanaf het klembord
+ - Handmatig een Lightning-adres invoeren
 
 
-Je kunt ook een ontvanger selecteren uit je Address Boek, waar je bliksemadressen kunt opslaan voor gemakkelijk hergebruik.
+Je kunt ook een ontvanger uit je adresboek selecteren, waar je Lightning-adressen kunt opslaan voor gemakkelijk hergebruik.
 
 
 
 
-## gW-16 ontvangen
+## 💸 Bitcoin ontvangen
 
 Sats ontvangen met Alby Go:
 
@@ -91,21 +91,21 @@ Sats ontvangen met Alby Go:
 2. Kies een van de volgende opties:
 
 
- - Deel je bliksem Address zoals weergegeven
- - Selecteer "Bedrag" om generate een bliksem Invoice met aangepaste bedragen te maken
- - Klik op "Redeem" om QR-codes te scannen die LNURL intrekken
+ - Deel je Lightning-adres zoals weergegeven
+ - Selecteer "Bedrag" om een Lightning-invoice met aangepast bedrag te maken
+ - Klik op "Redeem" om een afhaal LNRL QR-code te scannen 
 
 
-Zowel QR-codes als Invoice strings zijn beschikbaar voor het gemak van de verzender.
+Zowel QR-codes als invoice strings zijn beschikbaar voor het gemak van de verzender.
 
 
 
 
-## ga!
+## 🧳 Ga!
 
-Neem je Bitcoin overal mee naartoe.
+Neem je bitcoin overal mee naartoe.
 
-**Alby Go** is lichtgewicht, snel en makkelijk te gebruiken - perfect voor node operators en Bitcoiners onderweg.
+**Alby Go** is lichtgewicht, snel en makkelijk te gebruiken - perfect voor node-operators en Bitcoiners die onderweg ziin.
 
 Geen opgeblazen gevoel. Geen gedoe. Bliksemsnel.
 
@@ -115,12 +115,12 @@ Geen opgeblazen gevoel. Geen gedoe. Bliksemsnel.
 ## 🛠️ Extra functies
 
 
-- 🗺️ BTC Map (een uitgebreide lijst van handelaren die Bitcoin betalingen accepteren)
-- donker & lichtmodus
-- aangepaste valuta-invoer en rekenmachine
-- transactiegeschiedenis
-- gW-25 boek
-- portefeuilles toevoegen, verwijderen en exporteren
+- 🗺️ BTC Map (een uitgebreide lijst van handelaren die bitcoin betalingen accepteren)
+- 🌗 Donker & lichtmodus
+- 💱 Aangepaste valuta-invoer en rekenmachine
+- 🧾 Transactiegeschiedenis
+- 👥 Adresboek
+- 🧷 wallets toevoegen, verwijderen en exporteren
 
 
 **💡 Hulp nodig? **

--- a/tutorials/wallet/alby/nl.md
+++ b/tutorials/wallet/alby/nl.md
@@ -9,7 +9,7 @@ description: Browseruitbreiding voor Bitcoin en Lightning Network
 
 
 
-Betalingen steeds eenvoudiger maken met bitcoin is de uitdaging waar veel bedrijven in de sector voor staan. Alby onderscheidt zich met zijn Alby wallet extensie voor browsers. Deze extensie heeft als doel een vloeiend raamwerk op te zetten dat automatisch adressen detecteert en waarmee je frictieloze bitcoinbetalingen kunt doen. In deze tutorial ontdekken we de Alby extensie en testen we hoe deze betalingen vanuit de browser mogelijk maakt.
+Betalingen steeds eenvoudiger maken met bitcoin is de uitdaging waar veel bedrijven in de sector voor staan. Alby onderscheidt zich met zijn Alby wallet browserextensie. Deze extensie heeft als doel een vloeiende omkadering op te zetten dat automatisch adressen detecteert en waarmee je vlot bitcoinbetalingen kunt doen. In deze tutorial ontdekken we de Alby-extensie en testen we hoe deze betalingen vanuit de browser mogelijk maakt.
 
 
 
@@ -19,11 +19,11 @@ Betalingen steeds eenvoudiger maken met bitcoin is de uitdaging waar veel bedrij
 
 
 
-## Alby uitbreiding
+## Alby-extensie
 
 
 
-De Alby extensie is een hulpmiddel waarmee je webbrowser gemakkelijk en veilig kan communiceren met het Bitcoin netwerk en de Lightning Network laag. Het wordt gekenmerkt door drie aspecten:
+De Alby-extensie is een handige tool waarmee je webbrowser eenvoudig en veilig met het Bitcoin-netwerk en haar Lightning Network-laag kan communiceren. Het wordt gekenmerkt door drie aspecten:
 
 
 
@@ -42,11 +42,11 @@ https://planb.academy/tutorials/node/others/umbrel-nostr-7ae147e8-f5cd-46e1-861b
 
 
 
-In deze tutorial gebruiken we de Alby extensie in de Firefox browser onder een Ubuntu besturingssysteem. Het is echter ook beschikbaar op Windows en met browsers zoals Chrome.
+In deze tutorial gebruiken we de Alby-extensie in de Firefox browser onder een Ubuntu besturingssysteem. Het is echter ook beschikbaar op Windows en met browsers zoals Chrome.
 
 
 
-Je kunt de Alby extensie aan je browser toevoegen door de [Firefox] extensie store (https://addons.mozilla.org/fr/firefox/addon/alby/) of de [Chrome] extensie store (https://chromewebstore.google.com/detail/alby-bitcoin-wallet-for-l/iokeahhehimjnekafflcihljlcjccdbe) te bezoeken.
+Je kunt de Alby-extensie aan je browser toevoegen door de [Firefox] extensie store (https://addons.mozilla.org/fr/firefox/addon/alby/) of de [Chrome] extensie store (https://chromewebstore.google.com/detail/alby-bitcoin-wallet-for-l/iokeahhehimjnekafflcihljlcjccdbe) te bezoeken.
 
 
 
@@ -124,7 +124,7 @@ Log in op uw Alby account, of maak er een aan als u er nog geen heeft.
 
 
 
-Eenmaal ingelogd kun je op de Alby extensie in de werkbalk klikken om je portfolio te openen.
+Eenmaal ingelogd kun je op de Alby-extensie in de werkbalk klikken om je portfolio te openen.
 
 
 
@@ -174,7 +174,7 @@ Open verzendkanalen door het blokkeren van satoshis op een bitcoin onchain adres
 
 
 
-Je kunt nu satoshi's verzenden en ontvangen via de Alby extensie.
+Je kunt nu satoshi's verzenden en ontvangen via de Alby-extensie.
 
 
 
@@ -182,7 +182,7 @@ Je kunt nu satoshi's verzenden en ontvangen via de Alby extensie.
 
 
 
-Vanaf dit punt is de Alby extensie in staat om Lightning-adressen en facturen te detecteren die beschikbaar zijn op de webpagina's die je bezoekt, en zal ze je voorstellen om ze rechtstreeks vanuit je extensie te betalen in bitcoin of Lightning.
+Vanaf dit punt is de Alby-extensie in staat om Lightning-adressen en facturen te detecteren die beschikbaar zijn op de webpagina's die je bezoekt, en zal ze je voorstellen om ze rechtstreeks vanuit je extensie te betalen in bitcoin of Lightning.
 
 
 
@@ -199,7 +199,7 @@ Vanaf dit punt is de Alby extensie in staat om Lightning-adressen en facturen te
 
 
 
-De hoofdsleutel die wordt aangeboden door de Alby uitbreiding werkt als een beschermende overlay die u in staat stelt om veilig te communiceren met de hoofdlaag van het Bitcoin netwerk (Onchain), het Nostr systeem en stelt u in staat om de Lightning verbinding met Nostr toepassingen te activeren.
+De hoofdsleutel die wordt aangeboden door de Alby uitbreiding werkt als een beschermende overlay die u in staat stelt om veilig te communiceren met de hoofdlaag van het Bitcoin-netwerk (Onchain), het Nostr systeem en stelt u in staat om de Lightning verbinding met Nostr toepassingen te activeren.
 
 
 
@@ -218,7 +218,7 @@ https://planb.academy/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a
 
 
 
-U kunt nu wrijvingsloze bitcoin- en Lightning-betalingen ervaren met de Alby extensie. Als je deze tutorial leuk vond, raden we je onze Alby Hub tutorial aan om je eigen Alby node op te zetten en alle aspecten van je Alby wallets te beheren vanuit een soepele en krachtige interface.
+U kunt nu wrijvingsloze bitcoin- en Lightning-betalingen ervaren met de Alby-extensie. Als je deze tutorial leuk vond, raden we je onze Alby Hub tutorial aan om je eigen Alby node op te zetten en alle aspecten van je Alby wallets te beheren vanuit een soepele en krachtige interface.
 
 
 

--- a/tutorials/wallet/alby/nl.md
+++ b/tutorials/wallet/alby/nl.md
@@ -28,9 +28,9 @@ De Alby-extensie is een handige tool waarmee je webbrowser eenvoudig en veilig m
 
 
 
-- Lightning Network wallet: Koppel je Alby node of account om snel en goedkoop bitcoin te versturen en ontvangen via de Lightning Network laag.
-- Vloeiende betalingen via het web: Je hoeft geen QR-codes meer te scannen of te wisselen tussen applicaties voor bitcoinbetalingen op websites die Lightning ondersteunen. Het maakt soepele transacties mogelijk met één klik, of zonder bevestiging als je een budget hebt ingesteld.
-- Een Nostr manager: De extensie beheert je Nostr sleutels, waardoor het makkelijk is om verbinding te maken en te communiceren met Nostr applicaties als een veilige ondertekenaar, zonder je private sleutel bloot te stellen aan elk platform.
+- Lightning Network-wallet: Koppel je Alby-node of account om snel en goedkoop bitcoin te versturen en ontvangen via de Lightning Network-laag.
+- Vlotte betalingen via het web: Je hoeft geen QR-codes meer te scannen of te wisselen tussen applicaties voor bitcoinbetalingen op websites die Lightning ondersteunen. Het maakt soepele transacties mogelijk met één klik, of zonder bevestiging als je een budget hebt ingesteld.
+- Een Nostr-manager: De extensie beheert je Nostr-sleutels en fungeert als een veilige ondertekenaar. Zo verbind en communiceer je makkelijk met Nostr-applicaties, zonder dat je je privésleutel ooit hoeft bloot te stellen aan elk platform.
 
 
 
@@ -46,7 +46,7 @@ In deze tutorial gebruiken we de Alby-extensie in de Firefox browser onder een U
 
 
 
-Je kunt de Alby-extensie aan je browser toevoegen door de [Firefox] extensie store (https://addons.mozilla.org/fr/firefox/addon/alby/) of de [Chrome] extensie store (https://chromewebstore.google.com/detail/alby-bitcoin-wallet-for-l/iokeahhehimjnekafflcihljlcjccdbe) te bezoeken.
+Je kunt de Alby-extensie aan je browser toevoegen door de [Firefox] extensie-store (https://addons.mozilla.org/fr/firefox/addon/alby/) of de [Chrome] extensie-store (https://chromewebstore.google.com/detail/alby-bitcoin-wallet-for-l/iokeahhehimjnekafflcihljlcjccdbe) te bezoeken.
 
 
 
@@ -58,14 +58,14 @@ Je kunt de Alby-extensie aan je browser toevoegen door de [Firefox] extensie sto
 
 
 
-ℹ️ Het is belangrijk om te controleren of de auteur van de extensie inderdaad het officiële Alby account is, om elke vorm van piraterij of diefstal van je bitcoins te voorkomen.
+ℹ️ Het is belangrijk om te controleren of de auteur van de extensie inderdaad het officiële Alby-account is, om elke vorm van piraterij of diefstal van je bitcoins te voorkomen.
 
 
 
 Voeg de extensie toe aan je browser door op de knop rechts te klikken.
 
 
-Geef de nodige rechten om de extensie te installeren en te gebruiken en prik de extensie vast op de werkbalk zodat je deze gemakkelijk kunt terugvinden.
+Geef de extensie de nodige rechten om te installeren en te gebruiken en zet de extensie vast op de werkbalk zodat je deze gemakkelijk kunt terugvinden.
 
 
 
@@ -73,11 +73,11 @@ Geef de nodige rechten om de extensie te installeren en te gebruiken en prik de 
 
 
 
-U moet ook een ontgrendelingscode instellen (erg belangrijk), die veilige toegang tot uw Lightning wallet vanaf uw browser garandeert. We raden je aan een sterk alfanumeriek wachtwoord in te stellen.
+Je moet ook een ontgrendelingscode (passcode) instellen (erg belangrijk), die veilige toegang tot je Lightning-wallet vanaf je browser garandeert. We raden je aan een sterk alfanumeriek wachtwoord in te stellen.
 
 
 
-ℹ️ Bewaar dit wachtwoord op een veilige plaats zodat u het kunt raadplegen als u het vergeet, want het kan worden gewijzigd maar niet worden teruggehaald.
+ℹ️ Bewaar dit wachtwoord op een veilige plek zodat je het kunt raadplegen als je het vergeet. Het kan namelijk wel worden gewijzigd, maar niet worden hersteld.
 
 
 
@@ -92,8 +92,8 @@ Alby toont zijn aanpassingsvermogen door je twee keuzes te bieden:
 
 
 
-- Ga door met een Alby account als je wilt genieten van de toepassingen terwijl je controle houdt over je bitcoins.
-- Sluit je eigen wallet of Lightning node aan als je er al een hebt die door de extensie wordt ondersteund.
+- Ga door met een Alby-account als je toepassingen wilt gebruiken  terwijl je de controle over je bitcoins behoudt.
+- Sluit je eigen wallet of Lightning-node aan als je er al een hebt die door de extensie wordt ondersteund.
 
 
 
@@ -104,7 +104,7 @@ https://planb.academy/tutorials/node/lightning-network/lightning-network-daemon-
 https://planb.academy/tutorials/business/point-of-sale/btcpay-server-928eb01e-824b-4b57-a3e8-8727633beddc
 
 
-In deze tutorial kiezen we ervoor om door te gaan met het Alby account om te profiteren van de mogelijkheden van het Alby ecosysteem.
+In deze tutorial kiezen we ervoor om door te gaan met het Alby-account, zodat we kunnen profiteren van de mogelijkheden van het Alby-ecosysteem.
 
 
 
@@ -112,7 +112,7 @@ https://planb.academy/tutorials/wallet/mobile/alby-go-40202802-b346-4a3c-9863-46
 
 https://planb.academy/tutorials/node/lightning-network/alby-hub-62e6356c-6a6d-4134-8f22-c3b6afb9882a
 
-Log in op uw Alby account, of maak er een aan als u er nog geen heeft.
+Log in op je Alby-account, of maak er een aan als je er nog geen hebt.
 
 
 
@@ -124,7 +124,7 @@ Log in op uw Alby account, of maak er een aan als u er nog geen heeft.
 
 
 
-Eenmaal ingelogd kun je op de Alby-extensie in de werkbalk klikken om je portfolio te openen.
+Eenmaal ingelogd kun je op de Alby-extensie in de werkbalk klikken om je wallet te openen.
 
 
 
@@ -132,7 +132,7 @@ Eenmaal ingelogd kun je op de Alby-extensie in de werkbalk klikken om je portfol
 
 
 
-Zodra je een Alby account hebt aangemaakt, moet je het verbinden met een wallet om satoshis te kunnen uitgeven. Om de bitcoin wallet aan je Alby account te koppelen, raden we je aan een Alby Hub node te gebruiken, die je op je computer kunt installeren of je kunt abonneren op een plan dat Alby aanbiedt.
+Zodra je een Alby-account hebt aangemaakt, moet je het verbinden aan een wallet om satoshis te kunnen uitgeven. Om de bitcoin-wallet aan je Alby-account te koppelen, raden we je aan een Alby Hub-node te gebruiken. Deze kun je op je computer installeren of je kunt je abonneren op een plan dat Alby aanbiedt.
 
 
 
@@ -141,16 +141,16 @@ Zodra je een Alby account hebt aangemaakt, moet je het verbinden met een wallet 
 
 
 
-In deze tutorial wordt ons Alby account ondersteund door een lokale installatie op onze machine.
+In deze tutorial wordt ons Alby-account ondersteund door een lokale installatie op onze machine.
 
 
-Om je eigen Alby node te bouwen, raden we je onze Alby Hub tutorial aan.
+Om je eigen Alby-node te bouwen, raden we je onze Alby Hub tutorial aan.
 
 
 
 https://planb.academy/tutorials/node/lightning-network/alby-hub-62e6356c-6a6d-4134-8f22-c3b6afb9882a
 
-Met dit knooppunt kun je zelfgemaakte Lightning-portefeuilles maken en je Lightning-kanalen voor het verzenden en ontvangen van satoshi's efficiënt beheren.
+Met deze node kun je zelfgemaakte Lightning-wallets maken en je Lightning-kanalen voor het verzenden en ontvangen van satoshi's efficiënt beheren.
 
 
 
@@ -158,7 +158,7 @@ Met dit knooppunt kun je zelfgemaakte Lightning-portefeuilles maken en je Lightn
 
 
 
-Open ontvangstkanalen die het totale aantal satoshi's bepalen dat je kunt ontvangen.
+Open ontvangstkanalen; deze bepalen het totale aantal satoshis dat je kunt ontvangen.
 
 
 
@@ -166,7 +166,7 @@ Open ontvangstkanalen die het totale aantal satoshi's bepalen dat je kunt ontvan
 
 
 
-Open verzendkanalen door het blokkeren van satoshis op een bitcoin onchain adres. De geblokkeerde satoshis bepalen het totaal aan satoshis dat je kunt uitgeven.
+Open verzendkanalen door satoshis te blokkeren op een onchain bitcoin-adres. De geblokkeerde satoshis bepalen het toaal aan satoshis dat je kunt uitgeven.
 
 
 
@@ -174,7 +174,7 @@ Open verzendkanalen door het blokkeren van satoshis op een bitcoin onchain adres
 
 
 
-Je kunt nu satoshi's verzenden en ontvangen via de Alby-extensie.
+Je kunt nu satoshis verzenden en ontvangen via de Alby-extensie.
 
 
 
@@ -182,7 +182,7 @@ Je kunt nu satoshi's verzenden en ontvangen via de Alby-extensie.
 
 
 
-Vanaf dit punt is de Alby-extensie in staat om Lightning-adressen en facturen te detecteren die beschikbaar zijn op de webpagina's die je bezoekt, en zal ze je voorstellen om ze rechtstreeks vanuit je extensie te betalen in bitcoin of Lightning.
+Vanaf dit punt kan de Alby-extensie Lightning-adressen en facturen detecteren op de webpagina's die je bezoekt. Vervolgens zal de extensie je voorstellen om deze rechtstreeks met bitcoin of Lightning te betalen.
 
 
 
@@ -199,7 +199,7 @@ Vanaf dit punt is de Alby-extensie in staat om Lightning-adressen en facturen te
 
 
 
-De hoofdsleutel die wordt aangeboden door de Alby uitbreiding werkt als een beschermende overlay die u in staat stelt om veilig te communiceren met de hoofdlaag van het Bitcoin-netwerk (Onchain), het Nostr systeem en stelt u in staat om de Lightning verbinding met Nostr toepassingen te activeren.
+De hoofdsleutel die wordt aangeboden door de Alby-extensie werkt als een beschermende laag. Hiermee kun je veilig communiceren met de hoofdlaag van het Bitcoin-netwerk (onchain) en het Nostr-systeem, en maakt het mogelijk de Lightning-verbinding met Nostr-toepassingen te activeren.
 
 
 
@@ -218,7 +218,7 @@ https://planb.academy/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a
 
 
 
-U kunt nu wrijvingsloze bitcoin- en Lightning-betalingen ervaren met de Alby-extensie. Als je deze tutorial leuk vond, raden we je onze Alby Hub tutorial aan om je eigen Alby node op te zetten en alle aspecten van je Alby wallets te beheren vanuit een soepele en krachtige interface.
+Je kan nu frictieloze bitcoin- en Lightning-betalingen ervaren met de Alby-extensie. Als je deze tutorial leuk vond, raden we je onze Alby Hub-tutorial aan om je eigen Alby-node op te zetten en alle aspecten van je Alby-wallets te beheren vanuit een soepele en krachtige interface.
 
 
 

--- a/tutorials/wallet/aqua/nl.md
+++ b/tutorials/wallet/aqua/nl.md
@@ -1,44 +1,44 @@
 ---
 name: Aqua
-description: Bitcoin, Lightning en Liquid in één Wallet
+description: Bitcoin, Lightning en Liquid in één wallet
 ---
 ![cover](assets/cover.webp)
 
 
-Aqua is een mobiele applicatie die het eenvoudig maakt om een Hot Wallet te maken voor Bitcoin en Liquid, en biedt ook de mogelijkheid om Lightning te gebruiken zonder de complexiteit van het beheren van een node, dankzij geïntegreerde swaps. Het maakt het ook mogelijk om USDT stablecoins te beheren op verschillende netwerken.
+Aqua is een mobiele applicatie die het eenvoudig maakt om een hot wallet te maken voor Bitcoin en Liquid. Dankzij geïntegreerde swaps biedt de app ook de mogelijkheid om Lightning te gebruiken zonder de complexiteit van het beheren van een node. Bovendien kun je er USDT-stablecoins mee beheren op verschillende netwerken.
 
 
-De Aqua app, ontwikkeld door het bedrijf JAN3 onder leiding van Samson Mow, is in eerste instantie specifiek ontworpen voor de behoeften van gebruikers in Latijns-Amerika, hoewel hij geschikt is voor elke gebruiker wereldwijd. De app is vooral interessant voor beginners en mensen die Bitcoin dagelijks gebruiken voor hun betalingen.
+De Aqua-app, ontwikkeld door het bedrijf JAN3 onder leiding van Samson Mow, is in eerste instantie specifiek ontworpen voor de behoeften van gebruikers in Latijns-Amerika, hoewel de app wereldwijd voor iedereen geschikt is. De app is vooral interessant voor beginners en mensen die Bitcoin dagelijks gebruiken voor hun betalingen.
 
 
-In deze tutorial gaan we uitzoeken hoe we de vele functies van Aqua kunnen gebruiken. Maar voordat we dat doen, nemen we even de tijd om te begrijpen wat een Sidechain is op Bitcoin en hoe Liquid werkt, zodat we de waarde van Aqua volledig kunnen begrijpen.
+In deze tutorial gaan we uitzoeken hoe je de vele functies van Aqua kunt gebruiken. Maar voordat we dat doen, nemen we even de tijd om te begrijpen wat een Bitcoin-sidechain is en hoe Liquid werkt, zodat je de waarde van Aqua volledig kunt begrijpen.
 
 
 ![AQUA](assets/fr/01.webp)
 
 
-## Wat is een Sidechain?
+## Wat is een sidechain?
 
 
-Het Bitcoin protocol heeft opzettelijke technische beperkingen die helpen om de decentralisatie van het netwerk te behouden en om ervoor te zorgen dat de veiligheid verdeeld wordt over alle gebruikers. Deze beperkingen kunnen gebruikers echter soms frustreren, vooral tijdens congestie als gevolg van een hoog volume aan gelijktijdige transacties. Het debat over de schaalbaarheid van Bitcoin heeft de gemeenschap lang verdeeld, vooral tijdens de Blocksize War. Sinds deze episode wordt algemeen erkend binnen de Bitcoin gemeenschap dat de schaalbaarheid verzekerd moet worden door off-chain oplossingen, op tweede Layer systemen. Deze oplossingen omvatten sidechains, die nog relatief onbekend zijn en weinig gebruikt worden in vergelijking met andere systemen zoals de Lightning Network.
+Het Bitcoin-protocol heeft opzettelijke technische beperkingen die helpen de decentralisatie van het netwerk te behouden en de veiligheid over alle gebruikers te verdelen. Deze beperkingen kunnen voor gebruikers soms echter frustrerend zijn, vooral tijdens congestieperioden als gevolg van een hoog volume aan gelijktijdige transacties. Het debat over de schaalbaarheid van Bitcoin heeft de gemeenschap lang verdeeld gehouden, met name tijdens de Blocksize War. Sinds deze episode wordt binnen de Bitcoin-gemeenschap algemeen aanvaard dat schaalbaarheid door off-chain oplossingen, oftewel second-layer-systemen, moet worden verzekers. Deze oplossingen omvatten sidechains, die nog relatief onbekend zijn en in vergelijking met andere systemen zoals het Lightning Network weinig gebruikt worden.
 
 
-Een Sidechain is een onafhankelijke Blockchain die parallel aan de hoofd Bitcoin Blockchain werkt. Het gebruikt Bitcoin als rekeneenheid, dankzij een mechanisme genaamd "*two-way peg*". Dit systeem maakt het mogelijk om bitcoins vast te zetten op de hoofdketen om hun waarde te reproduceren op de Sidechain, waar ze circuleren in de vorm van tokens die worden ondersteund door de originele bitcoins. Deze tokens behouden normaal gesproken dezelfde waarde als de bitcoins die op de hoofdketen zijn vergrendeld, en het proces kan worden omgekeerd om geld terug te krijgen op Bitcoin.
+Een sidechain is een onafhankelijke blockchain die parallel aan de hoofd-Bitcoin-blockchain werkt. Het gebruikt bitcoin als rekeneenheid, dankzij een mechanisme genaamd "*two-way peg*". Dit systeem maakt het mogelijk om bitcoins vast te zetten op de hoofdketen om hun waarde te reproduceren op de sidechain, waar ze circuleren in de vorm van tokens die gedekt worden door de originele bitcoins. Deze tokens behouden normaal gesproken dezelfde waarde als de bitcoins die op de hoofdketen zijn vergrendeld, en het proces kan worden omgekeerd om geld terug te krijgen op Bitcoin.
 
 
-Het doel van sidechains is om extra functionaliteiten of technische verbeteringen te bieden, zoals snellere transacties, lagere kosten of ondersteuning voor slimme contracten. Deze innovaties kunnen niet altijd direct op Bitcoin geïmplementeerd worden zonder de decentralisatie of veiligheid in gevaar te brengen. Sidechains maken het daarom mogelijk om nieuwe oplossingen te testen en te onderzoeken, terwijl de integriteit van Bitcoin behouden blijft. Deze protocollen vereisen echter vaak compromissen, vooral op het gebied van decentralisatie en veiligheid, afhankelijk van het gekozen bestuursmodel en consensusmechanisme.
+Het doel van sidechains is om extra functionaliteiten of technische verbeteringen te bieden, zoals snellere transacties, lagere kosten of ondersteuning voor smart contracts (slimme contracten). Deze innovaties kunnen niet altijd direct op Bitcoin geïmplementeerd worden zonder de decentralisatie of veiligheid in gevaar te brengen. Sidechains maken het daarom mogelijk om nieuwe oplossingen te testen en te verkennen, terwijl de integriteit van Bitcoin behouden blijft. Deze protocollen vereisen echter vaak compromissen, vooral op het gebied van decentralisatie en veiligheid, afhankelijk van het gekozen bestuursmodel en consensusmechanisme.
 
 
 ## Wat is Liquid?
 
 
-Liquid is een gefedereerde Sidechain overlay voor Bitcoin, ontwikkeld door Blockstream om de transactiesnelheid, privacy en functionaliteit te verbeteren. Het maakt gebruik van een bilateraal verankeringsmechanisme op een federatie om bitcoins op de hoofdketen te vergrendelen en in ruil daarvoor Liquid-bitcoins (L-BTC) te creëren, tokens die circuleren op Liquid terwijl ze ondersteund blijven door de oorspronkelijke bitcoins.
+Liquid is een gefedereerde sidechain-laag voor Bitcoin, ontwikkeld door Blockstream om de transactiesnelheid, privacy en functionaliteit te verbeteren. Het maakt gebruik van een bilateraal verankeringsmechanisme op een federatie om bitcoins op de hoofdketen te vergrendelen en in ruil daarvoor Liquid-bitcoins (L-BTC) te creëren. Dit zijn tokens die circuleren op Liquid terwijl ze gedekt blijven door de oorspronkelijke bitcoins.
 
 
 ![AQUA](assets/fr/02.webp)
 
 
-Liquid Network vertrouwt op een federatie van deelnemers, bestaande uit erkende entiteiten uit het Bitcoin ecosysteem, die blokken valideren en bilaterale pegging beheren. Naast L-BTC maakt Liquid ook de uitgifte van andere digitale activa mogelijk, zoals USDT stablecoin en andere cryptocurrencies.
+Liquid Network vertrouwt op een federatie van deelnemers, bestaande uit erkende entiteiten uit het Bitcoin-ecosysteem, die blokken valideren en bilaterale pegging beheren. Naast L-BTC maakt Liquid ook de uitgifte van andere digitale activa mogelijk, zoals USDT stablecoin en andere cryptocurrencies.
 
 
 ![AQUA](assets/fr/03.webp)
@@ -47,7 +47,7 @@ Liquid Network vertrouwt op een federatie van deelnemers, bestaande uit erkende 
 ## De Aqua-toepassing installeren
 
 
-De eerste stap is natuurlijk het downloaden van de Aqua applicatie. Ga naar je applicatiewinkel:
+De eerste stap is natuurlijk het downloaden van de Aqua-applicatie. Ga naar de app store van je telefoon:
 
 
 
@@ -69,34 +69,34 @@ Start de applicatie en vink het vakje "*Ik heb de Servicevoorwaarden en het Priv
 ![AQUA](assets/fr/06.webp)
 
 
-## Maak uw Wallet op Aqua
+## Maak je wallet aan op Aqua
 
 
-Klik op de knop "*Creëer Wallet*".
+Klik op de knop "*Create wallet*".
 
 
 ![AQUA](assets/fr/07.webp)
 
 
-En voilà, je Wallet is al gemaakt!
+En voilà, je wallet is al aangemaakt!
 
 
 ![AQUA](assets/fr/08.webp)
 
 
-Maar allereerst, aangezien dit een zelfbewaarnemende Wallet is, is het noodzakelijk om een fysieke back-up van je Mnemonic te maken. **Deze Mnemonic geeft je volledige, onbeperkte toegang tot al je bitcoins**. Iedereen die in het bezit is van deze Mnemonic kan je fondsen stelen, zelfs zonder fysieke toegang tot je telefoon.
+Maar allereerst: aangezien dit een self-custodial wallet is, is het essentieel om een fysieke back-up van je mnemonische zin (seed phrase) te maken. **Deze zin geeft je volledige, onbeperkte toegang tot al je bitcoins**. Iedereen die in het bezit is van deze zin kan je fondsen stelen, zelfs zonder fysieke toegang tot je telefoon.
 
 
-Hiermee kun je weer toegang krijgen tot je bitcoins in geval van verlies, diefstal of breuk van je telefoon. Het is daarom erg belangrijk om het zorgvuldig op te slaan op een fysieke drager (niet digitaal) en het op een veilige locatie te bewaren. Je kunt het opschrijven op een stuk papier, of voor extra veiligheid, als dit een grote Wallet is, zou ik aanraden om het te graveren op een roestvrijstalen steun om het te beschermen tegen het risico van brand, overstroming of instorting (voor een Hot die is ontworpen om een kleine hoeveelheid bitcoins te beveiligen, is een eenvoudige back-up op papier waarschijnlijk voldoende).
+Hiermee kun je de toegang tot je bitcoins herstellen in geval van verlies, diefstal of een defecte telefoon. Het is daarom cruciaal om het zorgvuldig op te slaan op een fysieke drager (niet digitaal) en het op een veilige locatie te bewaren. Je kunt de zin opschrijven op een stuk papier of, voor extra veiligheid als dit een grote wallet is, zou ik aanraden om hem in roestvrij staal te graveren om hem te beschermen tegen het risico van brand, overstroming of instorting. (Voor een hot wallet die is ontworpen om een kleine hoeveelheid bitcoins te beveiligen, is een eenvoudige back-up op papier waarschijnlijk voldoende.)
 
 
-Klik hiervoor op het menu Instellingen.
+Klik hiervoor op het menu "*Settings*".
 
 
 ![AQUA](assets/fr/09.webp)
 
 
-Klik dan op "*View seed Phrase*". Maak een fysieke back-up van deze 12-woorden zin.
+Klik dan op "*View Seed Phrase*". Maak een fysieke back-up van deze 12-woorden zin.
 
 
 ![AQUA](assets/fr/10.webp)
@@ -108,18 +108,18 @@ In hetzelfde instellingenmenu kun je ook de taal van de applicatie en de gebruik
 ![AQUA](assets/fr/11.webp)
 
 
-Voordat je je eerste bitcoins ontvangt in je Wallet, **raad ik je sterk aan om een lege hersteltest uit te voeren**. Maak een notitie van wat referentie-informatie, zoals je xpub of de eerste Address die je ontvangt, wis dan je Wallet op de Aqua app terwijl hij nog leeg is. Probeer dan je Wallet op Aqua te herstellen met je papieren back-ups. Controleer of de cookie-informatie die na het herstellen wordt gegenereerd, overeenkomt met de informatie die je oorspronkelijk hebt opgeschreven. Als dat zo is, kunt u er zeker van zijn dat uw papieren back-ups betrouwbaar zijn. Om meer te weten te komen over hoe je een testherstel uitvoert, kun je deze andere tutorial raadplegen:
+Voordat je je eerste bitcoins ontvangt in je wallet, **raad ik je sterk aan om een lege hersteltest uit te voeren**. Noteer enkele referentiegegevens, zoals je xpub of het eerste ontvangstadres, wis dan je wallet op de Aqua-app terwijl hij nog leeg is. Probeer dan je wallet in Aqua te herstellen met je papieren back-ups. Controleer of de gegenereerde gegevens na het herstellen overeenkomen met de informatie die je oorspronkelijk hebt opgeschreven. Als dat zo is, kun je er zeker van zijn dat je papieren back-ups betrouwbaar zijn. Voor meer informatie over het uitvoeren van een testherstel kun je deze andere tutorial raadplegen:
 
 
 https://planb.academy/tutorials/wallet/backup/recovery-test-5a75db51-a6a1-4338-a02a-164a8d91b895
 
-Je kunt het niet zien op mijn scherm omdat ik een emulator gebruik, maar in de instellingen vind je een optie om de app te vergrendelen met een biometrisch authenticatiesysteem. Ik raad ten zeerste aan om deze beveiligingsfunctie in te schakelen, omdat zonder deze functie iedereen met toegang tot je ontgrendelde telefoon je bitcoins kan stelen. Je kunt Face ID gebruiken op iOS of je vingerafdruk op Android. Als deze methoden mislukken tijdens de verificatie, kun je nog steeds toegang krijgen tot de app met behulp van de PIN-code van je telefoon.
+Je kunt het op mijn scherm niet zien omdat ik een emulator gebruik, maar in de instellingen vind je een optie om de app te vergrendelen met een biometrisch authenticatiesysteem. Ik raad ten zeerste aan om deze beveiligingsfunctie in te schakelen, omdat iedereen met toegang tot je ontgrendelde telefoon anders je bitcoins kan stelen. Je kunt Face ID gebruiken op iOS of je vingerafdruk op Android. Als deze methoden mislukken tijdens de verificatie, kun je nog steeds toegang krijgen tot de app met behulp van de PIN-code van je telefoon.
 
 
 ## Bitcoins ontvangen op Aqua
 
 
-Nu je Wallet is ingesteld, ben je klaar om je eerste Sats te ontvangen! Klik gewoon op de knop "*Ontvangen*" in het menu "*Wallet*".
+Nu je wallet is ingesteld, ben je klaar om je eerste sats te ontvangen! Klik gewoon op de knop "*Receive*" in het menu "*Wallet*".
 
 
 ![AQUA](assets/fr/12.webp)
@@ -131,13 +131,13 @@ Je kunt ervoor kiezen om bitcoins onchain, op Liquid of via Lightning te ontvang
 ![AQUA](assets/fr/13.webp)
 
 
-Voor onchain-transacties zal Aqua generate een specifieke ontvangende Address zijn, waar je je Sats kunt ontvangen.
+Voor onchain-transacties zal Aqua een specifieke ontvangstadres aanmaken, waar je je sats kunt ontvangen.
 
 
 ![AQUA](assets/fr/14.webp)
 
 
-Op dezelfde manier, als je Liquid, Aqua kiest, krijg je een Liquid Address.
+Op dezelfde manier, als je Liquid kiest, dan krijg je van Aqua een Liquid-adres.
 
 
 ![AQUA](assets/fr/15.webp)
@@ -149,25 +149,25 @@ Als je liever geld ontvangt via Lightning, moet je eerst het gewenste bedrag opg
 ![AQUA](assets/fr/16.webp)
 
 
-Klik dan op "*generate Invoice*".
+Klik dan op "*Generate Invoice*".
 
 
 ![AQUA](assets/fr/17.webp)
 
 
-Aqua zal een Invoice aanmaken om fondsen te ontvangen van een Lightning Wallet. Merk op dat, in tegenstelling tot de onchain en Liquid opties, fondsen ontvangen via Lightning automatisch worden omgezet naar L-BTC op Liquid met behulp van de Boltz tool, aangezien Aqua geen Lightning node is. Met dit proces kunt u fondsen ontvangen en verzenden via Lightning, maar zonder ooit uw bitcoins op Lightning op te slaan.
+Aqua zal een invoice aanmaken om fondsen te ontvangen van een Lightning-wallet. Merk op dat, in tegenstelling tot de onchain- en Liquid-opties, fondsen die via Lightning ontvangen automatisch worden omgezet naar L-BTC op Liquid met behulp van de Boltz-tool, omdat Aqua geen Lightning-node heeft. Met dit proces kan je geld ontvangen en verzenden via Lightning, maar zonder ooit je bitcoins op Lightning op te slaan.
 
 
 ![AQUA](assets/fr/18.webp)
 
 
-Persoonlijk begin ik met het versturen van bitcoins via Lightning naar Aqua. Zodra de transactie met de Invoice is voltooid, ontvangen we een bevestiging.
+Persoonlijk begin ik met het versturen van bitcoins via Lightning naar Aqua. Zodra de transactie met de invoice is voltooid, ontvangen we een bevestiging.
 
 
 ![AQUA](assets/fr/19.webp)
 
 
-Om de voortgang van de swap te volgen, ga je terug naar de startpagina van je Wallet en klik je op het "*L2 Bitcoin*" account, waar Lightning (via swap) en Liquid transacties staan.
+Om de voortgang van de swap te volgen, ga je terug naar de startpagina van je wallet en klik je op het "*L2 Bitcoin*" account, waar Lightning (via swap) en Liquid-transacties staan.
 
 
 ![AQUA](assets/fr/20.webp)
@@ -179,10 +179,10 @@ Hier kun je je transactie en je L-BTC saldo bekijken.
 ![AQUA](assets/fr/21.webp)
 
 
-## Bitcoin ruilen met Aqua
+## Bitcoin omwisseling (swap) met Aqua
 
 
-Nu je activa hebt in je Aqua Wallet, kun je ze direct vanuit de app omwisselen, ofwel om ze over te zetten naar de hoofd Bitcoin Blockchain, of naar Liquid. Je kunt ook Bitcoins omwisselen naar USDT stablecoin (of andere). Je kunt ook je bitcoins omzetten in USDT stablecoin (of andere). Ga hiervoor naar het menu "*Marktplaats*".
+Nu je activa hebt in je Aqua-wallet, kun je deze direct vanuit de app omwisselen. Dit kun je doen om ze over te zetten naar de Bitcoin-blockchain, of naar Liquid, of om je bitcoins om te wisselen naar een USDT-stablecoin (of andere). Je kunt ook je bitcoins omzetten in USDT stablecoin (of andere). Ga hiervoor naar het menu "*Marketplace*".
 
 
 ![AQUA](assets/fr/22.webp)
@@ -194,13 +194,13 @@ Klik op "*Swaps*".
 ![AQUA](assets/fr/23.webp)
 
 
-Selecteer in het vak "*Omzetten van*" de activa die je wilt verhandelen. Momenteel bezit ik alleen L-BTC, dus dat selecteer ik.
+Selecteer in het vak "*Transfer from*" de activa die je wilt verhandelen. Momenteel bezit ik alleen L-BTC, dus dat selecteer ik.
 
 
 ![AQUA](assets/fr/24.webp)
 
 
-Kies in het vak "*Transfer to*" de doelactiva voor je swap. Ik koos voor USDT op de Liquid Network.
+Kies in het vak "*Transfer to*" de doelactiva voor je swap. Ik koos voor USDT op het Liquid Network.
 
 
 ![AQUA](assets/fr/25.webp)
@@ -212,7 +212,7 @@ Voer het bedrag in dat je wilt converteren.
 ![AQUA](assets/fr/26.webp)
 
 
-Bevestig door op "*Doorgaan*" te klikken.
+Bevestig door op "*Continue*" te klikken.
 
 
 ![AQUA](assets/fr/27.webp)
@@ -230,7 +230,7 @@ Je ruil is nu bevestigd.
 ![AQUA](assets/fr/29.webp)
 
 
-Als we terugkijken naar onze Wallet, zien we dat we nu USDT op Liquid hebben.
+Als we terugkijken naar onze wallet, zien we dat we nu USDT op Liquid hebben.
 
 
 ![AQUA](assets/fr/30.webp)
@@ -239,31 +239,31 @@ Als we terugkijken naar onze Wallet, zien we dat we nu USDT op Liquid hebben.
 ## Bitcoins versturen met Aqua
 
 
-Nu je bitcoins in je Aqua Wallet hebt, kun je ze versturen. Klik op de knop "*Versturen*".
+Nu je bitcoins in je Aqua-wallet hebt, kun je ze versturen. Klik op de knop "*Send*".
 
 
 ![AQUA](assets/fr/31.webp)
 
 
-Kies de activa die je wilt verzenden of selecteer het netwerk om de transactie uit te voeren. Voor mijn part ga ik bitcoins versturen via Lightning.
+Kies de activa die je wilt verzenden of selecteer het netwerk om de transactie uit te voeren. Ik ga bijvoorbeeld bitcoins versturen via Lightning.
 
 
 ![AQUA](assets/fr/32.webp)
 
 
-Voer vervolgens de informatie in die nodig is om de betaling te verzenden: voor onchain of Liquid bitcoins moet u een ontvangende Address invoeren; voor Lightning is een Invoice vereist. U kunt deze informatie rechtstreeks in het daarvoor bestemde veld plakken, of het QR-codepictogram gebruiken om uw camera te openen en de Address of Invoice te scannen. Klik vervolgens op "*Doorgaan*".
+Voer vervolgens de benodigde informatie in om de betaling te verzenden: voor onchain- of Liquid-bitcoins moet je een ontvangstadres invoeren; voor Lightning is een invoice vereist. Je kunt deze informatie rechtstreeks in het daarvoor bestemde veld plakken, of het QR-codepictogram gebruiken om je camera te openen en het invoice-adres te scannen. Klik vervolgens op "*Continue*".
 
 
 ![AQUA](assets/fr/33.webp)
 
 
-Klik opnieuw op "*Doorgaan*" als alle informatie correct lijkt.
+Klik opnieuw op "*Continue*" als alle informatie correct lijkt.
 
 
 ![AQUA](assets/fr/34.webp)
 
 
-Aqua toont je vervolgens een samenvatting van de transactie. Controleer of alle informatie correct is, inclusief de Address bestemming, kosten en bedrag. Om de transactie te bevestigen, schuif je op de knop "*Slide to send*" onderaan het scherm.
+Aqua toont je vervolgens een samenvatting van de transactie. Controleer of alle informatie correct is, inclusief het bestemmingadres, kosten en bedrag. Om de transactie te bevestigen, schuif je op de knop "*Slide to send*" onderaan het scherm.
 
 
 ![AQUA](assets/fr/35.webp)
@@ -275,13 +275,13 @@ Je ontvangt dan een bevestiging van de verzending.
 ![AQUA](assets/fr/36.webp)
 
 
-Nu weet je dus hoe je de Aqua app kunt gebruiken om geld te ontvangen en uit te geven op Bitcoin, Lightning en Liquid, allemaal vanaf één Interface.
+Nu weet je dus hoe je de Aqua-app kunt gebruiken om geld te ontvangen en uit te geven op Bitcoin, Lightning en Liquid, allemaal vanaf één interface.
 
 
-Als je deze tutorial nuttig vond, zou ik je dankbaar zijn als je hieronder een Green duim achterlaat. Voel je vrij om dit artikel te delen op je sociale netwerken. Hartelijk dank!
+Als je deze tutorial nuttig vond, zou ik je dankbaar zijn als je hieronder een groene duim achterlaat. Voel je vrij om dit artikel te delen op je sociale netwerken. Hartelijk dank!
 
 
-Ik raad je ook aan deze andere uitgebreide tutorial over de Blockstream Green mobiele app te bekijken, wat een andere interessante oplossing is voor het instellen van je Liquid Wallet :
+Ik raad je ook aan deze andere uitgebreide tutorial over de Blockstream Green mobiele app te bekijken, wat een andere interessante oplossing is voor het instellen van je Liquid-wallet:
 
 
 https://planb.academy/tutorials/wallet/mobile/blockstream-app-liquid-b3e4fb82-902e-4782-ad2b-a61ab05a543a

--- a/tutorials/wallet/blue-wallet/nl.md
+++ b/tutorials/wallet/blue-wallet/nl.md
@@ -30,7 +30,7 @@ Blue Wallet is een open source, self-custodial Bitcoin-wallet waarmee je control
 
 
 
-⚠️ Zorg ervoor dat je de Blue Wallet bitcoin-wallet applicatie downloadt op een officieel platform om de echtheid ervan te garanderen en je bitcoins te beschermen tegen mogelijke lekken en hacks.
+⚠️ Zorg ervoor dat je de Blue Wallet Bitcoin-wallet app downloadt op een officieel platform om de echtheid ervan te garanderen en je bitcoins te beschermen tegen mogelijke lekken en hacks.
 
 
 
@@ -40,7 +40,7 @@ Eenmaal geïnstalleerd, kun je een nieuwe wallet aanmaken en de 12 herstelwoorde
 
 https://planb.academy/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-Met Blue Wallet kun je aparte, speciale bitcoin-wallets aanmaken. Je kunt bijvoorbeeld een wallet hebben voor je spaargeld en een andere voor je dagelijkse uitgaven, allemaal binnen dezelfde applicatie.
+Met Blue Wallet kun je aparte, speciale Bitcoin-wallets aanmaken. Je kunt bijvoorbeeld een wallet hebben voor je spaargeld en een andere voor je dagelijkse uitgaven, allemaal binnen dezelfde applicatie.
 
 
 
@@ -69,11 +69,11 @@ https://planb.academy/tutorials/wallet/mobile/phoenix-0f681345-abff-4bdc-819c-4a
 
 https://planb.academy/tutorials/wallet/mobile/aqua-8e6d7dd3-8c03-45cc-90dd-fe3899a7d125
 
-Blue Wallet's bitcoin-wallet vertegenwoordigt de standaard-wallet in het Bitcoin-ecosysteem. Je kunt bitcoins uitgeven zolang je in het bezit bent van de herstelwoorden die zorgen voor een geldige handtekening op het netwerk om te verifiëren dat je de bitcoins bezit.
+Blue Wallet's Bitcoin-wallet vertegenwoordigt de standaard-wallet in het Bitcoin-ecosysteem. Je kunt bitcoins uitgeven zolang je in het bezit bent van de herstelwoorden die zorgen voor een geldige handtekening op het netwerk om te verifiëren dat je de bitcoins bezit.
 
 
 
-Om een bitcoin-wallet aan te maken, klik je op de knop **Add now**, voer je de naam van je wallet in en kies je het Bitcoin-type.
+Om een Bitcoin-wallet aan te maken, klik je op de knop **Add now**, voer je de naam van je wallet in en kies je het Bitcoin-type.
 
 
 
@@ -85,17 +85,17 @@ Als je op de voorbeeldweergave van je Bitcoin-wallet klikt, kun je je transactie
 
 
 
-⚠️ Alle transacties in je bitcoin-wallet vinden plaats op de hoofdketen van het Bitcoin-protocol (Mainnet).
+⚠️ Alle transacties in je Bitcoin-wallet vinden plaats op de hoofdketen van het Bitcoin-protocol (Mainnet).
 
 
 
 
 
-- Bitcoins ontvangen met de Blue Wallet bitcoin-wallet is intuïtief. Klik onderaan op de knop **Receive**. Deel de QR-code of je Bitcoin-adres met je afzender, zodat hij je de bitcoins kan sturen.
+- Bitcoins ontvangen met de Blue Wallet Bitcoin-wallet is intuïtief. Klik onderaan op de knop **Receive**. Deel de QR-code of je Bitcoin-adres met je afzender, zodat hij je de bitcoins kan sturen.
 
 
 
-Je kunt ook een vooraf gedefinieerd bedrag instellen om het bitcoin bedrag te specificeren dat je wilt ontvangen.
+Je kunt ook een vooraf gedefinieerd bedrag instellen om het bitcoinbedrag te specificeren dat je wilt ontvangen.
 
 
 
@@ -163,7 +163,7 @@ Je kunt één of alle ontvangers verwijderen door respectievelijk op **Remove Re
 
 
 
-De Multisig (multi-handtekening) wallet vertegenwoordigt een wallet die is gecreëerd uit de groepering van een bepaald aantal (minimaal 2) bitcoin-wallets. Bij dit type wallet wordt, afhankelijk van de gekozen configuratie en methode, het uitgeven van bitcoins een collectieve en coöperatieve actie.
+De Multisig (multi-handtekening) wallet vertegenwoordigt een wallet die is gecreëerd uit de groepering van een bepaald aantal (minimaal 2) Bitcoin-wallets. Bij dit type wallet wordt, afhankelijk van de gekozen configuratie en methode, het uitgeven van bitcoins een collectieve en coöperatieve actie.
 
 
 
@@ -183,7 +183,7 @@ Definieer de m-van-n configuratie voor je multisig-organisatie door te klikken o
 
 
 
-⚠️ In een m-van-n configuratie staat **m** voor het minimum aantal handtekeningen dat nodig is om een transactie goed te keuren en **n** voor het aantal wallets in uw organisatie.
+⚠️ In een m-van-n configuratie staat **m** voor het minimum aantal handtekeningen dat nodig is om een transactie goed te keuren en **n** voor het aantal wallets in je organisatie.
 
 
 
@@ -241,7 +241,7 @@ Op je Multisig-wallet pagina vind je je transactiegeschiedenis en de knoppen Rec
 
 
 
-Bitcoins ontvangen in een mulitsi-wallet is hetzelfde proces als in een standaard Bitcoin-wallet.
+Bitcoins ontvangen in een mulitsig-wallet is hetzelfde proces als in een standaard Bitcoin-wallet.
 
 
 
@@ -251,19 +251,19 @@ Bitcoins ontvangen in een mulitsi-wallet is hetzelfde proces als in een standaar
 
 
 
-Door een multisig-wallet te beheren, wordt het uitgeven van bitcoins een samengestelde actie, of het nu met andere mensen is of met een tweede wallet van jezelf. De enkele handtekening van je wallet is niet langer voldoende. Dit voegt een veiligheidslaag toe aan je bitcoins, omdat een kwaadwillende persoon die bitcoins niet zal kunnen uitgeven wanneer hij slechts één van je privésleutels bezit.
+Door een multisig-wallet te beheren, wordt het uitgeven van bitcoins een samengestelde actie, of het nu met andere mensen is of met een tweede wallet van jezelf. De enkele handtekening van je wallet is niet langer voldoende. Dit voegt een beveiligingslaag toe aan je bitcoins, omdat een kwaadwillende persoon die bitcoins niet zal kunnen uitgeven wanneer hij slechts één van je privésleutels bezit.
 
 
 
-Net als bij de standaard Blue Wallet bitcoin-wallet, kun je meerdere ontvangers definiëren met de **Add Recipients** optie.
+Net als bij de standaard Blue Wallet Bitcoin-wallet, kun je meerdere ontvangers definiëren met de **Add Recipients** optie.
 
 
 
-Bij het valideren van je transactie heb je een tweede handtekening nodig om het uitgeven van de bitcoins goed te keuren. Onthoud dat we in een 2-de-3 multi-handtekening configuratie zitten.
+Bij het valideren van je transactie heb je een tweede handtekening nodig om het uitgeven van de bitcoins goed te keuren. Onthoud dat we in een 2-van-3 multisig-configuratie zitten.
 
 
 
-De tweede Wallet ondertekenaar, als hij of zij ook een gebruiker is, kan de transactie ondertekenen, zelfs als hij of zij geen internet heeft (geen Wi-Fi, geen mobiele data) door de QR-code te scannen van de [gedeeltelijk ondertekende transactie](https://planb.academy/resources/glossary/psbt) die je zojuist hebt aangemaakt.
+De tweede wallet-ondertekenaar kan, als hij of zij ook een gebruiker is, de transactie ondertekenen, zelfs zonder internetverbinding (geen Wi-Fi, geen mobiele data), door de QR-code te scannen van de [gedeeltelijk ondertekende transactie](https://planb.academy/resources/glossary/psbt) die je zojuist hebt aangemaakt.
 
 
 
@@ -273,15 +273,15 @@ De tweede Wallet ondertekenaar, als hij of zij ook een gebruiker is, kan de tran
 
 
 
-- Ga verder met de **Multi signature** portfolio:
+- Ga verder met de **Multisig**-wallet:
 
 
 
-Klik op de Interface van je multisig-wallet op de knop **Toetsen beheren**.
+Klik in de interface van je multisig-wallet op de knop **Manage keys**.
 
 
 
-Door één van de herstelwoorden van één van de ondertekenende portefeuilles te vergeten (**Vergeet deze seed...**), laat je Blue Wallet weten dat het de back-up van deze woorden uit zijn geheugen moet wissen. Je hebt dus een externe back-up gemaakt.
+Door één van de herstelwoorden van één van de ondertekenende wallets te vergeten (**Forget this seed...**), laat je Blue Wallet weten dat het de back-up van deze woorden uit zijn geheugen moet wissen. Je hebt dus een externe back-up gemaakt.
 
 
 
@@ -289,11 +289,11 @@ Door één van de herstelwoorden van één van de ondertekenende portefeuilles t
 
 
 
-Door deze actie uit te voeren, behoudt u alleen de openbare sleutel die aan deze herstelwoorden is gekoppeld.
+Door deze actie uit te voeren, behoudt je alleen de openbare sleutel (XPUB) die aan deze herstelwoorden is gekoppeld.
 
 
 
-⚠️ Door alleen openbare sleutels te bewaren (XPUB) kun je een extra beveiligingsniveau toevoegen aan je 2-van-3 configuratie met meerdere handtekeningen. Het kan inderdaad nadelig zijn om alle herstelwoorden op één plaats te bewaren als je telefoon wordt aangevallen. Aanvallers met toegang tot slechts één **VAULT** (sleutelwoord) die je gebruikt om je transacties te ondertekenen, zullen niet in staat zijn om je bitcoins te stelen (minimaal 02 handtekeningen vereist) omdat publieke sleutels niet kunnen worden gebruikt om transacties te ondertekenen.
+⚠️ Door alleen openbare sleutels te bewaren (XPUB) kun je een extra beveiligingsniveau toevoegen aan je 2-van-3 multisig-configuratie. Het kan inderdaad nadelig zijn om alle herstelwoorden op één plaats te bewaren als je telefoon wordt aangevallen. Aanvallers met toegang tot slechts één **VAULT** (sleutelwoord) die je gebruikt om je transacties te ondertekenen, zullen niet in staat zijn om je bitcoins te stelen (minimaal 2 handtekeningen vereist) omdat publieke sleutels niet kunnen worden gebruikt om transacties te ondertekenen.
 
 
 
@@ -333,7 +333,7 @@ https://planb.academy/tutorials/node/lightning-network/umbrel-lnd-b12e0b5b-12ff-
 
 https://planb.academy/tutorials/node/lightning-network/lightning-network-daemon-linux-59d777e9-72c8-4b32-8c50-e86cdae8f2f9
 
-Je hebt nu de Blue Wallet rondleiding voltooid en bent klaar om Bitcoin in al zijn eenvoud en kracht te gebruiken. Wij raden je aan de volgende stap te nemen en te ontdekken hoe je Bitcoin betalingen kan accepteren in je winkel, dankzij de kracht van Lightning.
+Je hebt nu de Blue Wallet rondleiding voltooid en bent klaar om Bitcoin in al zijn eenvoud en kracht te gebruiken. Wij raden je aan de volgende stap te nemen en te ontdekken hoe je Bitcoin betalingen kunt accepteren in je winkel, dankzij de kracht van Lightning.
 
 
 

--- a/tutorials/wallet/blue-wallet/nl.md
+++ b/tutorials/wallet/blue-wallet/nl.md
@@ -1,17 +1,17 @@
 ---
 name: Blue Wallet
 
-description: Bitcoin Radicaal eenvoudige en krachtige portfolio
+description: Een radicaal eenvoudige en krachtige Bitcoin-wallet
 ---
 ![cover](assets/cover.webp)
 
 
 
-Beginnen met Bitcoin lijkt een grote uitdaging te zijn voor mensen die sceptisch zijn over de eenvoud van het gebruik ervan. Het vinden van de juiste hulpmiddelen om deze eenvoud te garanderen wordt daarom van het grootste belang voor een betere adoptie van Bitcoin als een medium van Exchange en niet alleen als een opslagplaats van waarde.
+Voor mensen die sceptisch zijn over het gebruik van Bitcoin, lijkt het beginnen een grote uitdaging. Het vinden van de juiste hulpmiddelen om deze eenvoud te garanderen, is dan ook van het grootste belang voor een betere adoptie van Bitcoin als een betaalmiddel en niet alleen als een waardeopslag.
 
 
 
-In deze tutorial kijken we naar Blue Wallet, een eenvoudige maar zeer effectieve Bitcoin Wallet waarmee je je bitcoins persoonlijk kunt beheren en waarmee je ook beheercoöperaties kunt opzetten op basis van [Multisig](https://planb.academy/resources/glossary/multisig) (maak je geen zorgen, we komen er nog op terug).
+In deze tutorial kijken we naar Blue Wallet, een eenvoudige maar zeer effectieve Bitcoin-wallet waarmee je je bitcoins persoonlijk kunt beheren en waarmee je ook beheercoöperaties kunt opzetten op basis van [multisig](https://planb.academy/resources/glossary/multisig) (maak je geen zorgen, hier komen we later nog op terug).
 
 
 
@@ -22,7 +22,7 @@ In deze tutorial kijken we naar Blue Wallet, een eenvoudige maar zeer effectieve
 
 
 
-Blue Wallet is een open source, self-hoarding Bitcoin Wallet waarmee je controle krijgt over je bitcoins. Het is beschikbaar als mobiele app op zowel Android- als iOS-platforms. In deze tutorial baseren we ons op de Android-versie, maar alle processen die worden ontwikkeld, zijn ook geldig op iOS.
+Blue Wallet is een open source, self-custodial Bitcoin-wallet waarmee je controle krijgt over je bitcoins. Het is beschikbaar als mobiele app op zowel Android- als iOS-platforms. In deze tutorial baseren we ons op de Android-versie, maar alle processen die worden beschreven, zijn ook geldig op iOS.
 
 
 
@@ -30,17 +30,17 @@ Blue Wallet is een open source, self-hoarding Bitcoin Wallet waarmee je controle
 
 
 
-⚠️ Zorg ervoor dat je de Blue Wallet Bitcoin Wallet applicatie downloadt op een officieel platform om de echtheid ervan te garanderen en je bitcoins te beschermen tegen mogelijke lekken en hacks.
+⚠️ Zorg ervoor dat je de Blue Wallet bitcoin-wallet applicatie downloadt op een officieel platform om de echtheid ervan te garanderen en je bitcoins te beschermen tegen mogelijke lekken en hacks.
 
 
 
-Eenmaal geïnstalleerd, kun je een nieuwe Wallet aanmaken en de 12 herstelwoorden opslaan, of een bestaande Bitcoin Wallet importeren. Ontdek hoe je een efficiënte back-up van je sleutelwoorden kunt maken, zodat je de toegang tot je bitcoins niet verliest.
+Eenmaal geïnstalleerd, kun je een nieuwe wallet aanmaken en de 12 herstelwoorden opslaan, of een bestaande Bitcoin-wallet importeren. Ontdek hoe je een efficiënte back-up van je sleutelwoorden kunt maken, zodat je de toegang tot je bitcoins niet verliest.
 
 
 
 https://planb.academy/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-Met Blue Wallet kun je aparte, speciale Bitcoin portefeuilles aanmaken. Je kunt bijvoorbeeld een Wallet hebben voor je spaargeld en een andere voor je dagelijkse uitgaven, allemaal in dezelfde toepassing.
+Met Blue Wallet kun je aparte, speciale bitcoin-wallets aanmaken. Je kunt bijvoorbeeld een wallet hebben voor je spaargeld en een andere voor je dagelijkse uitgaven, allemaal binnen dezelfde applicatie.
 
 
 
@@ -48,19 +48,19 @@ Met Blue Wallet kun je aparte, speciale Bitcoin portefeuilles aanmaken. Je kunt 
 
 
 
-## Soorten portefeuilles
+## Soorten wallets
 
 
 
-In Blue Wallet vind je twee native Bitcoin portefeuilletypes.
+In Blue Wallet vind je twee native Bitcoin-wallettypes.
 
 
 
-### Bitcoin portefeuille
+### Bitcoin wallet
 
 
 
-Als je gewend bent aan andere Bitcoin portfolio's zoals Phoenix of Aqua, zul je op Interface helemaal niet uit de pas lopen met het Bitcoin portfolio van Blue Wallet.
+Als je gewend bent aan andere bitcoin wallets zoals Phoenix of Aqua, zul je de interface van de Blue Wallet bitcoin wallet meteen herkennen.
 
 
 
@@ -69,11 +69,11 @@ https://planb.academy/tutorials/wallet/mobile/phoenix-0f681345-abff-4bdc-819c-4a
 
 https://planb.academy/tutorials/wallet/mobile/aqua-8e6d7dd3-8c03-45cc-90dd-fe3899a7d125
 
-Blue Wallet's Bitcoin Wallet vertegenwoordigt de standaard Wallet in het Bitcoin ecosysteem. Je kunt bitcoins uitgeven zolang je in het bezit bent van de herstelwoorden die zorgen voor een geldige handtekening op het netwerk om te verifiëren dat je de bitcoins bezit.
+Blue Wallet's bitcoin-wallet vertegenwoordigt de standaard-wallet in het Bitcoin-ecosysteem. Je kunt bitcoins uitgeven zolang je in het bezit bent van de herstelwoorden die zorgen voor een geldige handtekening op het netwerk om te verifiëren dat je de bitcoins bezit.
 
 
 
-Om een Bitcoin portefeuille aan te maken, klik je op de knop **Nu toevoegen**, voer je de naam van je portefeuille in en kies je het Bitcoin type.
+Om een bitcoin-wallet aan te maken, klik je op de knop **Add now**, voer je de naam van je wallet in en kies je het Bitcoin-type.
 
 
 
@@ -81,21 +81,21 @@ Om een Bitcoin portefeuille aan te maken, klik je op de knop **Nu toevoegen**, v
 
 
 
-Als je op je Bitcoin Wallet preview klikt, kun je je transactiegeschiedenis bekijken en bitcoins versturen en ontvangen.
+Als je op de voorbeeldweergave van je Bitcoin-wallet klikt, kun je je transactiegeschiedenis bekijken en bitcoins versturen en ontvangen.
 
 
 
-⚠️ Alle transacties in je Bitcoin Wallet zijn op de hoofdketen van het Bitcoin protocol (Mainnet).
+⚠️ Alle transacties in je bitcoin-wallet vinden plaats op de hoofdketen van het Bitcoin-protocol (Mainnet).
 
 
 
 
 
-- Bitcoins ontvangen met de Bitcoin Blue Wallet Wallet is intuïtief. Klik onderaan op de knop **Ontvangen**. Deel de QR-code of je Bitcoin Address met je afzender, zodat hij je de bitcoins kan sturen.
+- Bitcoins ontvangen met de Blue Wallet bitcoin-wallet is intuïtief. Klik onderaan op de knop **Receive**. Deel de QR-code of je Bitcoin-adres met je afzender, zodat hij je de bitcoins kan sturen.
 
 
 
-Je kunt ook een vooraf gedefinieerd bedrag instellen om de hoeveelheid Bitcoin te specificeren die je wilt ontvangen.
+Je kunt ook een vooraf gedefinieerd bedrag instellen om het bitcoin bedrag te specificeren dat je wilt ontvangen.
 
 
 
@@ -105,7 +105,7 @@ Je kunt ook een vooraf gedefinieerd bedrag instellen om de hoeveelheid Bitcoin t
 
 
 
-- Op de **Verstuur** knop, stuur bitcoins naar een Bitcoin Address, stel het gewenste bedrag in en valideer de transactie.
+- Tik op de **Send** knop om bitcoins naar een Bitcoin-adres te sturen, stel het gewenste bedrag in en valideer de transactie.
 
 
 
@@ -113,11 +113,11 @@ Je kunt ook een vooraf gedefinieerd bedrag instellen om de hoeveelheid Bitcoin t
 
 
 
-Met de Blue Wallet kun je de parameters van je Bitcoin verzending naar wens configureren.
+Met Blue Wallet kun je de parameters van je Bitcoin-transactie naar wens configureren.
 
 
 
-Je kunt dus de transactiekostenratio kiezen die bij je past als je wilt dat je transactie snel wordt gevalideerd in een Mempool en door de miners in een blok wordt opgenomen. Afhankelijk van de verhouding die je kiest, zullen de miners jouw transactie meer of minder prioriteit geven. Ontdek meer in onze Mempool Ruimte tutorial.
+Je kan dus de verhouding van de transactiekosten (fee ratio) kiezen die bij je past als je wilt dat je transactie snel wordt gevalideerd in een mempool en door miners in een blok wordt opgenomen. Afhankelijk van de verhouding die je kiest, zullen de miners jouw transactie meer of minder prioriteit geven. Ontdek meer in onze Mempool Space tutorial.
 
 
 
@@ -129,11 +129,11 @@ https://planb.academy/tutorials/privacy/explorer/mempool-space-f3e468a1-92f1-43c
 
 
 
-- Met Blue Wallet kun je meerdere ontvangers aan één zending toevoegen.
+- In het kader van gegroepeerde betalingen laat Blue Wallet je toe om meerdere ontvangers aan één transactie toe te voegen.
 
 
 
-Wanneer je de Bitcoin Address van je eerste ontvanger toevoegt, klik dan in de opties op **Recipiënt toevoegen**, voeg de Bitcoin Address toe en stel vervolgens het bedrag in dat naar deze ontvanger moet worden verzonden, enzovoort. Blue Wallet verzendt de bitcoins voor meerdere verzendingen op basis van jouw enkele actie.
+Wanneer je het Bitcoin-adres van je eerste ontvanger toevoegt, klik dan in de opties op **Add Recipient**, voeg het Bitcoin-adres toe en stel vervolgens het bedrag in dat naar deze ontvanger moet worden verzonden, enzovoort. Blue Wallet verzendt de bitcoins voor de meerdere transacties op basis van jouw enige actie.
 
 
 
@@ -141,7 +141,7 @@ Wanneer je de Bitcoin Address van je eerste ontvanger toevoegt, klik dan in de o
 
 
 
-Je kunt één of alle ontvangers verwijderen door respectievelijk op **Weg ontvanger** en **Verwijder alle ontvangers** te klikken.
+Je kunt één of alle ontvangers verwijderen door respectievelijk op **Remove Recipient** en **Remove All Recipients** te klikken.
 
 
 
@@ -151,7 +151,7 @@ Je kunt één of alle ontvangers verwijderen door respectievelijk op **Weg ontva
 
 
 
-- **Kosten opdrijven**: Heb je een transactie gedaan waarvan de bevestiging lang op zich laat wachten? Door kosteninflatie in te schakelen kun je extra transactiekosten toevoegen aan je lopende transactie om de bevestiging ervan te versnellen.
+- **Kosten opdrijven**: Heb je een transactie gedaan waarvan de bevestiging lang op zich laat wachten? Door RBF (Replace-By-Fee) (Allow Fee Bump) in te schakelen kun je extra transactiekosten toevoegen aan je lopende transactie om de bevestiging ervan te versnellen.
 
 
 
@@ -159,19 +159,19 @@ Je kunt één of alle ontvangers verwijderen door respectievelijk op **Weg ontva
 
 
 
-### Multisig portefeuille
+### Multisig-wallet
 
 
 
-De Multisig (multi-handtekening) Wallet vertegenwoordigt een Wallet gecreëerd uit de groepering van een bepaald aantal (minimaal 2) Bitcoin portemonnees. In dit type Wallet wordt, afhankelijk van de gekozen configuratie en methode, het uitgeven van bitcoins een collectieve en coöperatieve actie.
+De Multisig (multi-handtekening) wallet vertegenwoordigt een wallet die is gecreëerd uit de groepering van een bepaald aantal (minimaal 2) bitcoin-wallets. Bij dit type wallet wordt, afhankelijk van de gekozen configuratie en methode, het uitgeven van bitcoins een collectieve en coöperatieve actie.
 
 
 
-In Blue Wallet kun je portfolio's met meerdere handtekeningen maken voor je vereniging, je familie, je bedrijf. In dit hoofdstuk zullen we elk aspect van dit speciale type portfolio verkennen.
+In Blue Wallet kun je multisig-wallets maken voor je vereniging, je familie, je bedrijf. In dit hoofdstuk zullen we elk aspect van dit speciale type wallet verkennen.
 
 
 
-Voeg een nieuwe portefeuille toe en selecteer het type **Multisig Vault** om een portefeuille met meerdere handtekeningen aan te maken.
+Voeg een nieuwe wallet toe en selecteer het type **Multisig Vault** om een multisig-wallet aan te maken.
 
 
 
@@ -179,35 +179,35 @@ Voeg een nieuwe portefeuille toe en selecteer het type **Multisig Vault** om een
 
 
 
-Definieer de m-de-n configuratie in je organisatie met meerdere handtekeningen door te klikken op **Kluisinstellingen**.
+Definieer de m-van-n configuratie voor je multisig-organisatie door te klikken op **Vault Settings**.
 
 
 
-⚠️ In een m-of-n configuratie staat **m** voor het minimum aantal handtekeningen dat nodig is om een transactie goed te keuren en **n** voor het aantal portefeuilles in uw organisatie.
+⚠️ In een m-van-n configuratie staat **m** voor het minimum aantal handtekeningen dat nodig is om een transactie goed te keuren en **n** voor het aantal wallets in uw organisatie.
 
 
 
-Zorg ervoor dat je een minimum aantal handtekeningen (m) definieert voor de meerderheid van je organisatie. Bijvoorbeeld, een 2-van-3 multi-handtekening configuratie vereist dat twee portemonnees in je organisatie de transactie ondertekenen voordat deze kan worden uitgevoerd.
+Zorg ervoor dat je een minimum aantal handtekeningen (m) definieert voor de meerderheid van je organisatie. Bijvoorbeeld, een 2-van-3 multisig-configuratie vereist dat twee wallets in je organisatie de transactie ondertekenen voordat deze kan worden uitgevoerd.
 
 
 
-het definiëren van een m-of-n configuratie waarbij n gelijk is aan m is een groot risico. Wanneer een lid de toegang tot zijn Wallet verliest, verlies je de autorisatie om bitcoins in de Wallet uit te geven.
+Het definiëren van een m-van-n configuratie waarbij n gelijk is aan m is een groot risico. Wanneer een lid de toegang tot zijn wallet verliest, verlies je de autorisatie om bitcoins uit de wallet uit te geven.
 
 
 
-Hier zijn enkele voorbeelden van optimale configuraties om de veiligheid en toegankelijkheid van bitcoins te garanderen:
-
-
-
-
-
-- 2-de-3 multi-handtekening.
+Hier zijn enkele voorbeelden van optimale configuraties om de veiligheid en toegankelijkheid van je bitcoins te garanderen:
 
 
 
 
 
-- 5-de-7 multi-handtekening.
+- 2-de-3 multisig.
+
+
+
+
+
+- 5-de-7 multisig.
 
 
 
@@ -219,11 +219,11 @@ Houd je aan de best practice door het P2WSH-formaat te kiezen.
 
 
 
-❗ **[P2WSH](https://planb.academy/resources/glossary/p2wsh) of Pay to Witness Script Hash** is een vergrendelingsmethode die de uitgaande bitcoins (Outputs) van je transactie vergrendelt naar de Hash van een aangepast script dat Blue Wallet instelt. Het belangrijkste voordeel van dit type vergrendeling is dat het de grootte van transactiegegevens vermindert en je impliciet lagere transactiekosten kunt betalen.
+❗ **[P2WSH](https://planb.academy/resources/glossary/p2wsh) of Pay to Witness Script Hash** is een vergrendelingsmethode die de uitgaande bitcoins (outputs) van je transactie vergrendelt naar de hash van een aangepast script dat Blue Wallet instelt. Het belangrijkste voordeel van dit type vergrendeling is dat het de grootte van transactiegegevens vermindert en je impliciet lagere transactiekosten kan betalen.
 
 
 
-Maak of importeer elk van de **n** portfolio's in je configuratie. In onze tutorial gebruiken we een 2-van-3 configuratie met meerdere handtekeningen. Zorg ervoor dat je de herstelwoorden voor elke portefeuille afzonderlijk opslaat.
+Maak of importeer elk van de **n** wallets in je configuratie. In onze tutorial gebruiken we een 2-van-3 configuratie met meerdere handtekeningen. Zorg ervoor dat je de herstelwoorden voor elke wallet afzonderlijk opslaat.
 
 
 
@@ -233,15 +233,15 @@ Maak of importeer elk van de **n** portfolio's in je configuratie. In onze tutor
 
 
 
-- Bitcoins ontvangen
+- **Bitcoins ontvangen**
 
 
 
-Op je Multisig Wallet pagina vind je je transactiegeschiedenis en de knoppen Ontvangen en Verzenden.
+Op je Multisig-wallet pagina vind je je transactiegeschiedenis en de knoppen Receive en Send.
 
 
 
-Bitcoins ontvangen in een Wallet met meerdere handtekeningen is hetzelfde proces als wanneer je in een standaard Bitcoin Wallet zit.
+Bitcoins ontvangen in een mulitsi-wallet is hetzelfde proces als in een standaard Bitcoin-wallet.
 
 
 
@@ -251,11 +251,11 @@ Bitcoins ontvangen in een Wallet met meerdere handtekeningen is hetzelfde proces
 
 
 
-Door een Wallet met meerdere handtekeningen te beheren, wordt het uitgeven van bitcoins een samengestelde actie, of het nu met andere mensen is of met een tweede Wallet van jezelf. De enkele handtekening van je Wallet is niet langer voldoende. Dit voegt een Layer aan veiligheid toe aan je bitcoins, omdat een kwaadwillende persoon niet in staat zal zijn die bitcoins uit te geven wanneer hij in het bezit komt van slechts één van je privésleutels.
+Door een multisig-wallet te beheren, wordt het uitgeven van bitcoins een samengestelde actie, of het nu met andere mensen is of met een tweede wallet van jezelf. De enkele handtekening van je wallet is niet langer voldoende. Dit voegt een veiligheidslaag toe aan je bitcoins, omdat een kwaadwillende persoon die bitcoins niet zal kunnen uitgeven wanneer hij slechts één van je privésleutels bezit.
 
 
 
-Net als bij het standaard Bitcoin portfolio van Blue Wallet, kun je meerdere ontvangers definiëren in de **Aanvullen met ontvangers** optie.
+Net als bij de standaard Blue Wallet bitcoin-wallet, kun je meerdere ontvangers definiëren met de **Add Recipients** optie.
 
 
 
@@ -277,7 +277,7 @@ De tweede Wallet ondertekenaar, als hij of zij ook een gebruiker is, kan de tran
 
 
 
-Klik op de Interface van je Wallet met meerdere handtekeningen op de knop **Toetsen beheren**.
+Klik op de Interface van je multisig-wallet op de knop **Toetsen beheren**.
 
 
 
@@ -301,11 +301,11 @@ Door deze actie uit te voeren, behoudt u alleen de openbare sleutel die aan deze
 
 
 
-### Toegangsbeveiliging voor portfolio's verbeteren
+### Toegangsbeveiliging voor wallets verbeteren
 
 
 
-In Instellingen kun je met de optie **Veiligheid** het gebruik van een vingerafdruk definiëren om een transactie uit te voeren, je Wallet te exporteren of te verwijderen. Dit authenticeert de persoon die je smartphone gebruikt.
+In Settings kun je met de optie **Security** het gebruik van een vingerafdruk definiëren om een transactie uit te voeren, je wallet te exporteren of te verwijderen. Dit authenticeert de persoon die je smartphone gebruikt.
 
 
 
@@ -317,11 +317,11 @@ In Instellingen kun je met de optie **Veiligheid** het gebruik van een vingerafd
 
 
 
-Lightning Network wordt niet langer ondersteund in de Blue Wallet toepassing.
+Lightning Network wordt niet langer ondersteund in de Blue Wallet-applicatie.
 
 
 
-In Instellingen > **Lightning Instellingen**, kunt u uw Lightning Wallet handmatig koppelen wanneer u een Lightning Network Daemon (LND) knooppunt gebruikt. Installeer de LND Hub en koppel vervolgens uw Wallet door de link in te voeren die door de Hub wordt gegenereerd.
+In Instellingen > **Lightning Settings**, kun je je Lightning-wallet handmatig koppelen wanneer je een Lightning Network Daemon (LND) node gebruikt. Installeer de LND Hub en koppel vervolgens je wallet door de link in te voeren die door de hub wordt gegenereerd.
 
 
 
@@ -333,7 +333,7 @@ https://planb.academy/tutorials/node/lightning-network/umbrel-lnd-b12e0b5b-12ff-
 
 https://planb.academy/tutorials/node/lightning-network/lightning-network-daemon-linux-59d777e9-72c8-4b32-8c50-e86cdae8f2f9
 
-Je hebt nu de Blue Wallet tour voltooid, klaar om Bitcoin in al zijn eenvoud en kracht te gebruiken. Wij raden u aan de volgende stap te nemen en uit te vinden hoe u Bitcoin betalingen kunt accepteren in uw winkels, dankzij de kracht van Lightning.
+Je hebt nu de Blue Wallet rondleiding voltooid en bent klaar om Bitcoin in al zijn eenvoud en kracht te gebruiken. Wij raden je aan de volgende stap te nemen en te ontdekken hoe je Bitcoin betalingen kan accepteren in je winkel, dankzij de kracht van Lightning.
 
 
 

--- a/tutorials/wallet/bull-bitcoin/nl.md
+++ b/tutorials/wallet/bull-bitcoin/nl.md
@@ -416,19 +416,19 @@ Om de transactie te voltooien, geef je de afzender het `adres` of de `URI`. Je k
 
 
 
-Met de Bull Bitcoin-wallet kun je ook betalingen verzenden en ontvangen via het Lightning Network. Een belangrijk kenmerk is dat geld dat je via Lightning ontvangt automatisch wordt omgewisseld en opgeslagen op de `Liquid Network` binnen je `Instant Payments wallet`. Deze dienst wordt aangedreven door de `Boltz`. Door dit ontwerp kunt je profiteren van de snelheid en lage kosten van Lightning zonder de complexiteit van het beheren van liquiditeitskanalen, terwijl je je fondsen volledig zelf bewaart. Hoewel deze hybride benadering self-custodial is en de complexiteit van het beheren van kanalen vermijdt, introduceert het een dienst van een derde partij (Boltz), een kleine swapvergoeding en afhankelijkheid van de Liquid Network federatie van functionarissen als keyholders, wat anders is dan een traditionele, niet-custodial Lightning wallet waar je je eigen kanalen beheert. Je kunt hier meer te weten komen over Liquid en hun bestuursmodel:
+Met de Bull Bitcoin-wallet kun je ook betalingen verzenden en ontvangen via het Lightning Network. Een belangrijk kenmerk is dat geld dat je via Lightning ontvangt automatisch wordt omgewisseld en opgeslagen op het `Liquid Network` binnen je `Instant Payments Wallet`. Deze dienst wordt aangedreven door de `Boltz`. Door dit ontwerp kan je profiteren van de snelheid en lage kosten van Lightning zonder de complexiteit van het beheren van liquiditeitskanalen, terwijl je je fondsen volledig zelf bewaart. Hoewel deze hybride benadering self-custodial is en de complexiteit van het beheren van kanalen vermijdt, introduceert het een dienst van een derde partij (Boltz), een kleine swapvergoeding en afhankelijkheid van de Liquid Network federatie van functionarissen als keyholders, wat anders is dan een traditionele, niet-custodial Lightning-wallet waar je je eigen kanalen beheert. Je kan hier meer te weten komen over Liquid en hun bestuursmodel:
 
 
 https://planb.academy/en/courses/e17ee350-41d4-49fa-b270-29e4d26d22f8/overview-of-liquid-architecture-and-governance-model-17650c4b-cd1f-4bc6-b490-708f92dc9306
 
 
-- Grenzen:**
-    - Minimumbedrag:** Een minimumfactuurbedrag is vereist. Controleer de app voor de huidige limiet
-    - Kosten:** Jij, de ontvanger, bent verantwoordelijk voor een kleine swapvergoeding. Deze kosten worden afgetrokken van het bedrag dat de verzender overmaakt en kunnen veranderen
+- **Grenzen:**
+    - **Minimumbedrag:** Een minimumfactuurbedrag is vereist. Controleer de app voor de huidige limiet
+    - **Kosten:** Jij, de ontvanger, bent verantwoordelijk voor een kleine swapvergoeding. Deze kosten worden afgetrokken van het bedrag dat de verzender overmaakt en kunnen veranderen
 - Voordelen:**
-    - Zelfbeheerd:** Uw geld is altijd onder je controle, beveiligd op het Liquid-netwerk.
-    - Vermijd hoge on-chain kosten:** Door Lightning te gebruiken en op te slaan op Liquid, omzeilt je de on-chain kosten die gepaard gaan met het openen van een traditioneel Lightning-kanaal. U kunt ervoor kiezen om later geld over te hevelen naar een on-chain-kanaal, wanneer het geaccumuleerde bedrag de kosten rechtvaardigt.
-    - Tip:** Voor de meest kosteneffectieve transactie tussen twee Bull Bitcoin gebruikers, gebruikt je het **Liquid netwerk rechtstreeks** om de Lightning swapkosten volledig te vermijden.
+    - **Zelfbeheerd:** Uw geld is altijd onder je controle, beveiligd op het Liquid-netwerk.
+    - **Vermijd hoge on-chain kosten:** Door Lightning te gebruiken en op te slaan op Liquid, omzeilt je de on-chain kosten die gepaard gaan met het openen van een traditioneel Lightning-kanaal. U kunt ervoor kiezen om later geld over te hevelen naar een on-chain-kanaal, wanneer het geaccumuleerde bedrag de kosten rechtvaardigt.
+    - **Tip:** Voor de meest kosteneffectieve transactie tussen twee Bull Bitcoin gebruikers, gebruikt je het **Liquid netwerk rechtstreeks** om de Lightning swapkosten volledig te vermijden.
 
 
 Om een betaling te ontvangen, moet je generate een `bliksemfactuur` hebben:

--- a/tutorials/wallet/bull-bitcoin/nl.md
+++ b/tutorials/wallet/bull-bitcoin/nl.md
@@ -1,6 +1,6 @@
 ---
-name: Bull Bitcoin Wallet
-description: Ontdek hoe je de Wallet Bull Bitcoin gebruikt
+name: Bull Bitcoin-wallet
+description: Ontdek hoe je de Bull Bitcoin-wallet gebruikt
 ---
 
 ![cover](assets/cover.webp)
@@ -9,29 +9,29 @@ description: Ontdek hoe je de Wallet Bull Bitcoin gebruikt
 ![video](https://www.youtube.com/watch?v=6b0xTB2sE8E)
 
 
-*Deze videotutorial van BTC Sessions leidt je door het proces van het instellen en gebruiken van Bull Bitcoin Wallet!
+*Deze videotutorial van BTC Sessions leidt je door het proces van het instellen en gebruiken van de Bull Bitcoin-wallet!*
 
 
-Deze handleiding neemt je mee door de installatie, configuratie en het gebruik van Bull Bitcoin Wallet. Je leert geld verzenden en ontvangen op de Bitcoin On-Chain, Liquid en Lightning netwerken, en hoe je de Bitcoin daartussen kunt verplaatsen. De uitgebreide functies van de wallet maken het een krachtige, alles-in-één tool voor het beheren van uw Bitcoin. Laten we aan de slag gaan.
+Deze handleiding neemt je mee door de installatie, configuratie en het gebruik van de Bull Bitcoin-wallet. Je leert geld verzenden en ontvangen via de Bitcoin on-chain, Liquid en Lightning-netwerken, en hoe je de bitcoin daartussen kunt verplaatsen. De uitgebreide functies van de wallet maken het een krachtige, alles-in-één tool voor het beheren van je Bitcoin. Laten we aan de slag gaan.
 
 
 ## Inleiding
 
 
-Bull Bitcoin Wallet, ontwikkeld door [Bull Bitcoin](https://www.bullbitcoin.com/), is een **zelfbehoudende** Bitcoin wallet, wat betekent dat je volledige controle hebt over je privésleutels en dus je fondsen, zonder afhankelijk te zijn van een derde partij. Open-source en geworteld in een Cypherpunk filosofie, combineert deze Wallet eenvoud, vertrouwelijkheid en geavanceerde functies zoals cross-network swaps en PayJoin ondersteuning. Je kunt je bitcoins op drie netwerken beheren: **Bitcoin onchain**, **Liquid** en **Lightning**, elk op maat gemaakt voor specifiek gebruik. Op de [BullBitcoin GitHub](https://github.com/orgs/SatoshiPortal/projects/49), kunt u de huidige onderwerpen en komende ontwikkelingen bekijken. Aangezien het project 100% open-source is en "gebouwd in het openbaar", kun je ook je suggesties en bugs die je tegenkomt opsturen. Terwijl sommige wallets nu meerdere netwerken ondersteunen, onderscheidt de Bull Bitcoin Wallet zich door de diepgaande integratie van privacyfuncties over al deze netwerken, waardoor het een krachtig hulpmiddel is voor het beheren van je Bitcoin over alle grote netwerken
+Bull Bitcoin-wallet, ontwikkeld door [Bull Bitcoin](https://www.bullbitcoin.com/), is een **self-custodial** Bitcoin-wallet, wat betekent dat je volledige controle hebt over je privésleutels en dus je fondsen, zonder afhankelijk te zijn van een derde partij. Open-source en geworteld in een cypherpunk-filosofie, combineert deze wallet eenvoud, vertrouwelijkheid en geavanceerde functies zoals cross-network swaps en PayJoin ondersteuning. Je kunt je bitcoins op drie netwerken beheren: **Bitcoin on-chain**, **Liquid** en **Lightning**, elk op maat gemaakt voor specifiek gebruik. Op de [BullBitcoin GitHub](https://github.com/orgs/SatoshiPortal/projects/49), kun je actuele onderwerpen en komende ontwikkelingen bekijken. Aangezien het project 100% open-source is en "gebouwd in het openbaar", kun je ook je suggesties en bugs die je tegenkomt opsturen. Terwijl sommige wallets nu meerdere netwerken ondersteunen, onderscheidt de Bull Bitcoin-wallet zich door de diepgaande integratie van privacyfuncties over al deze netwerken, waardoor het een krachtig hulpmiddel is voor het beheren van je bitcoin over alle grote netwerken.
 
 
 ## 1️⃣ Vereisten
 
 
-Voordat u de **Bull Bitcoin Wallet** in gebruik neemt, moet u ervoor zorgen dat u de volgende onderdelen hebt:
+Voordat je de **Bull Bitcoin-wallet** in gebruik neemt, moet je ervoor zorgen dat je de volgende onderdelen hebt:
 
 
 
-- Compatibele smartphone**: Een **iOS** (iPhone of iPad) of **Android** apparaat
-- Internetverbinding
-- Veilige back-upmedia**: Schrijf je **herstelzin** (12 woorden) op papier of metaal en bewaar deze op een veilige plaats.
-- Basiskennis**: Een minimum aan kennis van Bitcoin concepten (adressen, transacties, kosten) is nuttig, hoewel deze tutorial elke stap uitlegt voor beginners.
+- **Compatibele smartphone**: Een **iOS** (iPhone of iPad) of **Android**-apparaat
+- **Internetverbinding**
+- **Veilige back-up media**: Schrijf je **herstelzin** (12 woorden) op papier of metaal en bewaar deze op een veilige plaats.
+- **Basiskennis**: Een minimum aan kennis van Bitcoin-concepten (adressen, transacties, kosten) is nuttig, hoewel deze tutorial elke stap uitlegt voor beginners.
 
 
 ## 2️⃣ Installatie
@@ -63,32 +63,30 @@ Bij het openen worden de volgende opties gevraagd:
 
 
 
-- `Maak nieuw Wallet`
+- `Create New Wallet`
 - `Recover Wallet` en
-- `Geavanceerde opties`
+- `Advanced Options`
 
 
-Laten we beginnen door op `Geavanceerde opties` te tikken.
+Laten we beginnen door op `Advanced Options` te tikken.
 
 
 Hier kunnen we de geavanceerde instellingen configureren voordat we een wallet aanmaken of herstellen:
 
 
 1. Schakel de `Tor proxy` in om verkeer over het Tor-netwerk te routeren.
-
-1. [Orbot-app](https://orbot.app/en/) moet geïnstalleerd en actief zijn voordat u deze inschakelt
-
-2. Tor Proxy is alleen van toepassing op Bitcoin (niet Liquid) en kan resulteren in een langzamere verbinding.
+      1. [Orbot-app](https://orbot.app/en/) moet geïnstalleerd en actief zijn voordat je deze inschakelt
+      2. Tor Proxy is alleen van toepassing op Bitcoin (niet Liquid) en kan resulteren in een langzamere verbinding.
 
 2. Een `Aangepaste Electrum Server` instellen, of
 
 3. Pas de `Recover Bull` instellingen aan. We zullen later meer leren over de [Recover Bull](https://recoverbull.com/).
 
 
-Nadat u alle optionele aanpassingen hebt gemaakt, tikt u op `Gedaan`. Als u een bestaande Wallet opnieuw wilt gebruiken, klik dan op `Herstel Wallet` en vul de 12 woorden van uw herstelzin in.
+Nadat je alle optionele aanpassingen hebt gemaakt, tikt je op `Gedaan`. Als je een bestaande wallet opnieuw wilt gebruiken, klik dan op `Herstel wallet` en vul de 12 woorden van je herstelzin in.
 
 
-Klik anders op `Maak een nieuwe Wallet`.
+Klik anders op `Create a New Wallet`.
 
 
 ![image](assets/en/01.webp)
@@ -101,13 +99,13 @@ Voordat we dieper duiken, kijken we eerst naar het `Home scherm` om ons te orië
 
 
 
-- het `transactieoverzicht` en `instellingsmenu` bevinden zich bovenaan.
-- Het `Beschikbaar Saldo` heeft een privacy-optie die `aan of uit` kan worden gezet.
-- Ga naar de `Bitcoin Bull Exchange` om te `Kopen, Verkopen of Betalen` (dit hangt af van de jurisdictie en kan KYC vereisen).
-- overdracht` van fondsen tussen portemonnees
-- `Veilig Bitcoin` is gelijk aan Onchain Bitcoin Wallet
-- `Instant payments` via de Lightning- / Liquid Network *(Opmerking: Bull Bitcoin Wallet maakt het mogelijk betalingen te doen en te ontvangen via Lightning. Fondsen ontvangen via Lightning worden opgeslagen op het [*Liquid netwerk](https://liquid.net/) (in de Wallet Instant Payments) dankzij een automatische swap via [*Boltz exchange](https://boltz.exchange/). Dit geeft u de mogelijkheid om te communiceren met Lightning zonder liquiditeitskanalen te hoeven beheren, terwijl u in zelfbewaarneming blijft.)*
-- `Versturen` en `Ontvangen` van fondsen
+- het `transactieoverzicht` (Transactions) en `instellingsmenu` (Settings) bevinden zich bovenaan.
+- Het `Beschikbaar Saldo` (Available Balance) heeft een privacy-optie die `aan of uit` kan worden gezet.
+- Ga naar de `Bitcoin Bull exchange` om te `Kopen, Verkopen of Betalen` (dit hangt af van de jurisdictie en kan KYC vereisen).
+- `Overdracht` (Transfer) van fondsen tussen wallets.
+- `Secure Bitcoin` is gelijk aan on-chain Bitcoin-wallet.
+- `Instant payments` via het Lightning- / Liquid Network *(Opmerking: Bull Bitcoin-wallet maakt het mogelijk betalingen te doen en te ontvangen via Lightning. Fondsen ontvangen via Lightning worden opgeslagen op het [*Liquid netwerk](https://liquid.net/) (in de wallet Instant Payments) dankzij een automatische swap via [*Boltz exchange](https://boltz.exchange/). Dit geeft je de mogelijkheid om te communiceren met Lightning zonder liquiditeitskanalen te hoeven beheren, terwijl je in self-custody blijft.)*
+- `Versturen` (Send) en `Ontvangen` (Receive) van fondsen.
 
 
 ![image](assets/en/02.webp)
@@ -132,17 +130,17 @@ Tik op `Physical Backup` om een lijst van 12 woorden te zien die jouw herstel- o
 
 
 
-- Schrijf je `herstelzin` met de grootste zorg op. Schrijf het op papier of metaal en bewaar het op een veilige plaats (kluis, offline locatie). Deze zin is uw enige manier om toegang te krijgen tot uw bitcoins in het geval van verlies van uw apparaat of verwijdering van de applicatie.
+- Schrijf je `herstelzin` met de grootste zorg op. Schrijf het op papier of metaal en bewaar het op een veilige plaats (kluis, offline locatie). Deze zin is je enige manier om toegang te krijgen tot je bitcoins in het geval van verlies van je apparaat of verwijdering van de applicatie.
 - Het is ook belangrijk om te weten dat iedereen met deze zin al je bitcoins kan stelen. Sla het nooit digitaal op:
-- Geen screenshot
-- Geen cloud-, e-mail- of berichtenback-ups
-- Geen kopiëren/plakken (risico van opslaan op klembord)
+    - Geen screenshot
+    - Geen cloud-, e-mail- of berichtenback-ups
+    - Geen kopiëren/plakken (risico van opslaan op klembord)
 
 
 ![image](assets/en/25.webp)
 
 
-Op het volgende scherm moet je de woorden in de juiste volgorde zetten om er zeker van te zijn dat je de seed zin goed hebt. Je krijgt een bevestiging als de test geslaagd is.
+Op het volgende scherm moet je de woorden in de juiste volgorde zetten om er zeker van te zijn dat je de herstelzin goed hebt. Je krijgt een bevestiging als de test geslaagd is.
 
 
 ! **Dit punt is cruciaal**. Voor verdere hulp :
@@ -155,37 +153,37 @@ https://planb.academy/courses/46b0ced2-9028-4a61-8fbc-3b005ee8d70f
 ### Gecodeerde kluis
 
 
-Er is ook de optie van een versleutelde, anonieme back-up in de cloud. Maar zeiden we in de vorige paragraaf niet dat cloudback-ups riskant zijn en vermeden moeten worden? Het Bull Bitcoin team heeft echter een slimme manier ontwikkeld om het proces veilig te maken. Dit is hoe het werkt:
+Er is ook de optie van een versleutelde, anonieme back-up in de cloud. Maar zeiden we in de vorige paragraaf niet dat cloudback-ups riskant zijn en vermeden moeten worden? Het Bull Bitcoin-team heeft echter een slimme manier ontwikkeld om het proces veilig te maken. Dit is hoe het werkt:
 
 
-`Recoverbull` is een back-upprotocol dat het beveiligen van uw Bitcoin wallet vereenvoudigt door de back-up in twee delen op te splitsen. Ten eerste wordt het back-upbestand van je wallet versleuteld op je apparaat met behulp van een sterke versleutelingscode. Je kunt dit versleutelde bestand opslaan waar je maar wilt, zoals Google Drive of je apparaat. Ten tweede, de coderingssleutel die nodig is om het bestand te ontgrendelen is opgeslagen door de Recoverbull Key Server. Om uw wallet te herstellen, heeft u zowel het versleutelde back-up bestand als de sleutel nodig, die u opent met uw PIN-code of wachtwoord. Dit ontwerp zorgt ervoor dat uw cloud back-up alleen nutteloos is en dat de sleutel server alleen nutteloos is zonder uw specifieke back-up bestand. Hierdoor blijven uw fondsen veilig, zelfs als één onderdeel is gecompromitteerd.
+`Recoverbull` is een back-upprotocol dat het beveiligen van je Bitcoin-wallet vereenvoudigt door de back-up in twee delen op te splitsen. Ten eerste wordt het back-upbestand van je wallet versleuteld op je apparaat met behulp van een sterke versleutelingscode. Je kunt dit versleutelde bestand opslaan waar je maar wilt, zoals Google Drive of je apparaat. Ten tweede, de coderingssleutel die nodig is om het bestand te ontgrendelen is opgeslagen door de Recoverbull Key Server. Om je wallet te herstellen, heb je zowel het versleutelde back-up bestand als de sleutel nodig, die je opent met je PIN-code of wachtwoord. Dit ontwerp zorgt ervoor dat je cloud back-up alleen nutteloos is en dat de sleutel server (Key Server) alleen nutteloos is zonder je specifieke back-up bestand. Hierdoor blijven je fondsen veilig, zelfs als één onderdeel is gecompromitteerd.
 
 
-Zie het als een kluis. Het versleutelde back-up bestand is de *box*, die u overal kunt opslaan (zoals Google Drive). Uw Recovery PIN is de *sleutel*, die apart wordt opgeslagen door de Recoverbull Key Server. Een dief zou zowel uw specifieke doos als uw specifieke sleutel moeten hebben om het te openen. Dit ontwerp zorgt ervoor dat zelfs als iemand uw back-up bestand krijgt, het nutteloos is zonder de sleutel van de server, en de sleutel van de server is nutteloos zonder uw unieke back-up bestand.
+Zie het als een kluis. Het versleutelde back-up bestand is de *box*, die je overal kunt opslaan (zoals Google Drive). Je recovery PIN is de *sleutel*, die apart wordt opgeslagen door de Recoverbull Key Server. Een dief zou zowel je specifieke doos als je specifieke sleutel moeten hebben om het te openen. Dit ontwerp zorgt ervoor dat zelfs als iemand je back-up bestand krijgt, het nutteloos is zonder de sleutel van de server, en de sleutel van de server is nutteloos zonder je unieke back-up bestand.
 
 
 Leer meer over het `Recoverbull` wallet back-upprotocol [hier](https://recoverbull.com/).
 
 
-Tik op `Gecodeerde kluis` en vervolgens op `Doorgaan` om het gebruik van de Standaardserver te bevestigen. De verbinding wordt omgeleid via het `Tor` Netwerk om privacy en anonimiteit te garanderen.
+Tik op `Encrypted Vault` en vervolgens op `Continue` om het gebruik van de standaardserver te bevestigen. De verbinding wordt omgeleid via het `Tor` Netwerk om privacy en anonimiteit te garanderen.
 
 
-**Inzicht in uw pincodes**
+**Inzicht in je pincodes**
 
 
 
-- `App Unlock PIN`**:** De optionele PIN die is ingesteld in `Instellingen > Beveiligings-PIN` om de app op uw telefoon te vergrendelen.
-- `Recovery PIN`**:** De verplichte PIN die is aangemaakt tijdens het `Encrypted Vault` back-upproces en die wordt gebruikt om uw back-upbestand te decoderen tijdens het herstel.
+- `App Unlock PIN`**:** De optionele PIN die is ingesteld in `Settings > Security-PIN` om de app op je telefoon te vergrendelen.
+- `Recovery PIN`**:** De verplichte PIN die is aangemaakt tijdens het `Encrypted Vault` back-upproces en die wordt gebruikt om je back-upbestand te decoderen tijdens het herstel.
 
 
-Dit zijn twee afzonderlijke PIN-codes. Vergeet uw Herstel PIN niet, want deze is essentieel voor het herstellen van uw wallet."
+Dit zijn twee afzonderlijke PIN-codes. Vergeet je Recovery PIN niet, want deze is essentieel voor het herstellen van je wallet."
 
 
 **Recovery PIN instellen:**
 
 
 
-- U moet een PIN-code of wachtwoord aanmaken om weer toegang te krijgen tot uw wallet.
+- Je moet een PIN-code of wachtwoord aanmaken om weer toegang te krijgen tot je wallet.
 - De PIN-code / het wachtwoord moet minstens 6 cijfers lang zijn (vermijd bijvoorbeeld eenvoudige reeksen zoals 123456, die niet worden geaccepteerd).
 - Zonder deze PIN is wallet herstel onmogelijk.
 
@@ -195,19 +193,19 @@ Selecteer vervolgens een vault provider:
 
 
 - google Drive` of
-- een `gekozen locatie` (bijvoorbeeld uw apparaat)
+- een `gekozen locatie` (bijvoorbeeld je apparaat)
 
 
 ![image](assets/en/04.webp)
 
 
-Sla nu het `back-up bestand` op. Tik vervolgens op `Test herstel`, selecteer je opgeslagen back-upbestand of kluis en tik op `Kluis ontsleutelen`. Voer je `PIN` of `Wachtwoord` in. Als alles werkt, verschijnt het scherm `Test succesvol voltooid`.
+Sla nu het `back-up bestand` op. Tik vervolgens op `Test Recovery`, selecteer je opgeslagen back-upbestand of kluis en tik op `Decrypt Vault`. Voer je `PIN` of `wachtwoord` in. Als alles werkt, verschijnt het scherm `Test completed successfully`.
 
 
 ### Labels importeren/exporteren
 
 
-Nu we onze Back-up hebben gemaakt, gaan we eens kijken naar `labels`.  De Bull Bitcoin wallet verbetert de privacy en organisatie door gebruikers in staat te stellen aangepaste labels te maken voor hun ontvangstadressen en transacties. Deze labels helpen je bij het categoriseren van je geld, omdat transacties die naar een gelabeld adres worden gestuurd, dat label overnemen, en je kunt ook uitgaande transacties labelen om hun verandering bij te houden. De wallet ondersteunt de [BIP-329](https://bip329.org/) standaard volledig, wat betekent dat u al uw labels naar een bestand kunt exporteren en in een andere wallet kunt importeren. Deze functie zorgt ervoor dat u naadloos een back-up kunt maken van uw transactiegeschiedenis en categorisaties, of deze kunt migreren tussen verschillende instanties van de wallet, zonder uw persoonlijke organisatie te verliezen.
+Nu we onze back-up hebben gemaakt, gaan we eens kijken naar `labels`.  De Bull Bitcoin-wallet verbetert de privacy en organisatie door gebruikers in staat te stellen aangepaste labels te maken voor hun ontvangstadressen en transacties. Deze labels helpen je bij het categoriseren van je geld, omdat transacties die naar een gelabeld adres worden gestuurd, dat label overnemen, en je kunt ook uitgaande transacties labelen om hun verandering bij te houden. De wallet ondersteunt de [BIP-329](https://bip329.org/) standaard volledig, wat betekent dat je al je labels naar een bestand kunt exporteren en in een andere wallet kunt importeren. Deze functie zorgt ervoor dat je naadloos een back-up kunt maken van je transactiegeschiedenis en categorisaties, of deze kunt migreren tussen verschillende instanties van de wallet, zonder je persoonlijke organisatie te verliezen.
 
 
 ![image](assets/en/05.webp)
@@ -222,19 +220,19 @@ Nu je primaire back-up veilig is gesteld, gaan we de andere functies in de inste
 ### A - Toegang beveiligen
 
 
-Om de app te beveiligen, navigeer naar `Instellingen` en kies `Beveiligings-PIN` om een PIN-code te selecteren. Maak een sterke PIN-code aan om de toegang tot uw wallet te vergrendelen. Hoewel deze stap optioneel is, wordt het sterk aanbevolen om onbevoegde toegang te voorkomen als iemand anders uw telefoon gebruikt.
+Om de app te beveiligen, navigeer naar ` Settings ` en kies `Security PIN` om een PIN-code te selecteren. Maak een sterke PIN-code aan om de toegang tot je wallet te vergrendelen. Hoewel deze stap optioneel is, wordt het sterk aanbevolen om onbevoegde toegang te voorkomen als iemand anders je telefoon gebruikt.
 
 
 ![image](assets/en/06.webp)
 
 
-### B - Verbinding met een persoonlijk knooppunt (optioneel)
+### B - Verbinding met een persoonlijke node (optioneel)
 
 
-De Wallet BullBitcoin maakt standaard verbinding met Electrum servers: de eerste wordt beheerd door Bull Bitcoin en een secundaire server van Blockstream, die beide geen logs bijhouden, waardoor het risico op tracering kleiner is.
+De wallet BullBitcoin maakt standaard verbinding met Electrum servers: de eerste wordt beheerd door Bull Bitcoin en een secundaire server van Blockstream, die beide geen logs bijhouden, waardoor het risico op tracering kleiner is.
 
 
-Voor meer vertrouwelijkheid kunt u de applicatie verbinden met uw eigen Bitcoin knooppunt via een Electrum server. Tik hiervoor op `Instellingen` > `Bitcoin Instellingen` > `Electrum Server Instellingen`, tik vervolgens op `+ Aangepaste server toevoegen` om het adres en de gegevens van uw server in te voeren.
+Voor meer vertrouwelijkheid kunt je de applicatie verbinden met je eigen Bitcoin knooppunt via een Electrum server. Tik hiervoor op ` Settings ` > `Bitcoin  Settings ` > `Electrum Server  Settings `, tik vervolgens op `+ Aangepaste server toevoegen` om het adres en de gegevens van je server in te voeren.
 
 
 ![image](assets/en/07.webp)
@@ -243,7 +241,7 @@ Voor meer vertrouwelijkheid kunt u de applicatie verbinden met uw eigen Bitcoin 
 ### C - Valuta
 
 
-Het beschikbare saldo wordt op het hoofdscherm weergegeven in zowel `sats` als `USD`. Om dit te veranderen, ga je naar `Instellingen` > `Munteenheid`. Daar kun je wisselen tussen `sats/BTC` en je `standaard fiatvaluta` selecteren.
+Het beschikbare saldo wordt op het hoofdscherm weergegeven in zowel `sats` als `USD`. Om dit te veranderen, ga je naar ` Settings ` > `Munteenheid`. Daar kun je wisselen tussen `sats/BTC` en je `standaard fiatvaluta` selecteren.
 
 
 ![image](assets/en/08.webp)
@@ -252,16 +250,16 @@ Het beschikbare saldo wordt op het hoofdscherm weergegeven in zowel `sats` als `
 ### D - Bitcoin Instellingen
 
 
-Het menu `Bitcoin Instellingen` biedt diepgaande toegang tot de kernconfiguraties en -gegevens van je wallet. Hier kun je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken. Hier kunt u de fundamentele details van uw `Secure Bitcoin` en `Instant payments wallets` bekijken, waardoor u volledige transparantie en controle heeft. De belangrijkste functies in dit menu zijn:
+Het menu `Bitcoin  Settings ` biedt diepgaande toegang tot de kernconfiguraties en -gegevens van je wallet. Hier kun je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken. Hier kunt je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken, waardoor je volledige transparantie en controle heeft. De belangrijkste functies in dit menu zijn:
 
 
 
-- Wallet Details:** Navigeer naar uw Beveiligde Bitcoin of Directe betalingen wallet om specifieke informatie te bekijken.
-- Wallet vingerafdruk:** Een unieke identificatie voor uw wallet.
-- Publieke sleutel (Pubkey):** De sleutel die gebruikt wordt om generate uw Bitcoin ontvangstadressen te geven.
+- Wallet Details:** Navigeer naar je Beveiligde Bitcoin of Directe betalingen wallet om specifieke informatie te bekijken.
+- Wallet vingerafdruk:** Een unieke identificatie voor je wallet.
+- Publieke sleutel (Pubkey):** De sleutel die gebruikt wordt om generate je Bitcoin ontvangstadressen te geven.
 - Descriptor:** Een technische samenvatting van de structuur van je wallet.
 - Afleidingspad:** Het specifieke pad dat wordt gebruikt om generate alle adressen van je privésleutel af te leiden.
-- Address bekijken:** Bekijk een lijst met uw ongebruikte ontvangstadressen en wijzig adressen (verschijnt binnenkort)
+- Address bekijken:** Bekijk een lijst met je ongebruikte ontvangstadressen en wijzig adressen (verschijnt binnenkort)
 
 
 Bovendien heb je de optie om:
@@ -269,17 +267,17 @@ Bovendien heb je de optie om:
 
 
 - `Enable Auto Transfer` instellingen om een maximum direct wallet saldo in te stellen, dat vervolgens automatisch wordt overgeboekt naar de beveiligde bitcoin wallet.
-- Generieke portemonnees importeren via `Mnemonic` zin of `watch-only` importeren
+- Generieke wallets importeren via `Mnemonic` zin of `watch-only` importeren
 - Verbind `Hardware wallets`: momenteel worden ColdcardQ, SeedSigner, Specter, Krux, Blockstream Jade en Foundation Passport ondersteund
 
 
 ## 7️⃣ Bull Bitcoin Exchange
 
 
-Direct vanuit de wallet heb je toegang tot de [Bull Bitcoin exchange](https://www.bullbitcoin.com/), zodat je Bitcoin kunt kopen, verkopen en betalen zonder de app te verlaten. Deze integratie biedt een handige oplossing voor het beheren van uw Bitcoin behoeften. Houd er rekening mee dat de toegang tot de beurs en de diensten beperkt kan zijn, afhankelijk van uw jurisdictie, en dat het voltooien van een KYC-verificatie (Know Your Customer) vereist kan zijn om te voldoen aan de wettelijke normen en gebruik te maken van alle functies van het platform.
+Direct vanuit de wallet heb je toegang tot de [Bull Bitcoin exchange](https://www.bullbitcoin.com/), zodat je Bitcoin kunt kopen, verkopen en betalen zonder de app te verlaten. Deze integratie biedt een handige oplossing voor het beheren van je Bitcoin behoeften. Houd er rekening mee dat de toegang tot de beurs en de diensten beperkt kan zijn, afhankelijk van je jurisdictie, en dat het voltooien van een KYC-verificatie (Know Your Customer) vereist kan zijn om te voldoen aan de wettelijke normen en gebruik te maken van alle functies van het platform.
 
 
-Om te beginnen tikt u op `Exchange` in de rechterbenedenhoek en vervolgens op `Sign up` of `Login` voor uw account.
+Om te beginnen tikt je op `Exchange` in de rechterbenedenhoek en vervolgens op `Sign up` of `Login` voor je account.
 
 
 De beurs biedt de volgende [functies](https://www.bullbitcoin.com/):
@@ -307,11 +305,11 @@ https://planb.academy/en/tutorials/exchange/centralized/bull-bitcoin-europe-0ccf
 ## 8️⃣ Geld ontvangen
 
 
-Geld ontvangen met **Bull Bitcoin Wallet** is eenvoudig en flexibel, met ondersteuning voor drie verschillende netwerken, op maat gemaakt voor verschillende gebruikssituaties:
+Geld ontvangen met **Bull Bitcoin-wallet** is eenvoudig en flexibel, met ondersteuning voor drie verschillende netwerken, op maat gemaakt voor verschillende gebruikssituaties:
 
 
 
-- Het `Bitcoin (onchain)` netwerk voor veilige, langdurige opslag.
+- Het `Bitcoin (on-chain)` netwerk voor veilige, langdurige opslag.
 - Het `Liquid` netwerk voor snelle, meer vertrouwelijke transacties.
 - Het `Lightning` netwerk voor directe, goedkope betalingen.
 
@@ -322,7 +320,7 @@ De app genereert automatisch het juiste adres of de juiste factuur op basis van 
 ### Ontvangen via Onchain (Bitcoin netwerk)
 
 
-Om on-chain fondsen te ontvangen, kun je ofwel de `Veilig Bitcoin Wallet` op het Beginscherm selecteren en op `Ontvangen` tikken, of op de hoofdknop `Ontvangen` tikken en dan het `Bitcoin netwerk` kiezen.
+Om on-chain fondsen te ontvangen, kun je ofwel de `Veilig Bitcoin wallet` op het Beginscherm selecteren en op `Ontvangen` tikken, of op de hoofdknop `Ontvangen` tikken en dan het `Bitcoin netwerk` kiezen.
 
 
 Je hebt twee primaire modi voor het genereren van een ontvangstadres:
@@ -418,7 +416,7 @@ Om de transactie te voltooien, geef je de afzender het `adres` of de `URI`. Je k
 
 
 
-Met de Bull Bitcoin Wallet kun je ook betalingen verzenden en ontvangen via de Lightning Network. Een belangrijk kenmerk is dat geld dat je via Lightning ontvangt automatisch wordt omgewisseld en opgeslagen op de `Liquid Network` binnen je `Instant Payments Wallet`. Deze dienst wordt aangedreven door de `Boltz`. Door dit ontwerp kunt u profiteren van de snelheid en lage kosten van Lightning zonder de complexiteit van het beheren van liquiditeitskanalen, terwijl u uw fondsen volledig zelf bewaart. Hoewel deze hybride benadering self-custodial is en de complexiteit van het beheren van kanalen vermijdt, introduceert het een dienst van een derde partij (Boltz), een kleine swapvergoeding en afhankelijkheid van de Liquid Network federatie van functionarissen als keyholders, wat anders is dan een traditionele, niet-custodial Lightning wallet waar u uw eigen kanalen beheert. Je kunt hier meer te weten komen over Liquid en hun bestuursmodel:
+Met de Bull Bitcoin-wallet kun je ook betalingen verzenden en ontvangen via de Lightning Network. Een belangrijk kenmerk is dat geld dat je via Lightning ontvangt automatisch wordt omgewisseld en opgeslagen op de `Liquid Network` binnen je `Instant Payments wallet`. Deze dienst wordt aangedreven door de `Boltz`. Door dit ontwerp kunt je profiteren van de snelheid en lage kosten van Lightning zonder de complexiteit van het beheren van liquiditeitskanalen, terwijl je je fondsen volledig zelf bewaart. Hoewel deze hybride benadering self-custodial is en de complexiteit van het beheren van kanalen vermijdt, introduceert het een dienst van een derde partij (Boltz), een kleine swapvergoeding en afhankelijkheid van de Liquid Network federatie van functionarissen als keyholders, wat anders is dan een traditionele, niet-custodial Lightning wallet waar je je eigen kanalen beheert. Je kunt hier meer te weten komen over Liquid en hun bestuursmodel:
 
 
 https://planb.academy/en/courses/e17ee350-41d4-49fa-b270-29e4d26d22f8/overview-of-liquid-architecture-and-governance-model-17650c4b-cd1f-4bc6-b490-708f92dc9306
@@ -428,9 +426,9 @@ https://planb.academy/en/courses/e17ee350-41d4-49fa-b270-29e4d26d22f8/overview-o
     - Minimumbedrag:** Een minimumfactuurbedrag is vereist. Controleer de app voor de huidige limiet
     - Kosten:** Jij, de ontvanger, bent verantwoordelijk voor een kleine swapvergoeding. Deze kosten worden afgetrokken van het bedrag dat de verzender overmaakt en kunnen veranderen
 - Voordelen:**
-    - Zelfbeheerd:** Uw geld is altijd onder uw controle, beveiligd op het Liquid-netwerk.
-    - Vermijd hoge On-Chain kosten:** Door Lightning te gebruiken en op te slaan op Liquid, omzeilt u de on-chain kosten die gepaard gaan met het openen van een traditioneel Lightning-kanaal. U kunt ervoor kiezen om later geld over te hevelen naar een on-chain-kanaal, wanneer het geaccumuleerde bedrag de kosten rechtvaardigt.
-    - Tip:** Voor de meest kosteneffectieve transactie tussen twee Bull Bitcoin gebruikers, gebruikt u het **Liquid netwerk rechtstreeks** om de Lightning swapkosten volledig te vermijden.
+    - Zelfbeheerd:** Uw geld is altijd onder je controle, beveiligd op het Liquid-netwerk.
+    - Vermijd hoge on-chain kosten:** Door Lightning te gebruiken en op te slaan op Liquid, omzeilt je de on-chain kosten die gepaard gaan met het openen van een traditioneel Lightning-kanaal. U kunt ervoor kiezen om later geld over te hevelen naar een on-chain-kanaal, wanneer het geaccumuleerde bedrag de kosten rechtvaardigt.
+    - Tip:** Voor de meest kosteneffectieve transactie tussen twee Bull Bitcoin gebruikers, gebruikt je het **Liquid netwerk rechtstreeks** om de Lightning swapkosten volledig te vermijden.
 
 
 Om een betaling te ontvangen, moet je generate een `bliksemfactuur` hebben:
@@ -440,7 +438,7 @@ Om een betaling te ontvangen, moet je generate een `bliksemfactuur` hebben:
 
 2. notitie toevoegen` **(Optioneel):** Voeg een memo of notitie toe. Deze wordt opgenomen in de factuur en weergegeven in je transactiegeschiedenis zodra de betaling is voltooid, zodat je deze gemakkelijker kunt identificeren.
 
-3. `Invoice Geldigheid`**:** De Lightning-factuur is tijdsgevoelig en vervalt na **12 uur**. Als de factuur niet binnen deze periode wordt betaald, wordt deze ongeldig en moet u generate een nieuwe factuur maken.
+3. `Invoice Geldigheid`**:** De Lightning-factuur is tijdsgevoelig en vervalt na **12 uur**. Als de factuur niet binnen deze periode wordt betaald, wordt deze ongeldig en moet je generate een nieuwe factuur maken.
 
 
 Geef de factuur aan de verzender door hem naar je klembord te kopiëren of door hem de QR-code te laten scannen die op je scherm wordt weergegeven.
@@ -452,13 +450,13 @@ Geef de factuur aan de verzender door hem naar je klembord te kopiëren of door 
 ## 9️⃣ Geld versturen
 
 
-Je kunt het verzendscherm rechtstreeks openen vanaf de startpagina of vanuit een van je portemonnees. Bull Bitcoin Wallet vereenvoudigt het proces door automatisch het bestemmingsnetwerk te detecteren - `Bitcoin`, `Liquid` of `Lightning` op basis van het adres of de factuur die je invoert, geplakt of gescand via een QR-code.
+Je kunt het verzendscherm rechtstreeks openen vanaf de startpagina of vanuit een van je portemonnees. Bull Bitcoin-wallet vereenvoudigt het proces door automatisch het bestemmingsnetwerk te detecteren - `Bitcoin`, `Liquid` of `Lightning` op basis van het adres of de factuur die je invoert, geplakt of gescand via een QR-code.
 
 
-### On-Chain Verzending via het Bitcoin Netwerk
+### on-chain Verzending via het Bitcoin Netwerk
 
 
-Geld overmaken via on-chain betekent dat uw transactie direct wordt geregistreerd op de Bitcoin blockchain. Deze methode is het beste voor grotere overschrijvingen of niet-tijdgevoelige overschrijvingen. Om te beginnen kun je rechtsonder op de `Verstuur Knop` tikken, en een `standaard Bitcoin adres` scannen of invoeren.
+Geld overmaken via on-chain betekent dat je transactie direct wordt geregistreerd op de Bitcoin blockchain. Deze methode is het beste voor grotere overschrijvingen of niet-tijdgevoelige overschrijvingen. Om te beginnen kun je rechtsonder op de `Verstuur Knop` tikken, en een `standaard Bitcoin adres` scannen of invoeren.
 
 
 Als het adres dat je opgeeft geen specifiek bedrag bevat, wordt je gevraagd om de details in te vullen op het verzendscherm. Je kunt het bedrag opgeven in de eenheid van je voorkeur, zoals BTC, satoshis of een fiat equivalent. Je hebt ook de optie om een persoonlijke notitie toe te voegen, wat een privémemo is voor je eigen referentie om je te helpen de transactie later te identificeren. Deze notitie wordt niet gedeeld met de ontvanger.
@@ -473,7 +471,7 @@ Omgekeerd, als het betalingsverzoek dat je scant of plakt al alle nodige details
 Voordat je transactie wordt uitgezonden, krijg je een bevestigingsscherm te zien. Het is van cruciaal belang dat je even de tijd neemt om elke parameter zorgvuldig te bekijken, waarbij je veel aandacht besteedt aan het adres van de ontvanger, het bedrag dat wordt verzonden en de netwerkkosten. Dit scherm biedt ook krachtige hulpmiddelen om je transactie aan te passen.
 
 
-Je kunt de kosten op twee manieren regelen. De eerste methode is het selecteren van een gewenste transactiesnelheid, zoals laag, medium of hoog, en de wallet berekent automatisch de juiste vergoeding voor je. De tweede methode biedt een preciezere controle door u een specifieke vergoeding te laten instellen, hetzij als een absoluut totaal in satoshi's of als een relatief tarief per byte, dat vervolgens een geschatte bevestigingstijd oplevert.
+Je kunt de kosten op twee manieren regelen. De eerste methode is het selecteren van een gewenste transactiesnelheid, zoals laag, medium of hoog, en de wallet berekent automatisch de juiste vergoeding voor je. De tweede methode biedt een preciezere controle door je een specifieke vergoeding te laten instellen, hetzij als een absoluut totaal in satoshi's of als een relatief tarief per byte, dat vervolgens een geschatte bevestigingstijd oplevert.
 
 
 Voor geavanceerde gebruikers biedt de wallet verschillende instellingen om de transactie nauwkeurig af te stellen. standaard is `Replace-by-Fee` (RBF) ingeschakeld, wat een waardevolle functie is waarmee je een transactie kunt versnellen als deze vastloopt in de mempool door deze opnieuw uit te zenden met een hogere vergoeding. Je kunt ook handmatig kiezen uit welke `Unspent Transaction Outputs` (UTXOs) je wilt uitgeven. Dit is een krachtig hulpmiddel voor UTXO consolidatie, een strategie waarbij je meerdere kleine ingangen combineert tot één grotere. Hoewel dit meer kosten met zich meebrengt voor de huidige transactie, kan het de kosten voor toekomstige transacties aanzienlijk verlagen, vooral als de netwerkkosten naar verwachting zullen stijgen.
@@ -488,7 +486,7 @@ PayJoin wordt automatisch geprobeerd wanneer je een betalingsverzoek van een ont
 ### Verzenden naar de Liquid Network
 
 
-De `Liquid Network` is ontworpen voor snelle, vertrouwelijke transacties met minimale kosten. Wanneer je geld verstuurt via de Liquid, wordt het opgenomen uit je `Instant Payments Wallet`. Het proces is eenvoudig: je hoeft alleen maar het `Liquid` adres van de ontvanger in te voeren of te scannen.
+De `Liquid Network` is ontworpen voor snelle, vertrouwelijke transacties met minimale kosten. Wanneer je geld verstuurt via de Liquid, wordt het opgenomen uit je `Instant Payments wallet`. Het proces is eenvoudig: je hoeft alleen maar het `Liquid` adres van de ontvanger in te voeren of te scannen.
 
 
 Als het adres geen bedrag opgeeft, wordt je gevraagd om er een op te geven op het verzendscherm. Je kunt het bedrag invoeren in BTC, satoshis of fiat. Een belangrijk voordeel van Liquid is de lage minimumdrempel. Net als bij on-chain transacties, kun je een optionele persoonlijke notitie toevoegen voor je eigen administratie. Als het betalingsverzoek al een bedrag bevat, gaat wallet direct door naar het bevestigingsscherm.
@@ -509,31 +507,31 @@ Je kunt een Lightning Address scannen (bijv. `runningbitcoin@rizful.com`) waarme
 *Houd er rekening mee dat er minimumbedragen en kosten van toepassing zijn.*
 
 
-De Bull Bitcoin Wallet verstuurt Lightning-betalingen door geld op te nemen uit uw `Instant Payments Wallet` (op Liquid) en dit om te wisselen via `Boltz`. Deze hybride benadering is volledig self-custodial en vermijdt de hoge on-chain kosten voor het beheren van een speciaal Lightning-kanaal, maar vereist wel het betalen van `swapkosten`. Stuur voor de laagste kosten rechtstreeks naar het Liquid adres van een ontvanger als deze ook een Bull Bitcoin wallet gebruikt.
+De Bull Bitcoin-wallet verstuurt Lightning-betalingen door geld op te nemen uit je `Instant Payments wallet` (op Liquid) en dit om te wisselen via `Boltz`. Deze hybride benadering is volledig self-custodial en vermijdt de hoge on-chain kosten voor het beheren van een speciaal Lightning-kanaal, maar vereist wel het betalen van `swapkosten`. Stuur voor de laagste kosten rechtstreeks naar het Liquid adres van een ontvanger als deze ook een Bull Bitcoin-wallet gebruikt.
 
 
-## geld overboeken tussen uw portefeuilles
+## geld overboeken tussen je portefeuilles
 
 
-Bull Bitcoin maakt het mogelijk om je Bitcoin te verplaatsen tussen je `Secure Bitcoin` wallet en je `Instant Payments Wallet` op de Liquid Network of naar een `externe Wallet`. Om een overschrijving uit te voeren, navigeer je gewoon naar de `Overschrijving` sectie, selecteer je de bron- en doelportemonnee, voer je het bedrag in dat je wilt verplaatsen en bevestig je de transactie.
+Bull Bitcoin maakt het mogelijk om je Bitcoin te verplaatsen tussen je `Secure Bitcoin` wallet en je `Instant Payments wallet` op de Liquid Network of naar een `externe wallet`. Om een overschrijving uit te voeren, navigeer je gewoon naar de `Overschrijving` sectie, selecteer je de bron- en doelportemonnee, voer je het bedrag in dat je wilt verplaatsen en bevestig je de transactie.
 
 
 ![image](assets/en/17.webp)
 
 
-## 1️⃣1️⃣ Uw Bull Bitcoin Wallet herstellen
+## 1️⃣1️⃣ Uw Bull Bitcoin-wallet herstellen
 
 
-Dit hoofdstuk legt uit hoe je weer toegang krijgt tot je Bull Bitcoin Wallet fondsen als je je apparaat verliest, de app verwijdert, of gewoon naar een nieuw apparaat moet overschakelen. Zoals eerder uitgelegd, zijn er twee primaire methoden voor herstel: met de unieke `Recoverbull` methode en met een standaard `BIP39 seed zin`.
+Dit hoofdstuk legt uit hoe je weer toegang krijgt tot je Bull Bitcoin-wallet fondsen als je je apparaat verliest, de app verwijdert, of gewoon naar een nieuw apparaat moet overschakelen. Zoals eerder uitgelegd, zijn er twee primaire methoden voor herstel: met de unieke `Recoverbull` methode en met een standaard `BIP39 seed zin`.
 
 
 ### Methode 1: Herstelbull
 
 
-Recapitulatie: Wallet back-ups worden lokaal versleuteld. Het versleutelde bestand kan opgeslagen worden in een cloud opslag, of op een ander apparaat. De encryptie sleutel wordt opgeslagen door de Recoverbull Key Server. Beide worden apart gehouden en moeten gecombineerd worden om een wallet te herstellen.
+Recapitulatie: wallet back-ups worden lokaal versleuteld. Het versleutelde bestand kan opgeslagen worden in een cloud opslag, of op een ander apparaat. De encryptie sleutel wordt opgeslagen door de Recoverbull Key Server. Beide worden apart gehouden en moeten gecombineerd worden om een wallet te herstellen.
 
 
-Om te beginnen wis ik de Wallet met alle fondsen erop en installeer ik de wallet opnieuw. We komen weer op het `Welkom scherm`. Selecteer deze keer de optie `Wallet herstellen`. Navigeer vervolgens naar de `Encrypted Vault` methode, bevestig het gebruik van de `Default Key server` en selecteer de locatie of `Vault provider` waar je het back-up bestand hebt opgeslagen.
+Om te beginnen wis ik de wallet met alle fondsen erop en installeer ik de wallet opnieuw. We komen weer op het `Welkom scherm`. Selecteer deze keer de optie `wallet herstellen`. Navigeer vervolgens naar de `Encrypted Vault` methode, bevestig het gebruik van de `Default Key server` en selecteer de locatie of `Vault provider` waar je het back-up bestand hebt opgeslagen.
 
 
 ![image](assets/en/18.webp)
@@ -548,38 +546,38 @@ Er staat dat de kluis met succes is geïmporteerd. Tik op de knop `Kluis ontsleu
 ### Methode 2: Zaadzin
 
 
-Deze methode gebruikt de master herstelzin van uw wallet, een standaard lijst van 12 woorden die dient als ultieme back-up voor uw fondsen. Het is de meest universele manier om een Bitcoin wallet te herstellen, omdat het niet gebonden is aan een specifieke dienst of server. Zolang je deze zin hebt, kun je je wallet herstellen op elk compatibel apparaat, zelfs zonder toegang tot de Bull Bitcoin keyserver.
+Deze methode gebruikt de master herstelzin van je wallet, een standaard lijst van 12 woorden die dient als ultieme back-up voor je fondsen. Het is de meest universele manier om een Bitcoin-wallet te herstellen, omdat het niet gebonden is aan een specifieke dienst of server. Zolang je deze zin hebt, kun je je wallet herstellen op elk compatibel apparaat, zelfs zonder toegang tot de Bull Bitcoin keyserver.
 
 
-Selecteer in het welkomstscherm `Recover Wallet`. Kies deze keer de `Physical backup` methode. De app toont een raster van woorden. Selecteer zorgvuldig elk woord van je 12-woorden seed zin in de juiste volgorde. Wees nauwgezet, want één foutje resulteert in een onjuiste wallet.
+Selecteer in het welkomstscherm `Recover wallet`. Kies deze keer de `Physical backup` methode. De app toont een raster van woorden. Selecteer zorgvuldig elk woord van je 12-woorden seed zin in de juiste volgorde. Wees nauwgezet, want één foutje resulteert in een onjuiste wallet.
 
 
-## 1️⃣2️⃣ Een Hardware Wallet aansluiten
+## 1️⃣2️⃣ Een Hardware wallet aansluiten
 
 
-Voor het hoogste niveau van veiligheid kiezen veel Bitcoin gebruikers ervoor om hun geld op te slaan in `cold storage`. Dit betekent dat de `private sleutels` die uw Bitcoin besturen op een apparaat bewaard worden dat nooit met het internet verbonden is. Een `hardware wallet` (of Signing device) is een gespecialiseerd fysiek apparaat dat precies voor dit doel is ontworpen. Het fungeert als een digitale kluis voor uw sleutels en zorgt ervoor dat ze nooit worden blootgesteld aan de potentiële bedreigingen van een online computer of smartphone.
+Voor het hoogste niveau van veiligheid kiezen veel Bitcoin gebruikers ervoor om hun geld op te slaan in `cold storage`. Dit betekent dat de `private sleutels` die je Bitcoin besturen op een apparaat bewaard worden dat nooit met het internet verbonden is. Een `hardware wallet` (of Signing device) is een gespecialiseerd fysiek apparaat dat precies voor dit doel is ontworpen. Het fungeert als een digitale kluis voor je sleutels en zorgt ervoor dat ze nooit worden blootgesteld aan de potentiële bedreigingen van een online computer of smartphone.
 
 
-Door een hardware wallet aan te sluiten op de Bull Bitcoin app, krijgt u het beste van twee werelden: de compromisloze veiligheid van koude opslag voor uw privésleutels, gecombineerd met de krachtige functies en gebruiksvriendelijke interface van de Bull Bitcoin wallet voor het bekijken van saldi en het beheren van transacties. In dit laatste hoofdstuk laten we zien hoe je een hardware wallet, zoals een [Coldcard Q](https://coldcard.com/q), op je Bull Bitcoin wallet aansluit. Deze tutorial gaat niet dieper in op het instellen van een Coldcard Q; dat kun je hier leren:
+Door een hardware wallet aan te sluiten op de Bull Bitcoin app, krijgt je het beste van twee werelden: de compromisloze veiligheid van koude opslag voor je privésleutels, gecombineerd met de krachtige functies en gebruiksvriendelijke interface van de Bull Bitcoin-wallet voor het bekijken van saldi en het beheren van transacties. In dit laatste hoofdstuk laten we zien hoe je een hardware wallet, zoals een [Coldcard Q](https://coldcard.com/q), op je Bull Bitcoin-wallet aansluit. Deze tutorial gaat niet dieper in op het instellen van een Coldcard Q; dat kun je hier leren:
 
 
 https://planb.academy/en/tutorials/wallet/hardware/coldcard-q-73e86d1a-6fe6-4d8b-bb15-8690298020e3
 
 https://planb.academy/en/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-eea9-48fe-a953-b003d5b115e0
 
-### Een Wallet importeren
+### Een wallet importeren
 
 
 ![image](assets/en/26.webp)
 
 
-Selecteer eerst in het hoofdmenu van je Coldcard Q `Export Wallet` en kies dan `Bull Wallet`. Je Coldcard zal generate een QR code krijgen.
+Selecteer eerst in het hoofdmenu van je Coldcard Q `Export wallet` en kies dan `Bull wallet`. Je Coldcard zal generate een QR code krijgen.
 
 
 ![image](assets/en/20.webp)
 
 
-Open de Bull Bitcoin Wallet en navigeer naar `Instellingen` > `Bitcoin Instellingen` > `Import wallet` en selecteer `Coldcard Q` op uw telefoon en tik op `Open de camera` om deze QR-code te scannen om de publieke sleutels van uw hardware wallet te importeren.
+Open de Bull Bitcoin-wallet en navigeer naar ` Settings ` > `Bitcoin  Settings ` > `Import wallet` en selecteer `Coldcard Q` op je telefoon en tik op `Open de camera` om deze QR-code te scannen om de publieke sleutels van je hardware wallet te importeren.
 
 
 ![image](assets/en/21.webp)
@@ -588,10 +586,10 @@ Open de Bull Bitcoin Wallet en navigeer naar `Instellingen` > `Bitcoin Instellin
 ### Ontvangen met Coldcard Q
 
 
-Om Bitcoin te ontvangen via uw aangesloten Coldcard Q, hoeft het apparaat niet fysiek verbonden te zijn met uw telefoon. De Bull Bitcoin Wallet heeft de benodigde publieke sleutels al geïmporteerd, waardoor het zelfstandig generate adressen kan ontvangen.
+Om Bitcoin te ontvangen via je aangesloten Coldcard Q, hoeft het apparaat niet fysiek verbonden te zijn met je telefoon. De Bull Bitcoin-wallet heeft de benodigde publieke sleutels al geïmporteerd, waardoor het zelfstandig generate adressen kan ontvangen.
 
 
-1. Tik op uw geïmporteerde Coldcard Q ondertekeningsapparaat en selecteer `Ontvangen`.
+1. Tik op je geïmporteerde Coldcard Q ondertekeningsapparaat en selecteer `Ontvangen`.
 
 2. De app zal automatisch een vers Bitcoin adres weergeven van de wallet van je Coldcard.
 
@@ -604,7 +602,7 @@ Om Bitcoin te ontvangen via uw aangesloten Coldcard Q, hoeft het apparaat niet f
 ### Verzenden met Coldcard Q
 
 
-Het verzenden van Bitcoin met uw Coldcard Q vereist uw fysieke bevestiging om elke transactie te autoriseren. Hoewel de Bull Wallet app wordt gebruikt om de transactie op te bouwen, kan de uiteindelijke handtekening alleen worden aangemaakt op de hardware wallet zelf.
+Het verzenden van Bitcoin met je Coldcard Q vereist je fysieke bevestiging om elke transactie te autoriseren. Hoewel de Bull wallet app wordt gebruikt om de transactie op te bouwen, kan de uiteindelijke handtekening alleen worden aangemaakt op de hardware wallet zelf.
 
 
 Open om te beginnen je `Coldcard Q` wallet en tik op `Versturen`. Open vervolgens de camera om de QR-code voor het ontvangende adres te scannen. Na het scannen voer je het `bedrag` in dat je wilt versturen en pas je de `kostenprioriteit` aan als dat nodig is.
@@ -619,22 +617,22 @@ Zodra je alle details hebt bekeken, tik je op `Toon PSBT` om de transactie voor 
 ![image](assets/en/23.webp)
 
 
-Tik op de `Scan` knop op uw Coldcard Q en gebruik de camera om de QR code op uw telefoon te scannen. Het Coldcard scherm toont u vervolgens alle transactie details. Controleer zorgvuldig het bedrag, het adres van de ontvanger en uw wijzigingsadres. Als alles correct is, druk dan op de `Enter` knop op de Coldcard Q om de transactie te ondertekenen. Vervolgens verschijnt er een QR code van de ondertekende transactie op het scherm.
+Tik op de `Scan` knop op je Coldcard Q en gebruik de camera om de QR code op je telefoon te scannen. Het Coldcard scherm toont je vervolgens alle transactie details. Controleer zorgvuldig het bedrag, het adres van de ontvanger en je wijzigingsadres. Als alles correct is, druk dan op de `Enter` knop op de Coldcard Q om de transactie te ondertekenen. Vervolgens verschijnt er een QR code van de ondertekende transactie op het scherm.
 
 
 ![image](assets/en/24.webp)
 
 
-Tik op de Bull wallet op `Ik ben klaar`, tik vervolgens op de `Camera` knop om de QR-code van de `ondertekende transactie` te scannen van uw Coldcard Q. De Bull wallet toont nu een overzichtsscherm van de ondertekende transactie. Controleer het nog een laatste keer en tik dan op `Transactie verzenden`. Dit rondt het proces af door de transactie naar het Bitcoin netwerk te sturen, en uw geld is onderweg.
+Tik op de Bull wallet op `Ik ben klaar`, tik vervolgens op de `Camera` knop om de QR-code van de `ondertekende transactie` te scannen van je Coldcard Q. De Bull wallet toont nu een overzichtsscherm van de ondertekende transactie. Controleer het nog een laatste keer en tik dan op `Transactie verzenden`. Dit rondt het proces af door de transactie naar het Bitcoin netwerk te sturen, en je geld is onderweg.
 
 
 ## conclusie
 
 
-Je hebt nu je reis door de Bull Bitcoin Wallet voltooid. De app brengt krachtige privacy- en beveiligingstools binnen handbereik, waardoor geavanceerde functies eenvoudig te gebruiken zijn. Het helpt je privé te blijven met functies zoals `PayJoin`, dat je transacties verbergt op de blockchain, en `Tor integratie`, dat je netwerkactiviteit maskeert voor nieuwsgierige ogen. Voor degenen die ultieme controle willen, kun je verbinding maken met je `eigen persoonlijke Bitcoin node` om niet meer afhankelijk te zijn van servers van derden, en een `Hardware wallet` gebruiken om je privésleutels volledig offline en veilig te bewaren. Met slimme back-upopties en naadloze ondersteuning voor Bitcoin, Liquid en Lightning is de Bull Bitcoin Wallet een sterke, alles-in-één keuze voor iedereen die zijn geld privé, veilig en volledig onder eigen controle wil houden.
+Je hebt nu je reis door de Bull Bitcoin-wallet voltooid. De app brengt krachtige privacy- en beveiligingstools binnen handbereik, waardoor geavanceerde functies eenvoudig te gebruiken zijn. Het helpt je privé te blijven met functies zoals `PayJoin`, dat je transacties verbergt op de blockchain, en `Tor integratie`, dat je netwerkactiviteit maskeert voor nieuwsgierige ogen. Voor degenen die ultieme controle willen, kun je verbinding maken met je `eigen persoonlijke Bitcoin node` om niet meer afhankelijk te zijn van servers van derden, en een `Hardware wallet` gebruiken om je privésleutels volledig offline en veilig te bewaren. Met slimme back-upopties en naadloze ondersteuning voor Bitcoin, Liquid en Lightning is de Bull Bitcoin-wallet een sterke, alles-in-één keuze voor iedereen die zijn geld privé, veilig en volledig onder eigen controle wil houden.
 
 
-## bull Wallet Hulpmiddelen
+## bull wallet Hulpmiddelen
 
 
 [Github](https://github.com/SatoshiPortal/bullbitcoin-mobile) | [Website ](https://www.bullbitcoin.com/)| [Recoverbull](https://recoverbull.com/)

--- a/tutorials/wallet/bull-bitcoin/nl.md
+++ b/tutorials/wallet/bull-bitcoin/nl.md
@@ -156,7 +156,7 @@ https://planb.academy/courses/46b0ced2-9028-4a61-8fbc-3b005ee8d70f
 Er is ook de optie van een versleutelde, anonieme back-up in de cloud. Maar zeiden we in de vorige paragraaf niet dat cloudback-ups riskant zijn en vermeden moeten worden? Het Bull Bitcoin-team heeft echter een slimme manier ontwikkeld om het proces veilig te maken. Dit is hoe het werkt:
 
 
-`Recoverbull` is een back-upprotocol dat het beveiligen van je Bitcoin-wallet vereenvoudigt door de back-up in twee delen op te splitsen. Ten eerste wordt het back-upbestand van je wallet versleuteld op je apparaat met behulp van een sterke versleutelingscode. Je kunt dit versleutelde bestand opslaan waar je maar wilt, zoals Google Drive of je apparaat. Ten tweede, de coderingssleutel die nodig is om het bestand te ontgrendelen is opgeslagen door de Recoverbull Key Server. Om je wallet te herstellen, heb je zowel het versleutelde back-up bestand als de sleutel nodig, die je opent met je PIN-code of wachtwoord. Dit ontwerp zorgt ervoor dat je cloud back-up alleen nutteloos is en dat de sleutel server (Key Server) alleen nutteloos is zonder je specifieke back-up bestand. Hierdoor blijven je fondsen veilig, zelfs als één onderdeel is gecompromitteerd.
+`Recoverbull` is een back-upprotocol dat het beveiligen van je Bitcoin-wallet vereenvoudigt door de back-up in twee delen op te splitsen. Ten eerste wordt het back-upbestand van je wallet versleuteld op je apparaat met behulp van een sterke versleutelingscode. Je kunt dit versleutelde bestand opslaan waar je maar wilt, zoals Google Drive of je apparaat. Ten tweede, de coderingssleutel die nodig is om het bestand te ontgrendelen is opgeslagen door de Recoverbull Key Server. Om je wallet te herstellen, heb je zowel het versleutelde back-upbestand als de sleutel nodig, die je opent met je PIN-code of wachtwoord. Dit ontwerp zorgt ervoor dat je cloud back-up alleen nutteloos is en dat de sleutel server (Key Server) alleen nutteloos is zonder je specifieke back-up bestand. Hierdoor blijven je fondsen veilig, zelfs als één onderdeel is gecompromitteerd.
 
 
 Zie het als een kluis. Het versleutelde back-up bestand is de *box*, die je overal kunt opslaan (zoals Google Drive). Je recovery PIN is de *sleutel*, die apart wordt opgeslagen door de Recoverbull Key Server. Een dief zou zowel je specifieke doos als je specifieke sleutel moeten hebben om het te openen. Dit ontwerp zorgt ervoor dat zelfs als iemand je back-up bestand krijgt, het nutteloos is zonder de sleutel van de server, en de sleutel van de server is nutteloos zonder je unieke back-up bestand.
@@ -192,7 +192,7 @@ Selecteer vervolgens een vault provider:
 
 
 
-- google Drive` of
+- Google Drive` of
 - een `gekozen locatie` (bijvoorbeeld je apparaat)
 
 
@@ -232,7 +232,7 @@ Om de app te beveiligen, navigeer naar `Settings` en kies `Security PIN` om een 
 De Bull Bitcoin-wallet maakt standaard verbinding met Electrum servers: de eerste wordt beheerd door Bull Bitcoin en een secundaire server van Blockstream, die beide geen logs bijhouden, waardoor het risico op tracering kleiner is.
 
 
-Voor meer vertrouwelijkheid kunt je de applicatie verbinden met je eigen Bitcoin node via een Electrum server. Tik hiervoor op `Settings` > `Bitcoin Settings` > `Electrum Server Settings`, tik vervolgens op `+ Add Custom Server` om het adres en de gegevens van je server in te voeren.
+Voor meer vertrouwelijkheid kun je de applicatie verbinden met je eigen Bitcoin node via een Electrum server. Tik hiervoor op `Settings` > `Bitcoin Settings` > `Electrum Server Settings`, tik vervolgens op `+ Add Custom Server` om het adres en de gegevens van je server in te voeren.
 
 
 ![image](assets/en/07.webp)
@@ -250,7 +250,7 @@ Het beschikbare saldo wordt op het hoofdscherm weergegeven in zowel `sats` als `
 ### D - Bitcoin instellingen
 
 
-Het menu `Bitcoin Settings` biedt diepgaande toegang tot de kernconfiguraties en -gegevens van je wallet. Hier kun je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken. Hier kunt je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken, waardoor je volledige transparantie en controle hebt. De belangrijkste functies in dit menu zijn:
+Het menu `Bitcoin Settings` biedt diepgaande toegang tot de kernconfiguraties en -gegevens van je wallet. Hier kun je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken. Hier kun je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken, waardoor je volledige transparantie en controle hebt. De belangrijkste functies in dit menu zijn:
 
 
 
@@ -423,25 +423,25 @@ https://planb.academy/en/courses/e17ee350-41d4-49fa-b270-29e4d26d22f8/overview-o
 
 
 - **Grenzen:**
-    - **Minimumbedrag:** Een minimumfactuurbedrag is vereist. Controleer de app voor de huidige limiet
-    - **Kosten:** Jij, de ontvanger, bent verantwoordelijk voor een kleine swapvergoeding. Deze kosten worden afgetrokken van het bedrag dat de verzender overmaakt en kunnen veranderen
-- Voordelen:**
-    - **Zelfbeheerd:** Uw geld is altijd onder je controle, beveiligd op het Liquid-netwerk.
-    - **Vermijd hoge on-chain kosten:** Door Lightning te gebruiken en op te slaan op Liquid, omzeilt je de on-chain kosten die gepaard gaan met het openen van een traditioneel Lightning-kanaal. U kunt ervoor kiezen om later geld over te hevelen naar een on-chain-kanaal, wanneer het geaccumuleerde bedrag de kosten rechtvaardigt.
-    - **Tip:** Voor de meest kosteneffectieve transactie tussen twee Bull Bitcoin gebruikers, gebruikt je het **Liquid netwerk rechtstreeks** om de Lightning swapkosten volledig te vermijden.
+    - **Minimumbedrag:** Een minimumfactuurbedrag is vereist. Controleer de app voor de huidige limiet.
+    - **Kosten:** Jij, de ontvanger, bent verantwoordelijk voor een kleine swapvergoeding. Deze kosten worden afgetrokken van het bedrag dat de verzender overmaakt en kunnen veranderen.
+- **Voordelen:**
+    - **Self-Custodial:** je geld is altijd onder jouw controle, beveiligd op het Liquid-netwerk.
+    - **Vermijd hoge on-chain kosten:** Door Lightning te gebruiken en op te slaan op Liquid, omzeil je de on-chain kosten die gepaard gaan met het openen van een traditioneel Lightning-kanaal. Je kan ervoor kiezen om later geld over te hevelen naar een on-chain-kanaal, wanneer het geaccumuleerde bedrag de kosten rechtvaardigt.
+    - **Tip:** Voor de meest kosteneffectieve transactie tussen twee Bull Bitcoin-gebruikers, gebruik je het **Liquid netwerk rechtstreeks** om de Lightning swapkosten volledig te vermijden.
 
 
-Om een betaling te ontvangen, moet je generate een `bliksemfactuur` hebben:
+Om een betaling te ontvangen, moet je een `Lightning-factuur` genereren:
 
 
-1. voer een bedrag in**:** Geef het bedrag op dat je wilt ontvangen in Bitcoin (BTC), Satoshis (Sats) of een fiatvaluta.
+1. **`Voer een bedrag in`:** Geef het bedrag op dat je wilt ontvangen in Bitcoin (BTC), Satoshis (Sats) of een fiatvaluta.
 
-2. notitie toevoegen` **(Optioneel):** Voeg een memo of notitie toe. Deze wordt opgenomen in de factuur en weergegeven in je transactiegeschiedenis zodra de betaling is voltooid, zodat je deze gemakkelijker kunt identificeren.
+2. **`Voeg een notitie toe` (optioneel):** Voeg een memo of notitie toe. Deze wordt opgenomen in de factuur en weergegeven in je transactiegeschiedenis zodra de betaling is voltooid, zodat je deze gemakkelijker kunt identificeren.
 
-3. `Invoice Geldigheid`**:** De Lightning-factuur is tijdsgevoelig en vervalt na **12 uur**. Als de factuur niet binnen deze periode wordt betaald, wordt deze ongeldig en moet je generate een nieuwe factuur maken.
+3. **`Geldigheid invoice`:** De Lightning-factuur is tijdsgevoelig en vervalt na **12 uur**. Als de factuur niet binnen deze periode wordt betaald, wordt deze ongeldig en moet je een nieuwe factuur genereren.
 
 
-Geef de factuur aan de verzender door hem naar je klembord te kopiëren of door hem de QR-code te laten scannen die op je scherm wordt weergegeven.
+Geef de factuur aan de verzender door deze te kopiëren naar je klembord of door de QR-code te laten scannen die op je scherm wordt weergegeven.
 
 
 ![image](assets/en/13.webp)
@@ -450,13 +450,13 @@ Geef de factuur aan de verzender door hem naar je klembord te kopiëren of door 
 ## 9️⃣ Geld versturen
 
 
-Je kunt het verzendscherm rechtstreeks openen vanaf de startpagina of vanuit een van je portemonnees. Bull Bitcoin-wallet vereenvoudigt het proces door automatisch het bestemmingsnetwerk te detecteren - `Bitcoin`, `Liquid` of `Lightning` op basis van het adres of de factuur die je invoert, geplakt of gescand via een QR-code.
+Je kunt het verzendscherm rechtstreeks openen vanaf de startpagina of vanuit een van je wallets. Bull Bitcoin-wallet vereenvoudigt het proces door automatisch het bestemmingsnetwerk te detecteren - `Bitcoin`, `Liquid` of `Lightning` op basis van het adres of de factuur die je invoert, geplakt of gescand via een QR-code.
 
 
-### on-chain Verzending via het Bitcoin Netwerk
+### on-chain verzending via het Bitcoin Netwerk
 
 
-Geld overmaken via on-chain betekent dat je transactie direct wordt geregistreerd op de Bitcoin blockchain. Deze methode is het beste voor grotere overschrijvingen of niet-tijdgevoelige overschrijvingen. Om te beginnen kun je rechtsonder op de `Verstuur Knop` tikken, en een `standaard Bitcoin adres` scannen of invoeren.
+Geld overmaken via on-chain betekent dat je transactie direct wordt geregistreerd op de Bitcoin-blockchain. Deze methode is het beste voor grotere overschrijvingen of niet-tijdgevoelige overschrijvingen. Om te beginnen kun je rechtsonder op de `Send` knop tikken, en een `standaard Bitcoin adres` scannen of invoeren.
 
 
 Als het adres dat je opgeeft geen specifiek bedrag bevat, wordt je gevraagd om de details in te vullen op het verzendscherm. Je kunt het bedrag opgeven in de eenheid van je voorkeur, zoals BTC, satoshis of een fiat equivalent. Je hebt ook de optie om een persoonlijke notitie toe te voegen, wat een privémemo is voor je eigen referentie om je te helpen de transactie later te identificeren. Deze notitie wordt niet gedeeld met de ontvanger.
@@ -474,25 +474,25 @@ Voordat je transactie wordt uitgezonden, krijg je een bevestigingsscherm te zien
 Je kunt de kosten op twee manieren regelen. De eerste methode is het selecteren van een gewenste transactiesnelheid, zoals laag, medium of hoog, en de wallet berekent automatisch de juiste vergoeding voor je. De tweede methode biedt een preciezere controle door je een specifieke vergoeding te laten instellen, hetzij als een absoluut totaal in satoshi's of als een relatief tarief per byte, dat vervolgens een geschatte bevestigingstijd oplevert.
 
 
-Voor geavanceerde gebruikers biedt de wallet verschillende instellingen om de transactie nauwkeurig af te stellen. standaard is `Replace-by-Fee` (RBF) ingeschakeld, wat een waardevolle functie is waarmee je een transactie kunt versnellen als deze vastloopt in de mempool door deze opnieuw uit te zenden met een hogere vergoeding. Je kunt ook handmatig kiezen uit welke `Unspent Transaction Outputs` (UTXOs) je wilt uitgeven. Dit is een krachtig hulpmiddel voor UTXO consolidatie, een strategie waarbij je meerdere kleine ingangen combineert tot één grotere. Hoewel dit meer kosten met zich meebrengt voor de huidige transactie, kan het de kosten voor toekomstige transacties aanzienlijk verlagen, vooral als de netwerkkosten naar verwachting zullen stijgen.
+Voor geavanceerde gebruikers biedt de wallet verschillende instellingen om de transactie nauwkeurig af te stellen. `Replace-by-Fee` (RBF) is standaard  ingeschakeld, wat een waardevolle functie is waarmee je een transactie kunt versnellen als deze vastloopt in de mempool door deze opnieuw uit te zenden met een hogere vergoeding. Je kunt ook handmatig kiezen uit welke `Unspent Transaction Outputs` (UTXOs) je wilt uitgeven. Dit is een krachtig hulpmiddel voor UTXO consolidatie, een strategie waarbij je meerdere kleine inputs combineert tot één grotere. Hoewel dit meer kosten met zich meebrengt voor de huidige transactie, kan het de kosten voor toekomstige transacties aanzienlijk verlagen, vooral als de netwerkkosten naar verwachting zullen stijgen.
 
 
 ![image](assets/en/15.webp)
 
 
-PayJoin wordt automatisch geprobeerd wanneer je een betalingsverzoek van een ontvanger scant (een BIP21 URI) dat een `pj=` parameter bevat. Als je gewoon een adres plakt zonder extra parameters, wordt deze functie niet geactiveerd. Deze collaboratieve methode verbetert de privacy door de input van zowel de verzender als de ontvanger te combineren, waardoor de heuristiek van gemeenschappelijk input-eigendom wordt doorbroken en er in sommige omstandigheden ook beter kan worden geschaald en kosten kunnen worden bespaard.
+PayJoin wordt automatisch geactiveerd als je een betalingsverzoek van een ontvanger scant (een BIP21 URI) met een `pj=` parameter. Als je gewoon een adres plakt zonder extra parameters, wordt deze functie niet geactiveerd. Deze collaboratieve methode verbetert de privacy door de input van zowel de verzender als de ontvanger te combineren, waardoor de heuristiek van gemeenschappelijk input-eigendom wordt doorbroken en er in sommige omstandigheden ook beter kan worden geschaald en kosten kunnen worden bespaard.
 
 
-### Verzenden naar de Liquid Network
+### Verzenden naar het Liquid Network
 
 
-De `Liquid Network` is ontworpen voor snelle, vertrouwelijke transacties met minimale kosten. Wanneer je geld verstuurt via de Liquid, wordt het opgenomen uit je `Instant Payments wallet`. Het proces is eenvoudig: je hoeft alleen maar het `Liquid` adres van de ontvanger in te voeren of te scannen.
+Het `Liquid Network` is ontworpen voor snelle, vertrouwelijke transacties met minimale kosten. Wanneer je geld verstuurt via Liquid, wordt het opgenomen uit je `Instant Payments Wallet`. Het proces is eenvoudig: je hoeft alleen maar het `Liquid` adres van de ontvanger in te voeren of te scannen.
 
 
-Als het adres geen bedrag opgeeft, wordt je gevraagd om er een op te geven op het verzendscherm. Je kunt het bedrag invoeren in BTC, satoshis of fiat. Een belangrijk voordeel van Liquid is de lage minimumdrempel. Net als bij on-chain transacties, kun je een optionele persoonlijke notitie toevoegen voor je eigen administratie. Als het betalingsverzoek al een bedrag bevat, gaat wallet direct door naar het bevestigingsscherm.
+Als het adres geen bedrag opgeeft, wordt je gevraagd om er een op te geven op het verzendscherm. Je kunt het bedrag invoeren in BTC, satoshis of fiat. Een belangrijk voordeel van Liquid is de lage minimumdrempel. Net als bij on-chain transacties, kun je een optionele persoonlijke notitie toevoegen voor je eigen administratie. Als het betalingsverzoek al een bedrag bevat, gaat de wallet direct door naar het bevestigingsscherm.
 
 
-Op het bevestigingsscherm voor een Liquid transactie bekijk je de details. De kosten zijn bijzonder laag en worden berekend op basis van de complexiteit van de transactie. Ze liggen meestal rond de 0,1 sat/vB, wat voor een eenvoudige transactie neerkomt op slechts 20-40 satoshis (bijvoorbeeld 26 satoshis per 21 december 2025).
+Bekijk de details van je Liquid-transactie op het bevestigingsscherm. De kosten zijn bijzonder laag en worden berekend op basis van de complexiteit van de transactie. Ze liggen meestal rond de 0,1 sat/vB, wat voor een eenvoudige transactie neerkomt op slechts 20-40 satoshis (bijvoorbeeld 26 satoshis op 21 december 2025).
 
 
 ![image](assets/en/16.webp)
@@ -501,64 +501,64 @@ Op het bevestigingsscherm voor een Liquid transactie bekijk je de details. De ko
 ### Verzenden naar het Lightning Network
 
 
-Je kunt een Lightning Address scannen (bijv. `runningbitcoin@rizful.com`) waarmee je het bedrag en een optionele notitie voor de ontvanger kunt instellen, of een factuur met een vooraf gedefinieerd bedrag scannen, waarmee je direct naar het bevestigingsscherm gaat.
+Je kunt een Lightning-adres scannen (bijv. `runningbitcoin@rizful.com`) waarmee je het bedrag en een optionele notitie voor de ontvanger kunt instellen, of een factuur met een vooraf gedefinieerd bedrag scannen, waarmee je direct naar het bevestigingsscherm gaat.
 
 
 *Houd er rekening mee dat er minimumbedragen en kosten van toepassing zijn.*
 
 
-De Bull Bitcoin-wallet verstuurt Lightning-betalingen door geld op te nemen uit je `Instant Payments wallet` (op Liquid) en dit om te wisselen via `Boltz`. Deze hybride benadering is volledig self-custodial en vermijdt de hoge on-chain kosten voor het beheren van een speciaal Lightning-kanaal, maar vereist wel het betalen van `swapkosten`. Stuur voor de laagste kosten rechtstreeks naar het Liquid adres van een ontvanger als deze ook een Bull Bitcoin-wallet gebruikt.
+De Bull Bitcoin-wallet neemt geld uit je `Instant Payments Wallet` (op Liquid) en wisselt dit via `Boltz` om Lightning-betalingen te versturen. Deze hybride benadering is volledig self-custodial en vermijdt de hoge on-chain kosten voor het beheren van een speciaal Lightning-kanaal, maar vereist wel het betalen van `swapkosten`. Stuur voor de laagste kosten rechtstreeks naar het Liquid-adres van een ontvanger als deze ook een Bull Bitcoin-wallet gebruikt.
 
 
-## geld overboeken tussen je portefeuilles
+## geld overboeken tussen je wallets
 
 
-Bull Bitcoin maakt het mogelijk om je Bitcoin te verplaatsen tussen je `Secure Bitcoin` wallet en je `Instant Payments wallet` op de Liquid Network of naar een `externe wallet`. Om een overschrijving uit te voeren, navigeer je gewoon naar de `Overschrijving` sectie, selecteer je de bron- en doelportemonnee, voer je het bedrag in dat je wilt verplaatsen en bevestig je de transactie.
+Bull Bitcoin maakt het mogelijk om je Bitcoin te verplaatsen tussen je `Secure Bitcoin Wallet` en je `Instant Payments Wallet` op het Liquid Network of naar een `externe wallet`. Om een overschrijving uit te voeren, navigeer je gewoon naar de `Transfer` sectie, selecteer je de bron- en doelwallet, voer je het bedrag in dat je wilt verplaatsen en bevestig je de transactie.
 
 
 ![image](assets/en/17.webp)
 
 
-## 1️⃣1️⃣ Uw Bull Bitcoin-wallet herstellen
+## 1️⃣1️⃣ Je Bull Bitcoin-wallet herstellen
 
 
 Dit hoofdstuk legt uit hoe je weer toegang krijgt tot je Bull Bitcoin-wallet fondsen als je je apparaat verliest, de app verwijdert, of gewoon naar een nieuw apparaat moet overschakelen. Zoals eerder uitgelegd, zijn er twee primaire methoden voor herstel: met de unieke `Recoverbull` methode en met een standaard `BIP39 seed zin`.
 
 
-### Methode 1: Herstelbull
+### Methode 1: Recoverbull
 
 
 Recapitulatie: wallet back-ups worden lokaal versleuteld. Het versleutelde bestand kan opgeslagen worden in een cloud opslag, of op een ander apparaat. De encryptie sleutel wordt opgeslagen door de Recoverbull Key Server. Beide worden apart gehouden en moeten gecombineerd worden om een wallet te herstellen.
 
 
-Om te beginnen wis ik de wallet met alle fondsen erop en installeer ik de wallet opnieuw. We komen weer op het `Welkom scherm`. Selecteer deze keer de optie `wallet herstellen`. Navigeer vervolgens naar de `Encrypted Vault` methode, bevestig het gebruik van de `Default Key server` en selecteer de locatie of `Vault provider` waar je het back-up bestand hebt opgeslagen.
+Om te beginnen wis ik de wallet met alle fondsen erop en installeer ik de wallet opnieuw. We komen weer op het welkomstscherm. Selecteer deze keer de optie `Recover Wallet`. Navigeer vervolgens naar de `Encrypted Vault` methode, bevestig het gebruik van de `Default Key server` en selecteer de locatie van de `Vault provider` waar je het back-up bestand hebt opgeslagen.
 
 
 ![image](assets/en/18.webp)
 
 
-Er staat dat de kluis met succes is geïmporteerd. Tik op de knop `Kluis ontsleutelen` en voer de `PIN` in. Het volgende scherm toont je `saldi` en het `aantal transacties` dat is hersteld.
+Er staat dat de kluis met succes is geïmporteerd. Tik op de knop `Decrypt Vault` en voer de `PIN` in. Het volgende scherm toont je `saldi` en het `aantal transacties` dat is hersteld.
 
 
 ![image](assets/en/19.webp)
 
 
-### Methode 2: Zaadzin
+### Methode 2: herstelzin (seed phrase)
 
 
-Deze methode gebruikt de master herstelzin van je wallet, een standaard lijst van 12 woorden die dient als ultieme back-up voor je fondsen. Het is de meest universele manier om een Bitcoin-wallet te herstellen, omdat het niet gebonden is aan een specifieke dienst of server. Zolang je deze zin hebt, kun je je wallet herstellen op elk compatibel apparaat, zelfs zonder toegang tot de Bull Bitcoin keyserver.
+Deze methode gebruikt de master herstelzin van je wallet, een standaard lijst van 12 woorden die dient als ultieme back-up voor je fondsen. Het is de meest universele manier om een Bitcoin-wallet te herstellen, omdat het niet gebonden is aan een specifieke dienst of server. Zolang je deze zin hebt, kun je je wallet herstellen op elk compatibel apparaat, zelfs zonder toegang tot de Bull Bitcoin Keyserver.
 
 
-Selecteer in het welkomstscherm `Recover wallet`. Kies deze keer de `Physical backup` methode. De app toont een raster van woorden. Selecteer zorgvuldig elk woord van je 12-woorden seed zin in de juiste volgorde. Wees nauwgezet, want één foutje resulteert in een onjuiste wallet.
+Selecteer in het welkomstscherm `Recover wallet`. Kies deze keer de `Physical backup` methode. De app toont een raster van woorden. Selecteer zorgvuldig elk woord van je 12-woorden herstelzin in de juiste volgorde. Wees nauwgezet, want één foutje resulteert in een onjuiste wallet.
 
 
 ## 1️⃣2️⃣ Een Hardware wallet aansluiten
 
 
-Voor het hoogste niveau van veiligheid kiezen veel Bitcoin gebruikers ervoor om hun geld op te slaan in `cold storage`. Dit betekent dat de `private sleutels` die je Bitcoin besturen op een apparaat bewaard worden dat nooit met het internet verbonden is. Een `hardware wallet` (of Signing device) is een gespecialiseerd fysiek apparaat dat precies voor dit doel is ontworpen. Het fungeert als een digitale kluis voor je sleutels en zorgt ervoor dat ze nooit worden blootgesteld aan de potentiële bedreigingen van een online computer of smartphone.
+Voor het hoogste niveau van veiligheid kiezen veel Bitcoin-gebruikers ervoor om hun geld op te slaan in `cold storage`. Dit betekent dat de `privésleutels` die je Bitcoin controleren op een apparaat bewaard worden dat nooit met het internet verbonden is. Een `hardware wallet` (of signing device) is een gespecialiseerd fysiek apparaat dat precies voor dit doel is ontworpen. Het fungeert als een digitale kluis voor je sleutels en zorgt ervoor dat ze nooit worden blootgesteld aan de potentiële bedreigingen van een online computer of smartphone.
 
 
-Door een hardware wallet aan te sluiten op de Bull Bitcoin app, krijgt je het beste van twee werelden: de compromisloze veiligheid van koude opslag voor je privésleutels, gecombineerd met de krachtige functies en gebruiksvriendelijke interface van de Bull Bitcoin-wallet voor het bekijken van saldi en het beheren van transacties. In dit laatste hoofdstuk laten we zien hoe je een hardware wallet, zoals een [Coldcard Q](https://coldcard.com/q), op je Bull Bitcoin-wallet aansluit. Deze tutorial gaat niet dieper in op het instellen van een Coldcard Q; dat kun je hier leren:
+Door een hardware wallet aan te sluiten op de Bull Bitcoin app, krijgt je het beste van twee werelden: de compromisloze veiligheid van cold storage voor je privésleutels, gecombineerd met de krachtige functies en gebruiksvriendelijke interface van de Bull Bitcoin-wallet voor het bekijken van saldi en het beheren van transacties. In dit laatste hoofdstuk laten we zien hoe je een hardware wallet, zoals een [Coldcard Q](https://coldcard.com/q), op je Bull Bitcoin-wallet aansluit. Deze tutorial gaat niet dieper in op het instellen van een Coldcard Q; dat kun je hier leren:
 
 
 https://planb.academy/en/tutorials/wallet/hardware/coldcard-q-73e86d1a-6fe6-4d8b-bb15-8690298020e3
@@ -571,13 +571,13 @@ https://planb.academy/en/tutorials/wallet/hardware/coldcard-q-advanced-b8cc3f29-
 ![image](assets/en/26.webp)
 
 
-Selecteer eerst in het hoofdmenu van je Coldcard Q `Export wallet` en kies dan `Bull wallet`. Je Coldcard zal generate een QR code krijgen.
+Selecteer eerst in het hoofdmenu van je Coldcard Q `Export wallet` en kies dan `Bull wallet`. Je Coldcard zal een QR code genereren.
 
 
 ![image](assets/en/20.webp)
 
 
-Open de Bull Bitcoin-wallet en navigeer naar `Settings` > `Bitcoin Settings` > `Import wallet` en selecteer `Coldcard Q` op je telefoon en tik op `Open de camera` om deze QR-code te scannen om de publieke sleutels van je hardware wallet te importeren.
+Open de Bull Bitcoin-wallet en navigeer naar `Settings` > `Bitcoin Settings` > `Import wallet` en selecteer `Coldcard Q` op je telefoon en tik op `Open the camera` om deze QR-code te scannen om de publieke sleutels van je hardware wallet te importeren.
 
 
 ![image](assets/en/21.webp)
@@ -586,10 +586,10 @@ Open de Bull Bitcoin-wallet en navigeer naar `Settings` > `Bitcoin Settings` > `
 ### Ontvangen met Coldcard Q
 
 
-Om Bitcoin te ontvangen via je aangesloten Coldcard Q, hoeft het apparaat niet fysiek verbonden te zijn met je telefoon. De Bull Bitcoin-wallet heeft de benodigde publieke sleutels al geïmporteerd, waardoor het zelfstandig generate adressen kan ontvangen.
+Om Bitcoin te ontvangen via je aangesloten Coldcard Q, hoeft het apparaat niet fysiek verbonden te zijn met je telefoon. De Bull Bitcoin-wallet heeft de benodigde publieke sleutels al geïmporteerd, waardoor het zelfstandig  ontvangstadressen kan genereren.
 
 
-1. Tik op je geïmporteerde Coldcard Q ondertekeningsapparaat en selecteer `Ontvangen`.
+1. Tik op je geïmporteerde Coldcard Q wallet en selecteer `Receive`.
 
 2. De app zal automatisch een vers Bitcoin adres weergeven van de wallet van je Coldcard.
 
@@ -605,34 +605,34 @@ Om Bitcoin te ontvangen via je aangesloten Coldcard Q, hoeft het apparaat niet f
 Het verzenden van Bitcoin met je Coldcard Q vereist je fysieke bevestiging om elke transactie te autoriseren. Hoewel de Bull wallet app wordt gebruikt om de transactie op te bouwen, kan de uiteindelijke handtekening alleen worden aangemaakt op de hardware wallet zelf.
 
 
-Open om te beginnen je `Coldcard Q` wallet en tik op `Versturen`. Open vervolgens de camera om de QR-code voor het ontvangende adres te scannen. Na het scannen voer je het `bedrag` in dat je wilt versturen en pas je de `kostenprioriteit` aan als dat nodig is.
+Open om te beginnen je `Coldcard Q` wallet en tik op `Versturen`. Open vervolgens de camera om de QR-code van het ontvangstadres te scannen. Na het scannen voer je het `bedrag` in dat je wilt versturen en pas je de `kostenprioriteit` aan als dat nodig is.
 
 
-Voor meer opties kun je kijken onder Geavanceerde instellingen. Hier vind je de optie `Vervangen door vergoeding` (RBF), die standaard geactiveerd is en waarmee je een vastgelopen transactie later kunt versnellen. Je hebt ook de `Coin Control` optie, waarmee je handmatig de specifieke UTXO's kunt selecteren die je wilt uitgeven.
+Voor meer opties kun je kijken onder Advanced Settings. Hier vind je de optie `Replace by Fee` (RBF), die standaard geactiveerd is en waarmee je een vastgelopen transactie later kunt versnellen. Je hebt ook de `Coin Control` optie, waarmee je handmatig de specifieke UTXO's kunt selecteren die je wilt uitgeven.
 
 
-Zodra je alle details hebt bekeken, tik je op `Toon PSBT` om de transactie voor te bereiden.
+Zodra je alle details hebt bekeken, tik je op `Show PSBT` om de transactie voor te bereiden.
 
 
 ![image](assets/en/23.webp)
 
 
-Tik op de `Scan` knop op je Coldcard Q en gebruik de camera om de QR code op je telefoon te scannen. Het Coldcard scherm toont je vervolgens alle transactie details. Controleer zorgvuldig het bedrag, het adres van de ontvanger en je wijzigingsadres. Als alles correct is, druk dan op de `Enter` knop op de Coldcard Q om de transactie te ondertekenen. Vervolgens verschijnt er een QR code van de ondertekende transactie op het scherm.
+Tik op de `Scan` knop op je Coldcard Q en gebruik de camera om de QR code op je telefoon te scannen. Het Coldcard scherm toont je vervolgens alle transactie details. Controleer zorgvuldig het bedrag, het adres van de ontvanger en je wisselgeldsadres. Als alles correct is, druk dan op de `Enter` knop op de Coldcard Q om de transactie te ondertekenen. Vervolgens verschijnt er een QR code van de ondertekende transactie op het scherm.
 
 
 ![image](assets/en/24.webp)
 
 
-Tik op de Bull wallet op `Ik ben klaar`, tik vervolgens op de `Camera` knop om de QR-code van de `ondertekende transactie` te scannen van je Coldcard Q. De Bull wallet toont nu een overzichtsscherm van de ondertekende transactie. Controleer het nog een laatste keer en tik dan op `Transactie verzenden`. Dit rondt het proces af door de transactie naar het Bitcoin netwerk te sturen, en je geld is onderweg.
+Tik op de Bull wallet op `I'm done`, tik vervolgens op de `Camera` knop om de QR-code van de `ondertekende transactie` te scannen van je Coldcard Q. De Bull wallet toont nu een overzichtsscherm van de ondertekende transactie. Controleer het nog een laatste keer en tik dan op `Broadcast Transactie`. Dit rondt het proces af door de transactie naar het Bitcoin-netwerk te sturen, en je geld is onderweg.
 
 
-## conclusie
+## 🎯 Conclusie
 
 
 Je hebt nu je reis door de Bull Bitcoin-wallet voltooid. De app brengt krachtige privacy- en beveiligingstools binnen handbereik, waardoor geavanceerde functies eenvoudig te gebruiken zijn. Het helpt je privé te blijven met functies zoals `PayJoin`, dat je transacties verbergt op de blockchain, en `Tor integratie`, dat je netwerkactiviteit maskeert voor nieuwsgierige ogen. Voor degenen die ultieme controle willen, kun je verbinding maken met je `eigen persoonlijke Bitcoin node` om niet meer afhankelijk te zijn van servers van derden, en een `Hardware wallet` gebruiken om je privésleutels volledig offline en veilig te bewaren. Met slimme back-upopties en naadloze ondersteuning voor Bitcoin, Liquid en Lightning is de Bull Bitcoin-wallet een sterke, alles-in-één keuze voor iedereen die zijn geld privé, veilig en volledig onder eigen controle wil houden.
 
 
-## bull wallet Hulpmiddelen
+## 📚 Bull Wallet tools
 
 
 [Github](https://github.com/SatoshiPortal/bullbitcoin-mobile) | [Website ](https://www.bullbitcoin.com/)| [Recoverbull](https://recoverbull.com/)

--- a/tutorials/wallet/bull-bitcoin/nl.md
+++ b/tutorials/wallet/bull-bitcoin/nl.md
@@ -172,8 +172,8 @@ Tik op `Encrypted Vault` en vervolgens op `Continue` om het gebruik van de stand
 
 
 
-- `App Unlock PIN`**:** De optionele PIN die is ingesteld in `Settings > Security-PIN` om de app op je telefoon te vergrendelen.
-- `Recovery PIN`**:** De verplichte PIN die is aangemaakt tijdens het `Encrypted Vault` back-upproces en die wordt gebruikt om je back-upbestand te decoderen tijdens het herstel.
+- **`App Unlock PIN`:** De optionele PIN die is ingesteld in `Settings > Security-PIN` om de app op je telefoon te vergrendelen.
+- **`Recovery PIN`:** De verplichte PIN die is aangemaakt tijdens het `Encrypted Vault` back-upproces en die wordt gebruikt om je back-upbestand te decoderen tijdens het herstel.
 
 
 Dit zijn twee afzonderlijke PIN-codes. Vergeet je Recovery PIN niet, want deze is essentieel voor het herstellen van je wallet."
@@ -220,7 +220,7 @@ Nu je primaire back-up veilig is gesteld, gaan we de andere functies in de inste
 ### A - Toegang beveiligen
 
 
-Om de app te beveiligen, navigeer naar ` Settings ` en kies `Security PIN` om een PIN-code te selecteren. Maak een sterke PIN-code aan om de toegang tot je wallet te vergrendelen. Hoewel deze stap optioneel is, wordt het sterk aanbevolen om onbevoegde toegang te voorkomen als iemand anders je telefoon gebruikt.
+Om de app te beveiligen, navigeer naar `Settings` en kies `Security PIN` om een PIN-code te selecteren. Maak een sterke PIN-code aan om de toegang tot je wallet te vergrendelen. Hoewel deze stap optioneel is, wordt het sterk aanbevolen om onbevoegde toegang te voorkomen als iemand anders je telefoon gebruikt.
 
 
 ![image](assets/en/06.webp)
@@ -229,10 +229,10 @@ Om de app te beveiligen, navigeer naar ` Settings ` en kies `Security PIN` om ee
 ### B - Verbinding met een persoonlijke node (optioneel)
 
 
-De wallet BullBitcoin maakt standaard verbinding met Electrum servers: de eerste wordt beheerd door Bull Bitcoin en een secundaire server van Blockstream, die beide geen logs bijhouden, waardoor het risico op tracering kleiner is.
+De Bull Bitcoin-wallet maakt standaard verbinding met Electrum servers: de eerste wordt beheerd door Bull Bitcoin en een secundaire server van Blockstream, die beide geen logs bijhouden, waardoor het risico op tracering kleiner is.
 
 
-Voor meer vertrouwelijkheid kunt je de applicatie verbinden met je eigen Bitcoin knooppunt via een Electrum server. Tik hiervoor op ` Settings ` > `Bitcoin  Settings ` > `Electrum Server  Settings `, tik vervolgens op `+ Aangepaste server toevoegen` om het adres en de gegevens van je server in te voeren.
+Voor meer vertrouwelijkheid kunt je de applicatie verbinden met je eigen Bitcoin node via een Electrum server. Tik hiervoor op `Settings` > `Bitcoin Settings` > `Electrum Server Settings`, tik vervolgens op `+ Add Custom Server` om het adres en de gegevens van je server in te voeren.
 
 
 ![image](assets/en/07.webp)
@@ -241,57 +241,57 @@ Voor meer vertrouwelijkheid kunt je de applicatie verbinden met je eigen Bitcoin
 ### C - Valuta
 
 
-Het beschikbare saldo wordt op het hoofdscherm weergegeven in zowel `sats` als `USD`. Om dit te veranderen, ga je naar ` Settings ` > `Munteenheid`. Daar kun je wisselen tussen `sats/BTC` en je `standaard fiatvaluta` selecteren.
+Het beschikbare saldo wordt op het hoofdscherm weergegeven in zowel `sats` als `USD`. Om dit te veranderen, ga je naar `Settings` > `Currency`. Daar kun je wisselen tussen `sats/BTC` en je `standaard fiatvaluta` selecteren.
 
 
 ![image](assets/en/08.webp)
 
 
-### D - Bitcoin Instellingen
+### D - Bitcoin instellingen
 
 
-Het menu `Bitcoin  Settings ` biedt diepgaande toegang tot de kernconfiguraties en -gegevens van je wallet. Hier kun je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken. Hier kunt je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken, waardoor je volledige transparantie en controle heeft. De belangrijkste functies in dit menu zijn:
+Het menu `Bitcoin Settings` biedt diepgaande toegang tot de kernconfiguraties en -gegevens van je wallet. Hier kun je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken. Hier kunt je de fundamentele details van je `Secure Bitcoin` en `Instant payments wallets` bekijken, waardoor je volledige transparantie en controle hebt. De belangrijkste functies in dit menu zijn:
 
 
 
-- Wallet Details:** Navigeer naar je Beveiligde Bitcoin of Directe betalingen wallet om specifieke informatie te bekijken.
-- Wallet vingerafdruk:** Een unieke identificatie voor je wallet.
+- **Wallet Details:** Navigeer naar je Beveiligde Bitcoin of Directe betalingen wallet om specifieke informatie te bekijken.
+- **Wallet vingerafdruk:** Een unieke identificatie voor je wallet.
 - Publieke sleutel (Pubkey):** De sleutel die gebruikt wordt om generate je Bitcoin ontvangstadressen te geven.
-- Descriptor:** Een technische samenvatting van de structuur van je wallet.
-- Afleidingspad:** Het specifieke pad dat wordt gebruikt om generate alle adressen van je privésleutel af te leiden.
-- Address bekijken:** Bekijk een lijst met je ongebruikte ontvangstadressen en wijzig adressen (verschijnt binnenkort)
+- **Descriptor:** Een technische samenvatting van de structuur van je wallet.
+- **Afleidingspad:** Het specifieke pad dat wordt gebruikt om generate alle adressen van je privésleutel af te leiden.
+- **Address bekijken:** Bekijk een lijst met je ongebruikte ontvangstadressen en wijzig adressen (verschijnt binnenkort)
 
 
 Bovendien heb je de optie om:
 
 
 
-- `Enable Auto Transfer` instellingen om een maximum direct wallet saldo in te stellen, dat vervolgens automatisch wordt overgeboekt naar de beveiligde bitcoin wallet.
-- Generieke wallets importeren via `Mnemonic` zin of `watch-only` importeren
-- Verbind `Hardware wallets`: momenteel worden ColdcardQ, SeedSigner, Specter, Krux, Blockstream Jade en Foundation Passport ondersteund
+- `Enable Auto Transfer` instellingen om een maximum wallet saldo in te stellen, dat vervolgens automatisch wordt overgeboekt naar de beveiligde bitcoin-wallet.
+- Generieke wallets via `Mnemonic` zin of `watch-only` importeren.
+- Verbind `Hardware wallets`: momenteel worden ColdcardQ, SeedSigner, Specter, Krux, Blockstream Jade en Foundation Passport ondersteund.
 
 
-## 7️⃣ Bull Bitcoin Exchange
+## 7️⃣ Bull Bitcoin exchange
 
 
-Direct vanuit de wallet heb je toegang tot de [Bull Bitcoin exchange](https://www.bullbitcoin.com/), zodat je Bitcoin kunt kopen, verkopen en betalen zonder de app te verlaten. Deze integratie biedt een handige oplossing voor het beheren van je Bitcoin behoeften. Houd er rekening mee dat de toegang tot de beurs en de diensten beperkt kan zijn, afhankelijk van je jurisdictie, en dat het voltooien van een KYC-verificatie (Know Your Customer) vereist kan zijn om te voldoen aan de wettelijke normen en gebruik te maken van alle functies van het platform.
+Direct vanuit de wallet heb je toegang tot de [Bull Bitcoin exchange](https://www.bullbitcoin.com/), zodat je bitcoin kunt kopen, verkopen en betalen zonder de app te verlaten. Deze integratie biedt een handige oplossing voor het beheren van je Bitcoin behoeften. Houd er rekening mee dat de toegang tot de exchange en de diensten beperkt kan zijn, afhankelijk van je jurisdictie, en dat het voltooien van een KYC-verificatie (Know Your Customer) vereist kan zijn om te voldoen aan de wettelijke normen en gebruik te maken van alle functies van het platform.
 
 
-Om te beginnen tikt je op `Exchange` in de rechterbenedenhoek en vervolgens op `Sign up` of `Login` voor je account.
+Om te beginnen tik je op `Exchange` in de rechterbenedenhoek en vervolgens op `Sign up` of `Login` voor je account.
 
 
-De beurs biedt de volgende [functies](https://www.bullbitcoin.com/):
+De exchange biedt de volgende [functies](https://www.bullbitcoin.com/):
 
 
 
-- Bitcoin kopen met zelfbehoud van je bankrekening
-- Niet-vrijheidsberovende
+- Bitcoin kopen met self-custody van je bankrekening
+- Non-custodial
 - Particulieren of bedrijven
 - Onmiddellijke opname
 - Geen verborgen kosten
 - Lightning Network beschikbaar
 - Geen transactielimieten
-- Terugkerende koopopties
+- Recurrente koopopties
 
 
 ![image](assets/en/09.webp)
@@ -317,26 +317,26 @@ Geld ontvangen met **Bull Bitcoin-wallet** is eenvoudig en flexibel, met onderst
 De app genereert automatisch het juiste adres of de juiste factuur op basis van je geselecteerde netwerk. Hier lees je hoe je te werk gaat voor elk netwerk.
 
 
-### Ontvangen via Onchain (Bitcoin netwerk)
+### Ontvangen via onchain (Bitcoin-netwerk)
 
 
-Om on-chain fondsen te ontvangen, kun je ofwel de `Veilig Bitcoin wallet` op het Beginscherm selecteren en op `Ontvangen` tikken, of op de hoofdknop `Ontvangen` tikken en dan het `Bitcoin netwerk` kiezen.
+Om on-chain fondsen te ontvangen, kun je ofwel de `Secure Bitcoin Wallet` op het beginscherm selecteren en op `Receive` tikken, of op de hoofdknop `Receive` tikken en dan het `Bitcoin netwerk` kiezen.
 
 
 Je hebt twee primaire modi voor het genereren van een ontvangstadres:
 
 
-**Standaardmodus (URI met extra invoerparameters)
+**Standaardmodus (URI met extra invoerparameters)**
 
 
 Standaard genereert de wallet een [BIP21 URI](https://bips.dev/21/). Dit is een gestandaardiseerd formaat dat meer informatie verpakt dan een eenvoudig adres, waaronder een bedrag, een persoonlijke notitie en PayJoin parameters om de privacy te verbeteren. Deze uitgebreide URI wordt gecodeerd in een QR-code en beschikbaar gesteld om te kopiëren. Het formaat ziet er als volgt uit: `bitcoin:<adres>?<parameter1>=<waarde1>&<parameter2>=<waarde2>`.
 
 
 
-- Extra invoerparameters:**
-    - Bedrag:** Geef een gevraagd bedrag op in BTC, sats of een fiatvaluta.
-    - Bericht:** Voeg een persoonlijke notitie toe die zichtbaar is voor de afzender.
-    - PayJoin:** Schakel deze optie in om de privacy te verbeteren door de input van zowel de verzender als de ontvanger te combineren in de transactie.
+- **Extra invoerparameters:**
+    - **Bedrag:** Geef een gevraagd bedrag op in BTC, sats of een fiatvaluta.
+    - **Bericht:** Voeg een persoonlijke notitie toe die zichtbaar is voor de afzender.
+    - **PayJoin:** Schakel deze optie in om de privacy te verbeteren door de input van zowel de verzender als de ontvanger te combineren in de transactie.
 
 
 Voorbeeld URI:
@@ -353,10 +353,10 @@ bitcoin:bc1q0vv86t2sj7daduvdc50njms6u6jzh2y54xxxxx?amount=0.0005&message=Tip+for
 ![image](assets/en/10.webp)
 
 
-**Kopieer of scan alleen Address optie ingeschakeld
+**Kopieer of scan adres alleen optie ingeschakeld**
 
 
-Met de `Kopieer of scan alleen Address optie` ingeschakeld, genereert de applicatie een eenvoudig Bitcoin adres in SegWit (bech32) formaat.
+Met de `Copy or scan Address only` optie ingeschakeld, genereert de applicatie een eenvoudig Bitcoin-adres in SegWit (bech32) formaat.
 
 
 Voorbeeld:
@@ -373,13 +373,13 @@ Zelfs als je een bedrag of een notitie invoert, worden deze niet opgenomen in de
 ![image](assets/en/11.webp)
 
 
-### Ontvangen via de Liquid Network
+### Ontvangen via het Liquid Network
 
 
-Je kunt een betaling ontvangen op de Liquid Network. Eenmaal op het `Ontvangen` scherm, heb je dezelfde twee opties om een betalingsverzoek te genereren:
+Je kunt een betaling ontvangen op het Liquid Network. Eenmaal op het `Receive` scherm, heb je dezelfde twee opties om een betalingsverzoek te genereren:
 
 
-**1. Eenvoudige Address:** Kopieer het standaard `Liquid adres`. Dit is een unieke identificatie voor je wallet op het Liquid netwerk en bevat geen specifiek bedrag of bericht.
+**1. Eenvoudig adres:** Kopieer het standaard `Liquid adres`. Dit is een unieke identificatie voor je wallet op het Liquid-netwerk en bevat geen specifiek bedrag of bericht.
 
 
 Voorbeeld Address:
@@ -394,8 +394,8 @@ lq1qq05k3vmnvbullbitcoinjujn6h04z9jtw53xuyktqf9mam2zpfz05j2fe2x8xhejgkga3nvmp4yy
 
 
 
-- Bedrag:** Je kunt het bedrag instellen in Bitcoin (BTC), Satoshis (Sats) of een fiatvaluta.
-- Opmerking:** Voeg een persoonlijk bericht toe om de transactie te identificeren.
+- **Bedrag:** Je kunt het bedrag instellen in Bitcoin (BTC), Satoshis (sats) of een fiatvaluta.
+- **Opmerking:** Voeg een persoonlijk bericht toe om de transactie te identificeren.
 
 
 **Voorbeeld URI:**
@@ -416,7 +416,7 @@ Om de transactie te voltooien, geef je de afzender het `adres` of de `URI`. Je k
 
 
 
-Met de Bull Bitcoin-wallet kun je ook betalingen verzenden en ontvangen via de Lightning Network. Een belangrijk kenmerk is dat geld dat je via Lightning ontvangt automatisch wordt omgewisseld en opgeslagen op de `Liquid Network` binnen je `Instant Payments wallet`. Deze dienst wordt aangedreven door de `Boltz`. Door dit ontwerp kunt je profiteren van de snelheid en lage kosten van Lightning zonder de complexiteit van het beheren van liquiditeitskanalen, terwijl je je fondsen volledig zelf bewaart. Hoewel deze hybride benadering self-custodial is en de complexiteit van het beheren van kanalen vermijdt, introduceert het een dienst van een derde partij (Boltz), een kleine swapvergoeding en afhankelijkheid van de Liquid Network federatie van functionarissen als keyholders, wat anders is dan een traditionele, niet-custodial Lightning wallet waar je je eigen kanalen beheert. Je kunt hier meer te weten komen over Liquid en hun bestuursmodel:
+Met de Bull Bitcoin-wallet kun je ook betalingen verzenden en ontvangen via het Lightning Network. Een belangrijk kenmerk is dat geld dat je via Lightning ontvangt automatisch wordt omgewisseld en opgeslagen op de `Liquid Network` binnen je `Instant Payments wallet`. Deze dienst wordt aangedreven door de `Boltz`. Door dit ontwerp kunt je profiteren van de snelheid en lage kosten van Lightning zonder de complexiteit van het beheren van liquiditeitskanalen, terwijl je je fondsen volledig zelf bewaart. Hoewel deze hybride benadering self-custodial is en de complexiteit van het beheren van kanalen vermijdt, introduceert het een dienst van een derde partij (Boltz), een kleine swapvergoeding en afhankelijkheid van de Liquid Network federatie van functionarissen als keyholders, wat anders is dan een traditionele, niet-custodial Lightning wallet waar je je eigen kanalen beheert. Je kunt hier meer te weten komen over Liquid en hun bestuursmodel:
 
 
 https://planb.academy/en/courses/e17ee350-41d4-49fa-b270-29e4d26d22f8/overview-of-liquid-architecture-and-governance-model-17650c4b-cd1f-4bc6-b490-708f92dc9306
@@ -498,7 +498,7 @@ Op het bevestigingsscherm voor een Liquid transactie bekijk je de details. De ko
 ![image](assets/en/16.webp)
 
 
-### Verzenden naar de Lightning Network
+### Verzenden naar het Lightning Network
 
 
 Je kunt een Lightning Address scannen (bijv. `runningbitcoin@rizful.com`) waarmee je het bedrag en een optionele notitie voor de ontvanger kunt instellen, of een factuur met een vooraf gedefinieerd bedrag scannen, waarmee je direct naar het bevestigingsscherm gaat.
@@ -577,7 +577,7 @@ Selecteer eerst in het hoofdmenu van je Coldcard Q `Export wallet` en kies dan `
 ![image](assets/en/20.webp)
 
 
-Open de Bull Bitcoin-wallet en navigeer naar ` Settings ` > `Bitcoin  Settings ` > `Import wallet` en selecteer `Coldcard Q` op je telefoon en tik op `Open de camera` om deze QR-code te scannen om de publieke sleutels van je hardware wallet te importeren.
+Open de Bull Bitcoin-wallet en navigeer naar `Settings` > `Bitcoin Settings` > `Import wallet` en selecteer `Coldcard Q` op je telefoon en tik op `Open de camera` om deze QR-code te scannen om de publieke sleutels van je hardware wallet te importeren.
 
 
 ![image](assets/en/21.webp)

--- a/tutorials/wallet/envoy/nl.md
+++ b/tutorials/wallet/envoy/nl.md
@@ -332,10 +332,10 @@ Klik op "*Continue*".
 ![Image](assets/fr/30.webp)
 
 
-Uw Passport zal nu generate je "*Backup Code*" geven. Dit is een reeks getallen die gebruikt kan worden om een back-up van je wallet, opgeslagen op een MicroSD, te ontsleutelen. Dit back-upsysteem, specifiek voor Foundation-apparaten, vormt een extra back-up voor je Mnemonic zin, maar is niet compatibel met andere Bitcoin software.
+Je Passport zal nu je "*Backup Code*" genereren. Dit is een reeks getallen die gebruikt kan worden om een back-up van je wallet, opgeslagen op een MicroSD, te ontsleutelen. Dit back-upsysteem, specifiek voor Foundation-apparaten, vormt een extra back-up voor je mnemonische zin, maar is niet compatibel met andere Bitcoin-software.
 
 
-Als je besluit om deze "*Backup Code*" te gebruiken, zorg er dan voor dat je deze op een andere locatie bewaart dan je MicroSD die de versleutelde back-up van je wallet bevat. U kunt er echter ook voor kiezen om dit systeem niet te gebruiken als je vindt dat een goede back-up van je Mnemonic zin voldoende is.
+Als je besluit om deze "*Backup Code*" te gebruiken, zorg er dan voor dat je deze op een andere locatie bewaart dan je MicroSD die de versleutelde back-up van je wallet bevat. Je kan er echter ook voor kiezen om dit systeem niet te gebruiken als je vindt dat een goede back-up van je mnemonische zin voldoende is.
 
 
 ![Image](assets/fr/31.webp)
@@ -353,16 +353,16 @@ Als er een MicroSD is geplaatst, is de versleutelde back-up van je wallet daar o
 ![Image](assets/fr/33.webp)
 
 
-Je Passport toont je Mnemonic-zin van 12 woorden. Deze Mnemonic geeft je volledige, onbeperkte toegang tot al je bitcoins. Iedereen die in het bezit is van deze zin kan je geld stelen, zelfs zonder fysieke toegang tot je Passport.
+Je Passport toont je mnemonische zin van 12 woorden. Deze mnemonische zin geeft je volledige, onbeperkte toegang tot al je bitcoins. Iedereen die in het bezit is van deze zin kan je geld stelen, zelfs zonder fysieke toegang tot je Passport.
 
 
-De 12-woorden zin herstelt de toegang tot je bitcoins in geval van verlies, diefstal of breuk van je Passport. Het is daarom erg belangrijk om het zorgvuldig te bewaren en op een veilige plaats op te bergen.
+Met 12-woorden zin herstel je de toegang tot je bitcoins als je Passport  kwijtraakt, gestolen wordt of kapotgaat. Het is daarom erg belangrijk om het zorgvuldig te bewaren en op een veilige plaats op te bergen.
 
 
-Je kunt het op het meegeleverde karton schrijven, of voor extra veiligheid raad ik aan om het op een roestvrijstalen basis te graveren om het te beschermen tegen brand, overstroming of instorting.
+Je kunt het op het meegeleverde karton schrijven, of voor extra veiligheid raad ik aan om het op een roestvrijstalen plaat te graveren om het te beschermen tegen brand, overstroming of instorting.
 
 
-Klik op de bevestigingsknop om je Mnemonic zin te zien.
+Klik op de bevestigingsknop om je mnemonische zin te zien.
 
 
 ![Image](assets/fr/34.webp)

--- a/tutorials/wallet/envoy/nl.md
+++ b/tutorials/wallet/envoy/nl.md
@@ -1,76 +1,76 @@
 ---
 name: Envoy
-description: Een paspoort instellen en gebruiken met de Envoy-toepassing
+description: Een Passport instellen en gebruiken met de Envoy-toepassing
 ---
 ![cover](assets/cover.webp)
 
 
-Envoy is een Bitcoin Wallet beheerapplicatie ontwikkeld door Foundation. Het is speciaal ontworpen voor gebruik met de Passport Hardware Wallet.
+Envoy is een Bitcoin wallet-beheerapplicatie ontwikkeld door Foundation. Het is speciaal ontworpen voor gebruik met de Passport hardware wallet.
 
 
-De Passport "*Batch 2*" die in deze handleiding met de Envoy-app wordt gepresenteerd, is de opvolger van de "*Founder's Edition*". Hij valt op door zijn eersteklas ontwerp, high-definition kleurenscherm en ergonomische fysieke toetsenbord. Het werkt in "*Air-Gap*" modus, wat ervoor zorgt dat de privésleutels van je Wallet volledig geïsoleerd blijven, met communicatie mogelijk via een MicroSD-kaart of QR-codes. Het apparaat is uitgerust met een verwijderbare, oplaadbare Nokia BL-5C batterij met een capaciteit van 1200 mAh. Deze niet-merkgebonden batterij kan eenvoudig worden vervangen, aangezien het BL-5C-model overal in de winkel verkrijgbaar is.
+De Passport "*Batch 2*" die in deze handleiding met de Envoy-app wordt gepresenteerd, is de opvolger van de "*Founder's Edition*". Hij valt op door zijn eersteklas ontwerp, het high-definition kleurenscherm en het ergonomische fysieke toetsenbord. Het werkt in "*Air-Gap*" modus, waardoor de privésleutels van je wallet volledig geïsoleerd blijven. Communicatie is mogelijk via een MicroSD-kaart of QR-codes. Het apparaat is uitgerust met een verwijderbare, oplaadbare Nokia BL-5C batterij met een capaciteit van 1200 mAh. Deze niet-merkgebonden batterij kan eenvoudig worden vervangen, aangezien het BL-5C-model overal in de winkel verkrijgbaar is.
 
 
 Wat betreft connectiviteit is de Passport uitgerust met een MicroSD-poort, een USB-C-poort voor opladen en een camera aan de achterkant voor het scannen van QR-codes.
 
 
-Op het gebied van beveiliging bevat de Passport een secure element en de broncode van het apparaat is volledig open-source. Het biedt alle functies die verwacht worden van een goede Bitcoin Hardware Wallet. Merk op dat de Passport nog geen miniscript ondersteunt, maar deze functie staat gepland voor het tweede kwartaal van 2025.
+Op het gebied van beveiliging bevat de Passport een secure element en de broncode van het apparaat is volledig open-source. Het biedt alle functies die je van een goede Bitcoin hardware wallet mag verwachten. Merk op dat de Passport nog geen miniscript ondersteunt, maar deze functie staat gepland voor het tweede kwartaal van 2025.
 
 
-Met een prijs van $199 wordt de Passport gepositioneerd als een high-end Hardware Wallet, die concurreert met de topmodellen Coldcard Q, Jade Plus, Tezor Safe 5 en Ledger.
+Met een prijs van $199 wordt de Passport gepositioneerd als een high-end hardware wallet, die concurreert met de topmodellen Coldcard Q, Jade Plus, Tezor Safe 5 en Ledger.
 
 
 ![Image](assets/fr/01.webp)
 
 
-Om je beveiligde Wallet op een Passport te beheren, heb je verschillende opties. Deze Hardware Wallet is compatibel met de meeste Wallet beheersoftware op de markt, waaronder Sparrow wallet, Specter Desktop, Nunchuk, Keeper, en anderen.
+Om je beveiligde wallet op een Passport te beheren, heb je verschillende opties. Deze hardware wallet is compatibel met de meeste wallet beheersoftware op de markt, waaronder Sparrow Wallet, Specter Desktop, Nunchuk, Keeper, en anderen.
 
 
-In deze tutorial, die gericht is op beginners en gevorderde gebruikers, gaan we ontdekken hoe je de Envoy-toepassing kunt gebruiken met je Passport. Het is de eenvoudigste manier om het meeste uit je Hardware Wallet te halen.
+In deze tutorial, die gericht is op beginners en gevorderde gebruikers, gaan we ontdekken hoe je de Envoy-toepassing kunt gebruiken met je Passport. Het is de eenvoudigste manier om het meeste uit je hardware wallet te halen.
 
 
-Als je een gevorderde gebruiker bent en complexere functies wilt ontdekken, raad ik je aan deze andere tutorial te bekijken, waarin we Passport configureren met Sparrow wallet :
+Als je een gevorderde gebruiker bent en complexere functies wilt ontdekken, raad ik je aan deze andere tutorial te bekijken, waarin we Passport configureren met Sparrow Wallet :
 
 
 https://planb.academy/tutorials/wallet/hardware/passport-74e53858-3fa2-43f9-b866-573297546236
 
-## Het paspoort uit de doos
+## Uitpakken van de Passport
 
 
-Controleer bij ontvangst van je Passport of de doos en Seal op de doos intact zijn om te bevestigen dat het pakket niet geopend is. Er wordt ook een softwareverificatie van de authenticiteit en integriteit van het apparaat uitgevoerd wanneer het wordt ingesteld.
+Controleer bij ontvangst van je Passport of de doos en de verzegeling intact zijn, om te bevestigen dat het pakket niet is geopend. Tijdens de installatie voert het apparaat ook een softwareverificatie om de authenticiteit en integriteit te controleren.
 
 
 ![Image](assets/fr/02.webp)
 
 
-Inhoud van de doos :
+Inhoud van de doos:
 
 
 
 
-- Paspoort;
-- Een stuk karton om je Mnemonic zin op te schrijven;
+- Passport;
+- Een stuk karton om je mnemonische zin op te schrijven;
 - Een USB-C-kabel voor opladen;
-- MicroSD-kaart ;
-- Twee MicroSD-naar-Lightning- of USB-C-adapters ;
+- MicroSD-kaart;
+- Twee MicroSD-naar-Lightning- of USB-C-adapters;
 - Stickers.
 
 
-Op het apparaat vindt u :
+Op het apparaat vindt je:
 
 
 
 
-- Een toetsenbord (1) ;
+- Een toetsenbord (1);
 - USB-C poort (2);
 - Een wisknop (3);
-- Een terugknop (4) ;
+- Een terugknop (4);
 - Een bevestigingstoets (5);
 - Richtingsknop (6);
 - Aan/uit-knop (7);
 - Een statusindicator (8);
-- MicroSD-poort (9) ;
-- Een knop om van modus te veranderen aA1 (10) ;
+- MicroSD-poort (9);
+- Een aA1-knop om van modus te veranderen (10);
 - Een camera aan de achterkant.
 
 
@@ -99,19 +99,19 @@ Je kunt het APK-bestand ook rechtstreeks downloaden [van Foundation's GitHub rep
 ![Image](assets/fr/51.webp)
 
 
-Zodra de applicatie open is, selecteer je "*Paspoort beheren*".
+Zodra de applicatie open is, selecteer je "*Manage Paspoort*".
 
 
 ![Image](assets/fr/52.webp)
 
 
-Kies of je de Tor-verbinding wilt activeren om de vertrouwelijkheid te versterken en druk dan op "*Doorgaan*".
+Kies of je de Tor-verbinding wilt activeren om de vertrouwelijkheid te versterken en druk dan op "*Continue*".
 
 
 ![Image](assets/fr/53.webp)
 
 
-Kies "*Sluit een bestaand Paspoort aan*" als uw Paspoort al geconfigureerd is, of "*Stel een nieuw Paspoort in*" als u uw Hardware Wallet voor de eerste keer initialiseert.
+Kies "*Connect an existing Passport*" als je Paspoort al geconfigureerd is, of "*Set up a new Passport*" als je je hardware wallet voor de eerste keer initialiseert.
 
 
 ![Image](assets/fr/54.webp)
@@ -123,13 +123,13 @@ Accepteer de gebruiksvoorwaarden.
 ![Image](assets/fr/55.webp)
 
 
-Vervolgens wordt u gevraagd om de echtheid van het paspoort te verifiëren. Klik op "*Volgende*".
+Vervolgens wordt je gevraagd om de echtheid van de Passport te verifiëren. Klik op "*Next*".
 
 
 ![Image](assets/fr/56.webp)
 
 
-## Startpaspoort
+## Start Passport
 
 
 Druk op de aan/uit-knop aan de zijkant van het apparaat om het op te starten.
@@ -144,43 +144,43 @@ Druk op de bevestigingstoets om naar het volgende menu te gaan.
 ![Image](assets/fr/05.webp)
 
 
-In deze tutorial gebruiken we Envoy om de Paspoort-beveiligde Wallet te beheren. Selecteer "*Envoy App*".
+In deze tutorial gebruiken we Envoy om de Passport-beveiligde wallet te beheren. Selecteer "*Envoy App*".
 
 
 ![Image](assets/fr/57.webp)
 
 
-Klik op "*Doorgaan op Envoy*".
+Klik op "*Continue on Envoy*".
 
 
 ![Image](assets/fr/58.webp)
 
 
-De volgende stap is het controleren van je apparaat. Dit bevestigt de echtheid van je paspoort en zorgt ervoor dat er tijdens het vervoer niet mee geknoeid is. Je wordt gevraagd een QR-code te scannen.
+De volgende stap is het controleren van je apparaat. Dit bevestigt de echtheid van je Passport en zorgt ervoor dat er tijdens het vervoer niet mee geknoeid is. Je wordt gevraagd een QR-code te scannen.
 
 
 ![Image](assets/fr/08.webp)
 
 
-Scan de dynamische QR-codes in de applicatie met je paspoort. Klik op "*Volgende*" wanneer het scannen is voltooid.
+Scan de dynamische QR-codes in de applicatie met je Passport. Klik op "*Next*" wanneer het scannen is voltooid.
 
 
 ![Image](assets/fr/59.webp)
 
 
-Scan vervolgens met je telefoon de QR-code die op je paspoort staat.
+Scan vervolgens met je telefoon de QR-code die op je Passport staat.
 
 
 ![Image](assets/fr/60.webp)
 
 
-Als het bericht "*Uw paspoort is veilig*" verschijnt, bevestigt dit dat uw Hardware Wallet echt is. Je kunt het nu gebruiken om een Bitcoin Wallet te beveiligen.
+Als het bericht "*Your Passport is secure*" verschijnt, bevestigt dit dat je hardware wallet echt is. Je kunt het nu gebruiken om een Bitcoin-wallet te beveiligen.
 
 
 ![Image](assets/fr/61.webp)
 
 
-Bevestig het testresultaat op je paspoort.
+Bevestig het testresultaat op je Passport.
 
 
 ![Image](assets/fr/14.webp)
@@ -189,31 +189,31 @@ Bevestig het testresultaat op je paspoort.
 ## De pincode instellen
 
 
-Daarna volgt de stap met de PIN-code. Met de PIN-code wordt uw paspoort ontgrendeld. Het biedt daarom bescherming tegen onbevoegde fysieke toegang. De PIN-code is niet betrokken bij de afleiding van de cryptografische sleutels van uw Wallet. Dus zelfs zonder toegang tot de PIN-code, kunt u met het bezit van uw 12- of 24-woorden Mnemonic zin weer toegang krijgen tot uw bitcoins.
+Daarna volgt de stap met de PIN-code. Met de PIN-code wordt je Passport ontgrendeld. Het biedt daarom bescherming tegen onbevoegde fysieke toegang. De PIN-code is niet betrokken bij de afleiding van de cryptografische sleutels van je wallet. Je kunt je bitcoins daarom altijd weer terugkrijgen met je 12 of 24 woorden (mnemonische zin), zelfs als je de PIN-code niet weet.
 
 
 ![Image](assets/fr/15.webp)
 
 
-We raden aan om een zo willekeurig mogelijke pincode te kiezen. Zorg er ook voor dat u deze code op een andere plaats opslaat dan waar uw Paspoort is opgeslagen (bijvoorbeeld in een wachtwoordmanager).
+We raden aan om een zo willekeurig mogelijke pincode te kiezen. Zorg er ook voor dat je deze code op een andere plaats opslaat dan waar je Paspoort is opgeslagen (bijvoorbeeld in een wachtwoordmanager).
 
 
 Je kunt een pincode kiezen tussen 6 en 12 cijfers. Ik raad je aan om hem zo lang mogelijk te maken.
 
 
-Gebruik het toetsenbord om uw PIN-codes in te voeren. Klik op de bevestigingsknop wanneer u klaar bent.
+Gebruik het toetsenbord om je PIN-code in te voeren. Klik op de bevestigingsknop wanneer je klaar bent.
 
 
 ![Image](assets/fr/16.webp)
 
 
-Bevestig uw pincode een tweede keer.
+Bevestig je PIN-code een tweede keer.
 
 
 ![Image](assets/fr/17.webp)
 
 
-Uw pincode is geregistreerd.
+Je PIN-code is geregistreerd.
 
 
 ![Image](assets/fr/18.webp)
@@ -222,7 +222,7 @@ Uw pincode is geregistreerd.
 ## Passport-firmware bijwerken
 
 
-Je Hardware Wallet stelt voor om de firmware te updaten. Ik raad je aan om direct te updaten om te profiteren van de verbeteringen en fixes van de laatste versies. Klik op de bevestigingstoets rechts om verder te gaan.
+Je hardware wallet stelt voor om de firmware bij te werken. Ik raad je aan om dit direct te doen om te profiteren van de verbeteringen en fixes in de nieuwste versie. Klik op de bevestigingstoets rechts om verder te gaan.
 
 
 ![Image](assets/fr/19.webp)
@@ -237,7 +237,7 @@ Je Passport is klaar om de nieuwe firmware te ontvangen via een MicroSD-kaart.
 ### Zonder Envoy-toepassing
 
 
-Gebruik hiervoor de MicroSD-kaart die in uw Passport-doos is meegeleverd (of een andere) en plaats deze in uw computer. Download de nieuwste firmwareversie van [de Foundation documentatiesite](https://docs.foundation.xyz/firmware-updates/passport/) of [hun GitHub repository](https://github.com/Foundation-Devices/passport2/releases).
+Gebruik hiervoor de MicroSD-kaart die in je Passport-doos is meegeleverd (of een andere) en plaats deze in je computer. Download de nieuwste firmwareversie van [de Foundation documentatiesite](https://docs.foundation.xyz/firmware-updates/passport/) of [hun GitHub repository](https://github.com/Foundation-Devices/passport2/releases).
 
 
 ![Image](assets/fr/21.webp)
@@ -257,13 +257,13 @@ De andere, eenvoudigere optie is om de Envoy-toepassing rechtstreeks te gebruike
 ![Image](assets/fr/62.webp)
 
 
-Gebruik de adapter die bij uw Passport is geleverd om de MicroSD-kaart op uw telefoon aan te sluiten.
+Gebruik de adapter die bij je Passport is geleverd om de MicroSD-kaart op je telefoon aan te sluiten.
 
 
 ![Image](assets/fr/63.webp)
 
 
-Selecteer de MicroSD-kaart in uw bestandsverkenner om de firmware op te slaan.
+Selecteer de MicroSD-kaart in je bestandsverkenner om de firmware op te slaan.
 
 
 ![Image](assets/fr/64.webp)
@@ -281,7 +281,7 @@ De Passport bestandsverkenner wordt geopend. Selecteer het bestand `vN.N.N-passp
 ![Image](assets/fr/22.webp)
 
 
-Klik op "*Selecteer*".
+Klik op "*Select*".
 
 
 ![Image](assets/fr/23.webp)
@@ -299,43 +299,43 @@ Wacht tot de update is voltooid.
 ![Image](assets/fr/25.webp)
 
 
-Zodra de update is voltooid, voert u uw PIN-code in om het apparaat te ontgrendelen en door te gaan met de configuratie.
+Zodra de update is voltooid, voer je je PIN-code in om het apparaat te ontgrendelen en door te gaan met de configuratie.
 
 
 ![Image](assets/fr/26.webp)
 
 
-## Maak een nieuwe Bitcoin Wallet
+## Maak een nieuwe Bitcoin-wallet aan
 
 
-Nu is het tijd om een nieuwe Bitcoin Wallet aan te maken. Klik op de bevestigingsknop.
+Nu is het tijd om een nieuwe Bitcoin-wallet aan te maken. Klik op de bevestigingsknop.
 
 
 ![Image](assets/fr/27.webp)
 
 
-Om een nieuwe Wallet aan te maken, klik je op "*Nieuw seed* aanmaken".
+Om een nieuwe wallet aan te maken, klik je op "*Create New Seed* aanmaken".
 
 
 ![Image](assets/fr/28.webp)
 
 
-Je kunt kiezen tussen een Mnemonic-zin van 12 of 24 woorden. De beveiliging die beide opties bieden is vergelijkbaar, dus je kunt kiezen voor de optie die het makkelijkst op te slaan is, d.w.z. 12 woorden.
+Je kunt kiezen tussen een mnemonische zin van 12 of 24 woorden. Omdat de beveiliging van beide opties vergelijkbaar is, kun je het best kiezen voor de optie die het makkelijkst op te slaan is: de zin van 12 woorden.
 
 
 ![Image](assets/fr/29.webp)
 
 
-Klik op "*Doorgaan*".
+Klik op "*Continue*".
 
 
 ![Image](assets/fr/30.webp)
 
 
-Uw Passport zal nu generate uw "*Backup Code*" geven. Dit is een reeks getallen die gebruikt kan worden om een back-up van uw Wallet, opgeslagen op een MicroSD, te ontsleutelen. Dit back-upsysteem, specifiek voor Foundation-apparaten, vormt een extra back-up voor uw Mnemonic zin, maar is niet compatibel met andere Bitcoin software.
+Uw Passport zal nu generate je "*Backup Code*" geven. Dit is een reeks getallen die gebruikt kan worden om een back-up van je wallet, opgeslagen op een MicroSD, te ontsleutelen. Dit back-upsysteem, specifiek voor Foundation-apparaten, vormt een extra back-up voor je Mnemonic zin, maar is niet compatibel met andere Bitcoin software.
 
 
-Als je besluit om deze "*Backup Code*" te gebruiken, zorg er dan voor dat je deze op een andere locatie bewaart dan je MicroSD die de versleutelde back-up van je Wallet bevat. U kunt er echter ook voor kiezen om dit systeem niet te gebruiken als u vindt dat een goede back-up van uw Mnemonic zin voldoende is.
+Als je besluit om deze "*Backup Code*" te gebruiken, zorg er dan voor dat je deze op een andere locatie bewaart dan je MicroSD die de versleutelde back-up van je wallet bevat. U kunt er echter ook voor kiezen om dit systeem niet te gebruiken als je vindt dat een goede back-up van je Mnemonic zin voldoende is.
 
 
 ![Image](assets/fr/31.webp)
@@ -347,16 +347,16 @@ Voer je "*Backup Code*" in om te bevestigen dat je het correct hebt opgeslagen.
 ![Image](assets/fr/32.webp)
 
 
-Als er een MicroSD is geplaatst, is de versleutelde back-up van uw Wallet daar opgeslagen.
+Als er een MicroSD is geplaatst, is de versleutelde back-up van je wallet daar opgeslagen.
 
 
 ![Image](assets/fr/33.webp)
 
 
-Je paspoort toont je Mnemonic-zin van 12 woorden. Deze Mnemonic geeft je volledige, onbeperkte toegang tot al je bitcoins. Iedereen die in het bezit is van deze zin kan je geld stelen, zelfs zonder fysieke toegang tot je paspoort.
+Je Passport toont je Mnemonic-zin van 12 woorden. Deze Mnemonic geeft je volledige, onbeperkte toegang tot al je bitcoins. Iedereen die in het bezit is van deze zin kan je geld stelen, zelfs zonder fysieke toegang tot je Passport.
 
 
-De 12-woorden zin herstelt de toegang tot je bitcoins in geval van verlies, diefstal of breuk van je paspoort. Het is daarom erg belangrijk om het zorgvuldig te bewaren en op een veilige plaats op te bergen.
+De 12-woorden zin herstelt de toegang tot je bitcoins in geval van verlies, diefstal of breuk van je Passport. Het is daarom erg belangrijk om het zorgvuldig te bewaren en op een veilige plaats op te bergen.
 
 
 Je kunt het op het meegeleverde karton schrijven, of voor extra veiligheid raad ik aan om het op een roestvrijstalen basis te graveren om het te beschermen tegen brand, overstroming of instorting.
@@ -373,7 +373,7 @@ Voor meer informatie over de juiste manier om je Mnemonic zin op te slaan en te 
 
 https://planb.academy/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-natuurlijk mag je deze woorden nooit delen op het Internet, zoals ik in deze tutorial doe. Dit voorbeeld Wallet wordt alleen gebruikt op Testnet en wordt verwijderd aan het einde van de tutorial.
+natuurlijk mag je deze woorden nooit delen op het Internet, zoals ik in deze tutorial doe. Dit voorbeeld wallet wordt alleen gebruikt op Testnet en wordt verwijderd aan het einde van de tutorial.
 
 
 Maak een fysieke back-up van deze zin.
@@ -388,16 +388,16 @@ Je Passport is succesvol geconfigureerd. Klik op de bevestigingsknop om verder t
 ![Image](assets/fr/36.webp)
 
 
-## De Wallet instellen op Envoy
+## De wallet instellen op Envoy
 
 
-In deze tutorial laat ik je zien hoe je de Passport kunt gebruiken met de Envoy-toepassing. Deze Hardware Wallet is echter ook compatibel met Sparrow wallet, Keeper, BlueWallet, Nunchuk, Specter en vele andere...
+In deze tutorial laat ik je zien hoe je de Passport kunt gebruiken met de Envoy-toepassing. Deze hardware wallet is echter ook compatibel met Sparrow wallet, Keeper, BlueWallet, Nunchuk, Specter en vele andere...
 
 
 ![Image](assets/fr/66.webp)
 
 
-Gebruik de Envoy-toepassing om de QR-code op je paspoort te scannen.
+Gebruik de Envoy-toepassing om de QR-code op je Passport te scannen.
 
 
 ![Image](assets/fr/67.webp)
@@ -409,19 +409,19 @@ Je publieke sleutels zijn nu geïmporteerd in de applicatie. Klik op "*Validate 
 ![Image](assets/fr/68.webp)
 
 
-Gebruik je paspoort om de Address te scannen die op Envoy wordt weergegeven.
+Gebruik je Passport om de Address te scannen die op Envoy wordt weergegeven.
 
 
 ![Image](assets/fr/69.webp)
 
 
-Je paspoort zal bevestigen of het Wallet geïmporteerd op Envoy geldig is. Bevestig dit in de aanvraag.
+Je Passport zal bevestigen of het wallet geïmporteerd op Envoy geldig is. Bevestig dit in de aanvraag.
 
 
 ![Image](assets/fr/70.webp)
 
 
-Je hebt nu toegang tot de openbare informatie van je Wallet op Envoy, maar om bitcoins uit te geven, moet je je paspoort gebruiken.
+Je hebt nu toegang tot de openbare informatie van je wallet op Envoy, maar om bitcoins uit te geven, moet je je Passport gebruiken.
 
 
 ![Image](assets/fr/71.webp)
@@ -440,25 +440,25 @@ Uw Passport Interface heeft drie hoofdmenu's:
 - "*Instellingen*".
 
 
-Om tussen deze menu's te navigeren, gebruikt u de pijlen naar links en rechts op de richtingsknop.
+Om tussen deze menu's te navigeren, gebruikt je de pijlen naar links en rechts op de richtingsknop.
 
 
 ### *Account*" menu
 
 
-In het menu "*Account*" vind je de belangrijkste functies van je Bitcoin Wallet. Je kunt een transactie ondertekenen via de camera of via de MicroSD-poort.
+In het menu "*Account*" vind je de belangrijkste functies van je Bitcoin wallet. Je kunt een transactie ondertekenen via de camera of via de MicroSD-poort.
 
 
 ![Image](assets/fr/37.webp)
 
 
-Het submenu "*Account Tools*" biedt opties zoals het verifiëren van een Address, het ondertekenen van een bericht of het raadplegen van de adressen in uw Wallet.
+Het submenu "*Account Tools*" biedt opties zoals het verifiëren van een Address, het ondertekenen van een bericht of het raadplegen van de adressen in je wallet.
 
 
 ![Image](assets/fr/38.webp)
 
 
-In het submenu "*Manage Account*" kun je je Bitcoin Wallet verbinden met een Wallet beheersoftware (die we in de volgende stappen van deze tutorial behandelen), of je account bekijken en hernoemen.
+In het submenu "*Manage Account*" kun je je Bitcoin-wallet verbinden met een wallet beheersoftware (die we in de volgende stappen van deze tutorial behandelen), of je account bekijken en hernoemen.
 
 
 ![Image](assets/fr/39.webp)
@@ -467,7 +467,7 @@ In het submenu "*Manage Account*" kun je je Bitcoin Wallet verbinden met een Wal
 ### Meer" menu
 
 
-In het menu "*Meer*" kun je een nieuw account aanmaken in je Wallet, gekoppeld aan dezelfde Mnemonic-zin.
+In het menu "*Meer*" kun je een nieuw account aanmaken in je wallet, gekoppeld aan dezelfde Mnemonic-zin.
 
 
 ![Image](assets/fr/40.webp)
@@ -482,7 +482,7 @@ Je kunt ook een BIP39 passphrase invoeren of een tijdelijke seed gebruiken.
 ### Menu "Instellingen
 
 
-In het menu "*Instellingen*" vind je al je Wallet en apparaatinstellingen.
+In het menu "*Instellingen*" vind je al je wallet en apparaatinstellingen.
 
 
 ![Image](assets/fr/42.webp)
@@ -494,7 +494,7 @@ Het submenu "*Device*" geeft je opties om de helderheid van het scherm aan te pa
 ![Image](assets/fr/43.webp)
 
 
-In het submenu "*Backup*" kunt u uw gecodeerde Wallet back-up exporteren, de geldigheid van een bestaande back-up controleren of uw "*Backup Code*" opnieuw opzoeken.
+In het submenu "*Backup*" kunt je je gecodeerde wallet back-up exporteren, de geldigheid van een bestaande back-up controleren of je "*Backup Code*" opnieuw opzoeken.
 
 
 ![Image](assets/fr/44.webp)
@@ -506,19 +506,19 @@ In het submenu "*Firmware*" kun je de firmware van je Passport bijwerken. We rad
 ![Image](assets/fr/45.webp)
 
 
-In het submenu "*Bitcoin*" kun je de weergegeven eenheid (BTC of satoshis) wijzigen, een mogelijke Multisig Wallet beheren of overschakelen naar de modus "*Testnet*".
+In het submenu "*Bitcoin*" kun je de weergegeven eenheid (BTC of satoshis) wijzigen, een mogelijke Multisig wallet beheren of overschakelen naar de modus "*Testnet*".
 
 
 ![Image](assets/fr/46.webp)
 
 
-In "*Geavanceerd*" kunt u de woorden van uw Mnemonic-zin bekijken, acties uitvoeren op de geplaatste MicroSD, uw Passport resetten naar de fabrieksinstellingen of een echtheidscontrole uitvoeren, zoals eerder is uitgevoerd.
+In "*Geavanceerd*" kunt je de woorden van je Mnemonic-zin bekijken, acties uitvoeren op de geplaatste MicroSD, je Passport resetten naar de fabrieksinstellingen of een echtheidscontrole uitvoeren, zoals eerder is uitgevoerd.
 
 
 ![Image](assets/fr/47.webp)
 
 
-U kunt "*Veiligheidswoorden*" activeren, een functie die een Layer beveiliging toevoegt door twee specifieke woorden weer te geven bij het ontgrendelen van het apparaat na het invoeren van de eerste vier cijfers van de PIN-code. Deze woorden, die tijdens de configuratie moeten worden opgeslagen, zorgen ervoor dat de Passport niet is vervangen of dat er niet mee is geknoeid. In het geval van een afwijking op een later tijdstip, adviseren wij u het apparaat niet te gebruiken. Ik adviseer je om deze optie te activeren om de meeste risico's van fysieke compromittering van het apparaat te voorkomen.
+U kunt "*Veiligheidswoorden*" activeren, een functie die een Layer beveiliging toevoegt door twee specifieke woorden weer te geven bij het ontgrendelen van het apparaat na het invoeren van de eerste vier cijfers van de PIN-code. Deze woorden, die tijdens de configuratie moeten worden opgeslagen, zorgen ervoor dat de Passport niet is vervangen of dat er niet mee is geknoeid. In het geval van een afwijking op een later tijdstip, adviseren wij je het apparaat niet te gebruiken. Ik adviseer je om deze optie te activeren om de meeste risico's van fysieke compromittering van het apparaat te voorkomen.
 
 
 ![Image](assets/fr/48.webp)
@@ -533,7 +533,7 @@ Tenslotte kun je in het submenu "*Extensions*" functies activeren die specifiek 
 ## Bitcoins ontvangen
 
 
-Nu je Passport is ingesteld, ben je klaar om je eerste Sats te ontvangen op je nieuwe Bitcoin Wallet. Klik hiervoor op Envoy op je "*Primary 0*" account.
+Nu je Passport is ingesteld, ben je klaar om je eerste Sats te ontvangen op je nieuwe Bitcoin wallet. Klik hiervoor op Envoy op je "*Primary 0*" account.
 
 
 ![Image](assets/fr/72.webp)
@@ -545,7 +545,7 @@ Klik op de knop "*Ontvangen*".
 ![Image](assets/fr/73.webp)
 
 
-Uw Envoy-toepassing toont de eerste beschikbare lege Address op uw Wallet. Voordat we het gebruiken, controleren we de Address op het Passport-scherm om er zeker van te zijn dat het echt bij onze Bitcoin Wallet hoort. Selecteer in het "*Account*" menu van je Passport "*Account Tools*".
+Uw Envoy-toepassing toont de eerste beschikbare lege Address op je wallet. Voordat we het gebruiken, controleren we de Address op het Passport-scherm om er zeker van te zijn dat het echt bij onze Bitcoin-wallet hoort. Selecteer in het "*Account*" menu van je Passport "*Account Tools*".
 
 
 ![Image](assets/fr/74.webp)
@@ -557,7 +557,7 @@ Klik op "*Verifieer Address*" en scan dan de QR-code die op Envoy wordt weergege
 ![Image](assets/fr/75.webp)
 
 
-Controleer of de Address op het paspoort precies overeenkomt met de Sparrow en of "*Verified*" verschijnt.
+Controleer of de Address op de Passport precies overeenkomt met de Sparrow en of "*Verified*" verschijnt.
 
 
 ![Image](assets/fr/76.webp)
@@ -572,7 +572,7 @@ Je kunt het nu gebruiken om bitcoins te ontvangen. Wanneer de transactie wordt u
 ## Bitcoins versturen
 
 
-Nu je een paar Sats in je Wallet hebt, kun je er ook een paar versturen. Klik daarvoor op de knop "*Versturen*".
+Nu je een paar Sats in je wallet hebt, kun je er ook een paar versturen. Klik daarvoor op de knop "*Versturen*".
 
 
 ![Image](assets/fr/78.webp)
@@ -590,7 +590,7 @@ Bepaal het bedrag dat je wilt verzenden en klik vervolgens op "*Bevestigen*".
 ![Image](assets/fr/80.webp)
 
 
-Selecteer de transactiekosten volgens de huidige marktsituatie en controleer vervolgens de transactiegegevens. Als alles correct is, klik je op "*Teken met paspoort*".
+Selecteer de transactiekosten volgens de huidige marktsituatie en controleer vervolgens de transactiegegevens. Als alles correct is, klik je op "*Teken met Passport*".
 
 
 ![Image](assets/fr/81.webp)
@@ -644,13 +644,13 @@ Als alle informatie correct is, klik je op de bevestigingsknop om de transactie 
 ![Image](assets/fr/89.webp)
 
 
-Je paspoort toont je ondertekende transactie in de vorm van een QR-code.
+Je Passport toont je ondertekende transactie in de vorm van een QR-code.
 
 
 ![Image](assets/fr/90.webp)
 
 
-Klik in de Envoy-toepassing op het QR-codepictogram en scan vervolgens het PSBT dat wordt weergegeven op het scherm van je paspoort.
+Klik in de Envoy-toepassing op het QR-codepictogram en scan vervolgens het PSBT dat wordt weergegeven op het scherm van je Passport.
 
 
 ![Image](assets/fr/91.webp)

--- a/tutorials/wallet/envoy/nl.md
+++ b/tutorials/wallet/envoy/nl.md
@@ -368,12 +368,12 @@ Klik op de bevestigingsknop om je mnemonische zin te zien.
 ![Image](assets/fr/34.webp)
 
 
-Voor meer informatie over de juiste manier om je Mnemonic zin op te slaan en te beheren, raad ik je aan deze andere tutorial te volgen, vooral als je een beginner bent:
+Voor meer informatie over het veilig opslaan en beheren van je mnemonische zin, raad ik je aan deze aanvullende tutorial te volgen. Deze is vooral aan te raden als je een beginner bent:
 
 
 https://planb.academy/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-natuurlijk mag je deze woorden nooit delen op het Internet, zoals ik in deze tutorial doe. Dit voorbeeld wallet wordt alleen gebruikt op Testnet en wordt verwijderd aan het einde van de tutorial.
+_**Natuurlijk mag je deze woorden nooit delen op het Internet, zoals ik in deze tutorial doe. Deze voorbeeld wallet wordt alleen gebruikt op Testnet en wordt verwijderd aan het einde van de tutorial.**_
 
 
 Maak een fysieke back-up van deze zin.
@@ -388,10 +388,10 @@ Je Passport is succesvol geconfigureerd. Klik op de bevestigingsknop om verder t
 ![Image](assets/fr/36.webp)
 
 
-## De wallet instellen op Envoy
+## De wallet configureren op Envoy
 
 
-In deze tutorial laat ik je zien hoe je de Passport kunt gebruiken met de Envoy-toepassing. Deze hardware wallet is echter ook compatibel met Sparrow wallet, Keeper, BlueWallet, Nunchuk, Specter en vele andere...
+In deze tutorial laat ik je zien hoe je de Passport kunt gebruiken met de Envoy-toepassing. Deze hardware wallet is echter ook compatibel met Sparrow Wallet, Keeper, Blue Wallet, Nunchuk, Specter en vele andere...
 
 
 ![Image](assets/fr/66.webp)
@@ -403,19 +403,19 @@ Gebruik de Envoy-toepassing om de QR-code op je Passport te scannen.
 ![Image](assets/fr/67.webp)
 
 
-Je publieke sleutels zijn nu geïmporteerd in de applicatie. Klik op "*Validate receive Address*".
+Je publieke sleutels zijn nu geïmporteerd in de applicatie. Klik op "*Validate receive address*".
 
 
 ![Image](assets/fr/68.webp)
 
 
-Gebruik je Passport om de Address te scannen die op Envoy wordt weergegeven.
+Gebruik je Passport om het adres te scannen dat op Envoy wordt weergegeven.
 
 
 ![Image](assets/fr/69.webp)
 
 
-Je Passport zal bevestigen of het wallet geïmporteerd op Envoy geldig is. Bevestig dit in de aanvraag.
+Je Passport zal bevestigen of de wallet die in Envoy is geïmporteerd geldig is. Bevestig dit in de applicatie.
 
 
 ![Image](assets/fr/70.webp)
@@ -427,23 +427,23 @@ Je hebt nu toegang tot de openbare informatie van je wallet op Envoy, maar om bi
 ![Image](assets/fr/71.webp)
 
 
-## Ontdek Paspoort-menu's
+## Ontdek de menus in Passpoort
 
 
-Uw Passport Interface heeft drie hoofdmenu's:
+Je Passport-interface heeft drie hoofdmenu's:
 
 
 
 
 - "*Account*";
-- "*Meer*";
-- "*Instellingen*".
+- "*More*";
+- "*Settings*".
 
 
 Om tussen deze menu's te navigeren, gebruikt je de pijlen naar links en rechts op de richtingsknop.
 
 
-### *Account*" menu
+### "*Account*" menu
 
 
 In het menu "*Account*" vind je de belangrijkste functies van je Bitcoin wallet. Je kunt een transactie ondertekenen via de camera of via de MicroSD-poort.
@@ -452,22 +452,22 @@ In het menu "*Account*" vind je de belangrijkste functies van je Bitcoin wallet.
 ![Image](assets/fr/37.webp)
 
 
-Het submenu "*Account Tools*" biedt opties zoals het verifiëren van een Address, het ondertekenen van een bericht of het raadplegen van de adressen in je wallet.
+Het submenu "*Account Tools*" biedt opties zoals het verifiëren van een adres, het ondertekenen van een bericht of het raadplegen van de adressen in je wallet.
 
 
 ![Image](assets/fr/38.webp)
 
 
-In het submenu "*Manage Account*" kun je je Bitcoin-wallet verbinden met een wallet beheersoftware (die we in de volgende stappen van deze tutorial behandelen), of je account bekijken en hernoemen.
+In het submenu "*Manage Account*" kun je je Bitcoin-wallet koppelen aan walletbeheersoftware. Daarnaast kun je je account bekijken en hernoemen. We bahandelen de software in de volgende stappen van deze tutorial. 
 
 
 ![Image](assets/fr/39.webp)
 
 
-### Meer" menu
+### "More" menu
 
 
-In het menu "*Meer*" kun je een nieuw account aanmaken in je wallet, gekoppeld aan dezelfde Mnemonic-zin.
+In het menu "*More*" kun je een nieuw account aanmaken in je wallet, gekoppeld aan dezelfde mnemonische zin.
 
 
 ![Image](assets/fr/40.webp)
@@ -479,10 +479,10 @@ Je kunt ook een BIP39 passphrase invoeren of een tijdelijke seed gebruiken.
 ![Image](assets/fr/41.webp)
 
 
-### Menu "Instellingen
+### Menu "Settings"
 
 
-In het menu "*Instellingen*" vind je al je wallet en apparaatinstellingen.
+In het menu "*Settings*" vind je al je wallet en apparaatinstellingen.
 
 
 ![Image](assets/fr/42.webp)
@@ -506,25 +506,25 @@ In het submenu "*Firmware*" kun je de firmware van je Passport bijwerken. We rad
 ![Image](assets/fr/45.webp)
 
 
-In het submenu "*Bitcoin*" kun je de weergegeven eenheid (BTC of satoshis) wijzigen, een mogelijke Multisig wallet beheren of overschakelen naar de modus "*Testnet*".
+In het submenu "*Bitcoin*" kun je de weergegeven eenheid (BTC of satoshis) wijzigen, een mogelijke multisig wallet beheren of overschakelen naar de modus "*Testnet*".
 
 
 ![Image](assets/fr/46.webp)
 
 
-In "*Geavanceerd*" kunt je de woorden van je Mnemonic-zin bekijken, acties uitvoeren op de geplaatste MicroSD, je Passport resetten naar de fabrieksinstellingen of een echtheidscontrole uitvoeren, zoals eerder is uitgevoerd.
+In "*Advanced*" kunt je de woorden van je mnemonische zin bekijken, acties uitvoeren op de geplaatste MicroSD, je Passport resetten naar de fabrieksinstellingen of een echtheidscontrole uitvoeren, zoals eerder is uitgevoerd.
 
 
 ![Image](assets/fr/47.webp)
 
 
-U kunt "*Veiligheidswoorden*" activeren, een functie die een Layer beveiliging toevoegt door twee specifieke woorden weer te geven bij het ontgrendelen van het apparaat na het invoeren van de eerste vier cijfers van de PIN-code. Deze woorden, die tijdens de configuratie moeten worden opgeslagen, zorgen ervoor dat de Passport niet is vervangen of dat er niet mee is geknoeid. In het geval van een afwijking op een later tijdstip, adviseren wij je het apparaat niet te gebruiken. Ik adviseer je om deze optie te activeren om de meeste risico's van fysieke compromittering van het apparaat te voorkomen.
+Je kunt "*Security words*" activeren, een functie die een beveiligingslaag toevoegt door twee specifieke woorden weer te geven bij het ontgrendelen van het apparaat na het invoeren van de eerste vier cijfers van de PIN-code. Deze woorden, die tijdens de configuratie moeten worden opgeslagen, zorgen ervoor dat de Passport niet is vervangen of dat er niet mee is geknoeid. Mocht er later een afwijking optreden, raad ik je aan het apparaat niet te gebruiken. Ik adviseer je om deze optie te activeren om de risico's van fysieke compromittering van je apparaat zoveel mogelijk te beperken.
 
 
 ![Image](assets/fr/48.webp)
 
 
-Tenslotte kun je in het submenu "*Extensions*" functies activeren die specifiek zijn voor bepaalde toepassingen van het apparaat, zoals het Whirlpool CoinJoin protocol.
+Tenslotte kun je in het submenu "*Extensions*" functies activeren die specifiek zijn voor bepaalde toepassingen van het apparaat, zoals het Whirlpool CoinJoin-protocol.
 
 
 ![Image](assets/fr/49.webp)
@@ -533,31 +533,31 @@ Tenslotte kun je in het submenu "*Extensions*" functies activeren die specifiek 
 ## Bitcoins ontvangen
 
 
-Nu je Passport is ingesteld, ben je klaar om je eerste Sats te ontvangen op je nieuwe Bitcoin wallet. Klik hiervoor op Envoy op je "*Primary 0*" account.
+Nu je Passport is ingesteld, ben je klaar om je eerste sats te ontvangen op je nieuwe Bitcoin-wallet. Klik hiervoor op Envoy op je "*Primary 0*" account.
 
 
 ![Image](assets/fr/72.webp)
 
 
-Klik op de knop "*Ontvangen*".
+Klik op de knop "*Receive*".
 
 
 ![Image](assets/fr/73.webp)
 
 
-Uw Envoy-toepassing toont de eerste beschikbare lege Address op je wallet. Voordat we het gebruiken, controleren we de Address op het Passport-scherm om er zeker van te zijn dat het echt bij onze Bitcoin-wallet hoort. Selecteer in het "*Account*" menu van je Passport "*Account Tools*".
+Je Envoy-toepassing toont het eerste beschikbare lege adres op je wallet. Voordat we het gebruiken, controleren we het adres op het Passport-scherm om er zeker van te zijn dat het echt bij onze Bitcoin-wallet hoort. Selecteer in het "*Account*" menu van je Passport "*Account Tools*".
 
 
 ![Image](assets/fr/74.webp)
 
 
-Klik op "*Verifieer Address*" en scan dan de QR-code die op Envoy wordt weergegeven.
+Klik op "*Verify Address*" en scan dan de QR-code die op Envoy wordt weergegeven.
 
 
 ![Image](assets/fr/75.webp)
 
 
-Controleer of de Address op de Passport precies overeenkomt met de Sparrow en of "*Verified*" verschijnt.
+Controleer of het adres op de Passport precies overeenkomt met de Envoy en of "*Verified*" verschijnt.
 
 
 ![Image](assets/fr/76.webp)
@@ -572,25 +572,25 @@ Je kunt het nu gebruiken om bitcoins te ontvangen. Wanneer de transactie wordt u
 ## Bitcoins versturen
 
 
-Nu je een paar Sats in je wallet hebt, kun je er ook een paar versturen. Klik daarvoor op de knop "*Versturen*".
+Nu je een paar sats in je wallet hebt, kun je er ook een paar versturen. Klik daarvoor op de knop "*Send*".
 
 
 ![Image](assets/fr/78.webp)
 
 
-Voer de Address van de ontvanger in door deze direct in te plakken of door de QR-code te scannen met de camera van je smartphone.
+Voer het adres van de ontvanger in door deze direct in te plakken of door de QR-code te scannen met de camera van je smartphone.
 
 
 ![Image](assets/fr/79.webp)
 
 
-Bepaal het bedrag dat je wilt verzenden en klik vervolgens op "*Bevestigen*".
+Bepaal het bedrag dat je wilt verzenden en klik vervolgens op "*Confirm*".
 
 
 ![Image](assets/fr/80.webp)
 
 
-Selecteer de transactiekosten volgens de huidige marktsituatie en controleer vervolgens de transactiegegevens. Als alles correct is, klik je op "*Teken met Passport*".
+Selecteer de transactiekosten volgens de huidige marktsituatie en controleer vervolgens de transactiegegevens. Als alles correct is, klik je op "*Sign with Passport*".
 
 
 ![Image](assets/fr/81.webp)
@@ -608,7 +608,7 @@ Envoy geeft dan een PSBT (*Partially Signed Bitcoin Transaction*) weer. De appli
 ![Image](assets/fr/83.webp)
 
 
-Ga op je Passport naar het menu "*Account*" en klik op "*Teken met QR Code*".
+Ga op je Passport naar het menu "*Account*" en klik op "*Sign with QR Code*".
 
 
 ![Image](assets/fr/84.webp)
@@ -620,13 +620,13 @@ Scan de PSBT (*Partially Signed Bitcoin Transaction*) die wordt weergegeven op E
 ![Image](assets/fr/85.webp)
 
 
-Controleer of de ontvangen Address en het verzonden bedrag correct zijn en druk vervolgens op de bevestigingstoets.
+Controleer of het ontvangstadres en het verzonden bedrag correct zijn en druk vervolgens op de bevestigingstoets.
 
 
 ![Image](assets/fr/86.webp)
 
 
-Controleer de Exchange Address. In mijn voorbeeld is er geen, omdat de transactie een enkele uitvoer bevat.
+Controleer het wisselgeldadres. In mijn voorbeeld is er geen, omdat de transactie maar een enkele output bevat.
 
 
 ![Image](assets/fr/87.webp)
@@ -656,7 +656,7 @@ Klik in de Envoy-toepassing op het QR-codepictogram en scan vervolgens het PSBT 
 ![Image](assets/fr/91.webp)
 
 
-Controleer je transactiegegevens nog een laatste keer. Als alles correct is, druk dan op "*Verstuur Transactie*" om het uit te zenden op het Bitcoin netwerk.
+Controleer je transactiegegevens nog een laatste keer. Als alles correct is, druk dan op "*Send Transaction*" om het uit te zenden op het Bitcoin-netwerk.
 
 
 ![Image](assets/fr/92.webp)
@@ -668,10 +668,10 @@ Je transactie wacht nu op bevestiging. Je kunt de status direct vanuit je accoun
 ![Image](assets/fr/93.webp)
 
 
-Gefeliciteerd, je weet nu hoe je de Passport kunt instellen en gebruiken met de Envoy-toepassing. Als je deze tutorial nuttig vond, zou ik je dankbaar zijn als je hieronder een Green duim achterlaat. Voel je vrij om dit artikel te delen op je sociale netwerken. Bedankt voor het delen!
+Gefeliciteerd, je weet nu hoe je de Passport instelt en gebruikt met de Envoy-app. Als je deze tutorial nuttig vond, zou ik je dankbaar zijn als je hieronder een groene duim achterlaat. Deel dit artikel gerust via je sociale netwerken. Bedankt voor het delen!
 
 
-Voor meer informatie, zie onze handleiding over Liana software:
+Om verder te gaan, kun je ook onze tutorial over de Liana-software raadplegen:
 
 
 https://planb.academy/tutorials/wallet/desktop/liana-306ef457-700c-4fdd-b07a-8fb7a8a29f04

--- a/tutorials/wallet/liana/nl.md
+++ b/tutorials/wallet/liana/nl.md
@@ -23,7 +23,7 @@ Als je geld wilt terugkrijgen van een bestaande Liana-wallet, lees dan de onders
 Liana is een softwarepakket open-source broncode, ontworpen voor het maken en beheren van geavanceerde wallets, met name als onderdeel van een geautomatiseerd opvolgingsmechanisme (erfenis) of een robuust back-upmechanisme. Het project wordt sinds 2022 ontwikkeld door Wizardsardine, een bedrijf dat mede-opgericht is door Kévin Loaec en Antoine Poinsot. Op de officiële website wordt Liana gepresenteerd als "een eenvoudige wallet voor persoonlijke custody, met herstel- en overervingsfunctionaliteiten". De software draait op computers -- Linux, MacOS, Windows -- en de (open) broncode is beschikbaar [op GitHub](https://github.com/wizardsardine/Liana).
 
 
-Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde wallet te maken. Met name maakt het gebruik van tijdsloten (*timelocks*), die het mogelijk maken om geld pas uit te geven als een bepaalde tijd verstreken is, en die een rol spelen bij het terughalen van je bitcoins. Een Liana wallet bestaat dus uit meerdere uitgavepaden:
+Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde wallet te maken. Met name maakt het gebruik van tijdsloten (*timelocks*), die het mogelijk maken om geld pas uit te geven als een bepaalde tijd verstreken is, en die een rol spelen bij het terughalen van je bitcoins. Een Liana-wallet bestaat dus uit meerdere uitgavepaden:
 
 
 
@@ -78,9 +78,9 @@ https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e
 https://planb.academy/tutorials/wallet/hardware/jade-7d62bf0c-f460-4e68-9635-af9b731dabc3
 
 
-- Twee opslagmedia (USB-sticks) om de wallet Descriptor op te slaan;
+- Twee opslagmedia (USB-sticks) om de wallet descriptor op te slaan;
 - Een opvolgingsbrief met instructies voor het terugvorderen van de fondsen;
-- Een genummerde verzegelde zak om er zeker van te zijn dat het terugwinningsapparaat (de Jade) niet is gebruikt.
+- Een genummerde verzegelde zak om er zeker van te zijn dat het herstelapparaat (de Jade) niet is gebruikt.
 
 
 ## Installatie en configuratie
@@ -97,19 +97,19 @@ Als je wilt weten hoe je handmatig de authenticiteit en integriteit van software
 
 https://planb.academy/tutorials/computer-security/data/integrity-authenticity-21d0420a-be02-4663-94a3-8d487f23becc
 
-Installeer de software op uw machine en start het op. Kies de optie "*Maak een nieuwe Liana wallet*" om uw wallet te configureren.
+Installeer de software op je machine en start het op. Kies de optie "*reate a new Liana-wallet*" om je wallet te configureren.
 
 
 ![Accueil Liana](assets/fr/03.webp)
 
 
-Kies je wallet type. Als je een verbeterde back-up met hersteltijd wilt instellen, kun je de optie "*Bouw je eigen*" selecteren en kiezen voor het standaardschema. Dit werkt op vrijwel dezelfde manier, behalve dat je de Hardware wallet herstelzin niet hoeft te behouden.
+Kies je wallet type. Als je een verbeterde back-up met hersteltijd wilt instellen, kun je de optie "*Build your own*" selecteren en kiezen voor het standaardschema. Dit werkt op vrijwel dezelfde manier, behalve dat je de hardware wallet herstelzin niet hoeft te behouden.
 
 
-We negeren hier het geval van de *Uitbreiding Multisig*, die een complexere configuratie opzet.
+We negeren hier het geval van de *Expanding Multisig*, dat een complexere configuratie opzet.
 
 
-In deze tutorial gebruiken we eenvoudige overerving.
+In deze tutorial gebruiken we eenvoudige overerving (*Simple inheritance*).
 
 
 ![Choisir type de portefeuille](assets/fr/04.webp)
@@ -121,13 +121,13 @@ Hieronder volgt een korte uitleg.
 ![Rapide explication](assets/fr/05.webp)
 
 
-Als je de uitleg hebt gelezen, kun je de sleutels voor je Liana wallet instellen. Dit is een cruciale stap, omdat het de bestedingskenmerken van je account bepaalt.
+Als je de uitleg hebt gelezen, kun je de sleutels voor je Liana-wallet instellen. Dit is een cruciale stap, omdat het de bestedingskenmerken van je account bepaalt.
 
 
 ![Configurer clés](assets/fr/06.webp)
 
 
-Allereerst kun je in het menu "Geavanceerde instellingen" beslissen over het "Descriptor type", d.w.z. de manier waarop de Contract op de ketting wordt geschreven. Je kunt kiezen uit twee types: P2WSH (SegWit) of Taproot. In beide gevallen is de semantiek van de bestedingsvoorwaarden hetzelfde. Terwijl P2WSH de Contract begrijpelijker maakt, is Taproot superieur omdat het ongebruikte voorwaarden verbergt en kosten bespaart bij het ophalen.
+Allereerst kun je in het menu "Advanced settings" beslissen over het "Descriptor type", d.w.z. de manier waarop het contract op de blockchain wordt geschreven. Je kunt kiezen uit twee types: P2WSH (SegWit) of Taproot. In beide gevallen is de semantiek van de bestedingsvoorwaarden hetzelfde. Terwijl P2WSH het contract begrijpelijker maakt, is Taproot superieur omdat het ongebruikte voorwaarden verbergt en kosten bespaart bij het herstel.
 
 
 Deze keuze is optioneel: laat in geval van twijfel de standaardoptie staan (P2WSH in het geval van versie 0.9, maar dit is onderhevig aan verandering).
@@ -136,19 +136,19 @@ Deze keuze is optioneel: laat in geval van twijfel de standaardoptie staan (P2WS
 ![Choisir le type de descripteur](assets/fr/07.webp)
 
 
-Configureer vervolgens je primaire sleutel (*primary key*). Deze sleutel (of liever, deze set sleutels) zal worden gebruikt voor de huidige uitgave van fondsen, die niet onderhevig is aan enige tijdsvoorwaarden. Door op "*Set*" te klikken, kun je het bijbehorende *signing device* selecteren. In ons geval hebben we de Ledger Nano S Plus Hardware wallet gekozen.
+Configureer vervolgens je primaire sleutel (*primary key*). Deze sleutel (of liever, deze sleutelset) zal worden gebruikt voor de lopende uitgaven van fondsen, die niet onderhevig is aan enige tijdsvoorwaarde. Door op "*Set*" te klikken, kun je het bijbehorende *signing device* selecteren. In ons geval hebben we de Ledger Nano S Plus-hardware wallet gekozen.
 
 
-Geef toestemming voor het delen van de uitgebreide openbare sleutel van het apparaat. Geef deze sleutel een betekenisvolle naam (in dit geval "Nano S+"). Merk op dat alle toepassingen die op het apparaat geïnstalleerd zijn normaal blijven werken.
+Geef toestemming voor het delen van de uitgebreide publieke sleutel van het apparaat. Geef deze sleutel een betekenisvolle naam (in dit geval "Nano S+"). Merk op dat alle applicaties die op het apparaat geïnstalleerd zijn normaal blijven werken.
 
 
 ![Configurer clé principale](assets/fr/08.webp)
 
 
-Stel vervolgens de terugbetalingsvertraging in, d.w.z. de tijd waarna het geld kan worden uitgegeven door de *erfgoedsleutel*. Deze vertraging wordt gedefinieerd in termen van blokken, waarbij elk blok wordt gescheiden door een gemiddelde van 10 minuten. Het kan variëren van 10 minuten (1 blok) tot ongeveer 15 maanden (65.535 blokken). Deze bovengrens is een beperking van het Bitcoin protocol, omdat de vergrendelingstijd gecodeerd is op 16 bits.
+Stel vervolgens de terugbetalingsvertraging in, d.w.z. de tijd waarna het geld kan worden uitgegeven door de *opvolgingssleutel* (inheritance key). Deze vertraging wordt gedefinieerd in termen van blokken, waarbij elk blok wordt gescheiden door een gemiddelde van 10 minuten. Het kan variëren van 10 minuten (1 blok) tot ongeveer 15 maanden (65.535 blokken). Deze bovengrens is een beperking van het Bitcoin-protocol, omdat de vergrendelingstijd gecodeerd is op 16 bits.
 
 
-Kies, behoudens speciale omstandigheden, voor de langste levertijd: 15 maanden of 65.535 blokken. Dit bespaart u kosten. We raden je echter aan om de updateprocedure (beschreven in het hoofdstuk "Updaten van wallet") één keer per jaar uit te voeren, altijd op hetzelfde moment van het jaar, om deze praktijk te "ritualiseren" en te voorkomen dat je het vergeet.
+Kies, behoudens speciale omstandigheden, voor de langste levertijd: 15 maanden of 65.535 blokken. Dit bespaart je kosten. We raden je echter aan om de updateprocedure (beschreven in het hoofdstuk "Updaten van wallet") één keer per jaar uit te voeren, altijd op hetzelfde moment van het jaar, om deze praktijk te "ritualiseren" en te voorkomen dat je het vergeet.
 
 
 Hier hebben we een hersteltijd van een uur (6 blokken) ingesteld om onze tests uit te voeren.
@@ -157,7 +157,7 @@ Hier hebben we een hersteltijd van een uur (6 blokken) ingesteld om onze tests u
 ![Configurer temps de verrouillage](assets/fr/09.webp)
 
 
-Stel ten slotte je boedelsleutel in. Deze sleutel (of beter gezegd, set sleutels) zal worden gebruikt om geld terug te krijgen in het geval van je verdwijning. Klik op "*Set*", kies het ondertekeningsapparaat en valideer het delen van de uitgebreide openbare sleutel erop.
+Stel ten slotte je boedelsleutel (estate key) in. Deze sleutel (of beter gezegd, sleutelset) zal worden gebruikt om geld terug te krijgen in het geval van je verdwijning. Klik op "*Set*", kies het ondertekenapparaat en valideer het delen van de uitgebreide publieke sleutel erop.
 
 
 Voor deze tutorial hebben we Jade gekozen. Geef de sleutel een suggestieve naam (hier "Jade"). Net als bij het eerste apparaat blijven conventionele accounts functioneren.
@@ -166,22 +166,22 @@ Voor deze tutorial hebben we Jade gekozen. Geef de sleutel een suggestieve naam 
 ![Configurer clé de succession](assets/fr/10.webp)
 
 
-Zodra al deze acties zijn voltooid, controleer je of alles in orde is en klik je op "*Doorgaan*" om je keuzes te bevestigen.
+Zodra al deze acties zijn voltooid, controleer je of alles in orde is en klik je op "*Continue*" om je keuzes te bevestigen.
 
 
 ![Confirmer clés](assets/fr/11.webp)
 
 
-De volgende stap is het opslaan van je wallet Descriptor. Dit is de informatie die je nodig hebt om het geld op je rekening te vinden. In tegenstelling tot de Mnemonic zin, kun je met de Descriptor geen geld uitgeven, dus het vrijgeven ervan zal alleen een vertrouwelijkheidsprobleem opleveren (de persoon zal al je transacties kennen).
+De volgende stap is het opslaan van je wallet descriptor. Dit is de informatie die je nodig hebt om het geld op je rekening terug te vinden. In tegenstelling tot de mnemonische zin, kun je met de descriptor geen geld uitgeven, dus het vrijgeven ervan leidt alleen tot een privacyprobleem (de persoon zal al je transacties zien).
 
 
-Bewaar twee kopieën van de Descriptor op elektronische media, zoals USB-sticks. Zorg ervoor dat je ook twee kopieën op papier afdrukt, zodat je er bij kunt in het geval van schade aan de elektronische media. Elke back-up moet gekoppeld zijn aan een handtekeningapparaat.
+Bewaar twee kopieën van de descriptor op elektronische media, zoals USB-sticks. Zorg er ook voor dat je twee kopieën op papier afdrukt, voor het geval elektronische media beschadigd raken. Elke back-up moet gekoppeld zijn aan een ondertekenapparaat (sigining device).
 
 
 ![Sauvegarder descripteur](assets/fr/12.webp)
 
 
-Onze Descriptor (die aan het eind van de tutorial wordt geanalyseerd) is als volgt:
+Onze descriptor (die aan het eind van de tutorial wordt geanalyseerd) is als volgt:
 
 
 ```plaintext
@@ -189,62 +189,62 @@ wsh(or_d(pk([3689a8e7/48'/0'/0'/2']xpub6FKYNH4XbbdADV98yTVxgZZrtB4eE2tiUPreEv5iJ
 ```
 
 
-De laatste stap in de initiële wallet configuratie is het verifiëren van de Descriptor in elk van de hardware wallets die dienen als handtekeningapparaten.
+De laatste stap in de initiële walletconfiguratie is het verifiëren van de descriptor in elk van de hardware wallets die dienen als ondertekenapparaten.
 
 
 ![Enregistrer descripteur](assets/fr/13.webp)
 
 
-Doe hetzelfde voor elk ondertekeningsapparaat. U moet controleren en bevestigen dat de Descriptor aan elke Hardware wallet is toegevoegd.
+Doe hetzelfde voor elk ondertekenapparaat. Je moet controleren en bevestigen dat de descriptor aan elke hardware wallet is toegevoegd.
 
 
 ![Enregistrer descripteur Nano S Plus](assets/fr/14.webp)
 
 
-Je wallet informatie is nu geregistreerd en je hoeft alleen nog maar te configureren hoe je verbinding wilt maken met het Bitcoin netwerk. Je kunt ervoor kiezen om je eigen node te gebruiken (lokaal of op afstand) of om de infrastructuur van WizardSardine te gebruiken. In het laatste geval moet je een e-mail Address koppelen aan je wallet, waarmee je de Descriptor kunt ophalen. WizardSardine heeft dan toegang tot al je transacties. De eerste optie wordt daarom aangeraden.
+Je wallet informatie is nu geregistreerd en je hoeft alleen nog maar te configureren hoe je verbinding wilt maken met het Bitcoin-netwerk. Je kunt ervoor kiezen om je eigen node te gebruiken (lokaal of op afstand) of om de infrastructuur van WizardSardine te gebruiken. In het laatste geval moet je een e-mailadres koppelen aan je wallet, waarmee je de descriptor kunt ophalen. WizardSardine heeft dan toegang tot al je transacties. De eerste optie wordt daarom aanbevolen.
 
 
 ![Sélectionner connexion réseau](assets/fr/15.webp)
 
 
-We hebben ervoor gekozen om ons eigen knooppunt te gebruiken. Je kunt een bestaand knooppunt gebruiken of een *pruned knooppunt* op je machine installeren. Als je geen toegang hebt tot een ander knooppunt, installeer dan je eigen knooppunt op je machine, wat enige tijd in beslag neemt (in de orde van enkele dagen).
+We hebben ervoor gekozen om onze eigen node te gebruiken. Je kunt een bestaande node gebruiken of een *pruned node* op je machine installeren. Als je geen toegang hebt tot een andere node, installeer dan je eigen node op je machine, wat enige tijd in beslag neemt (meerdere dagen).
 
 
 ![Choisir type de nœud](assets/fr/16.webp)
 
 
-Voor deze tutorial hebben we een bestaande (openbare) Electrum server gebruikt. Maar wees voorzichtig! Deze had toegang tot al onze activiteiten met de Liana wallet. Gebruik dus je eigen node als je je privacy wilt beschermen.
+Voor deze tutorial hebben we een bestaande (openbare) Electrum-server gebruikt. Maar wees voorzichtig! Deze had toegang tot al onze activiteiten met de Liana-wallet. Gebruik dus je eigen node als je je privacy wilt beschermen.
 
 
 ![Connexion serveur Electrum public](assets/fr/17.webp)
 
 
-Zodra de knooppuntconfiguratie voltooid is, opent het hoofdscherm, waarop je pas aangemaakte Liana wallet te zien is.
+Zodra de node-configuratie voltooid is, opent het hoofdscherm, waarop je pas aangemaakte Liana-wallet te zien is.
 
 
-Maak van de gelegenheid gebruik om de bergingseenheid op een veilige plaats op te bergen. Bewaar het op een strategische plek, zodat je erfgenamen het kunnen vinden als je overlijdt.
+Maak van de gelegenheid gebruik om de herstel apparaten op een veilige plaats op te bergen. Bewaar het op een strategische plek, zodat je erfgenamen het kunnen vinden als je overlijdt.
 
 
 Voor extra veiligheid kun je de onderdelen die je gebruikt voor herstel in een verzegelde zak doen (*tamper-evident bag*) en het serienummer ergens opschrijven. Dit zorgt ervoor dat niemand erbij kan en dat je apparaat geldig blijft.
 
 
-In ons voorbeeld hebben we de volgende Elements samengesteld:
+In ons voorbeeld hebben we de volgende elementen samengesteld:
 
 
 
 
-- Blockstream Jade als handtekeningapparaat voor het landgoed;
+- Blockstream Jade als ondertekenapparaat voor de boedel (estate);
 - Een USB-kabel om het apparaat aan te sluiten en op te laden;
-- Een papieren back-up van de zin in geval van storing of schade aan het apparaat (merk op dat het medium ook van metaal kan zijn, en dus beschermd tegen de Elements, zoals bijvoorbeeld het geval is met Cryptosteel capsules);
-- De USB-stick met de wallet Descriptor ;
-- Een papieren back-up van de Descriptor, in geval van storing of schade aan de USB-stick (deze back-up is hier niet gefotografeerd);
+- Een papieren back-up van de herstelzin in geval van storing of schade aan het apparaat (merk op dat het medium ook van metaal kan zijn, en dus beschermd tegen het weer, zoals bijvoorbeeld het geval is met Cryptosteel capsules);
+- De USB-stick met de wallet descriptor ;
+- Een papieren back-up van de descriptor, in geval van storing of schade aan de USB-stick (deze back-up is hier niet gefotografeerd);
 - Een opvolgingsbrief waarin de stappen worden beschreven die moeten worden genomen om de fondsen terug te vorderen.
 
 
 ![Éléments de récupération](assets/fr/18.webp)
 
 
-En we plaatsen deze items onder Seal!
+En we plaatsen deze items in de verzegelde zak!
 
 
 ![Sachet scellé récupération](assets/fr/19.webp)
@@ -253,7 +253,7 @@ En we plaatsen deze items onder Seal!
 ## Ontvangst van fondsen
 
 
-Het hoofdscherm van Liana toont uw saldo en de transacties (verleden en huidig) die aan uw wallet zijn gekoppeld. In ons geval is het saldo nul, wat normaal is.
+Het hoofdscherm van Liana toont je saldo en de transacties (verleden en huidig) die aan je wallet zijn gekoppeld. In ons geval is het saldo nul, wat normaal is.
 
 
 ![Écran principal](assets/fr/20.webp)
@@ -265,7 +265,7 @@ Om geld te ontvangen, ga je naar het tabblad "*Ontvangen*" en klik je op "*gener
 ![Générer nouvelle adresse](assets/fr/21.webp)
 
 
-Je moet deze Address verifiëren op je Hardware wallet door te klikken op "*Verify on hardware device*".
+Je moet deze Address verifiëren op je hardware wallet door te klikken op "*Verify on hardware device*".
 
 
 ![Vérifier adresse portefeuille matériel](assets/fr/22.webp)
@@ -294,7 +294,7 @@ https://planb.academy/courses/65c138b0-4161-4958-bbe3-c12916bc959c
 Huidige uitgaven is de normale situatie voor het gebruik van Liana. Bitcoins versturen met de hoofdsleutel werkt zoals in alle klassieke Bitcoin wallets zoals Electrum of Sparrow.
 
 
-Ga naar de tab "*Versturen*" en voer de essentiële informatie in: de BTC Address van de ontvanger, het te versturen bedrag en het gewenste tarief. Een beschrijving (lokaal opgeslagen) kan ook worden toegevoegd voor uw persoonlijk gemak. In ons voorbeeld stuurden we 10.000 satoshis naar een bepaalde Bob, voor een laadtarief van 4 sat/ov, of $0,67 op het moment van de transactie.
+Ga naar de tab "*Versturen*" en voer de essentiële informatie in: de BTC Address van de ontvanger, het te versturen bedrag en het gewenste tarief. Een beschrijving (lokaal opgeslagen) kan ook worden toegevoegd voor je persoonlijk gemak. In ons voorbeeld stuurden we 10.000 satoshis naar een bepaalde Bob, voor een laadtarief van 4 sat/ov, of $0,67 op het moment van de transactie.
 
 
 Liana biedt ook "Coin controle": je geeft aan welke Coin (UTXO) je wilt uitgeven. Hier hebben we gekozen voor de 50.000 satoshis die Coin eerder creëerde.
@@ -324,7 +324,7 @@ De transactie verschijnt op het hoofdscherm en je saldo wordt bijgewerkt.
 ## Portefeuille-update
 
 
-Zoals hierboven uitgelegd, vereist de Liana wallet dat u uw fondsen regelmatig bijwerkt door een transactie uit te voeren op de Blockchain. Als u dit niet doet, kan uw erfgenaam (of uw tweede apparaat in het geval van een uitgebreide back-up) uw fondsen terugvorderen. Als je dit niet doet, kan je geld worden teruggehaald door je erfgenaam (of door je tweede apparaat in het geval van een uitgebreide back-up). Deze situatie is niet extreem gevaarlijk, maar gaat wel in tegen het doel van dit mechanisme: controle houden over je bitcoins zonder een beroep te doen op een vertrouwde derde partij, terwijl je profiteert van een vangnet.
+Zoals hierboven uitgelegd, vereist de Liana-wallet dat u je fondsen regelmatig bijwerkt door een transactie uit te voeren op de Blockchain. Als u dit niet doet, kan je erfgenaam (of je tweede apparaat in het geval van een uitgebreide back-up) je fondsen terugvorderen. Als je dit niet doet, kan je geld worden teruggehaald door je erfgenaam (of door je tweede apparaat in het geval van een uitgebreide back-up). Deze situatie is niet extreem gevaarlijk, maar gaat wel in tegen het doel van dit mechanisme: controle houden over je bitcoins zonder een beroep te doen op een vertrouwde derde partij, terwijl je profiteert van een vangnet.
 
 
 Er wordt een waarschuwing weergegeven voordat je geld (of een deel ervan) vervalt en kan worden uitgegeven door de herstelsleutel. Het zal aangeven dat je "herstelpad" (*herstelpad*) binnenkort beschikbaar zal zijn. Gezien de korte hersteltijd (een uur), wordt dit bericht in ons geval direct weergegeven.
@@ -357,7 +357,7 @@ De transactie (met het label "*zelftransfer*") zal alleen zichtbaar zijn in het 
 ![Transactions après auto-transfert](assets/fr/33.webp)
 
 
-Eenmaal bevestigd, is uw Coin veilig! U kunt gerust zijn tot de volgende vervaldatum.
+Eenmaal bevestigd, is je Coin veilig! U kunt gerust zijn tot de volgende vervaldatum.
 
 
 ## Bitcoin herstel
@@ -366,7 +366,7 @@ Eenmaal bevestigd, is uw Coin veilig! U kunt gerust zijn tot de volgende vervald
 Wanneer je geld terughaalt van de Liana Wallet, kun je te maken krijgen met één van twee situaties. Misschien heb je toegang tot de computer waarop de software geïnstalleerd is, in dat geval hoef je hem alleen maar te openen (wat zal gebeuren in het geval van het uitgebreide back-up model). Het is echter mogelijk dat je geen toegang hebt tot deze computer, dus beginnen we hier vanaf nul. Merk op dat de herstelprocedure in beide gevallen hetzelfde is.
 
 
-Om te beginnen, download Liana van [de officiële Wizardsardine website](https://wizardsardine.com/Liana/), of van [de GitHub repository](https://github.com/wizardsardine/Liana/releases), waar je de authenticiteit van de software kunt controleren. Installeer de software en voer het uit. De versie die wij gebruiken is 0.9, dus de afbeeldingen kunnen veranderd zijn. Selecteer op het welkomstscherm de optie "Een bestaande Liana wallet toevoegen".
+Om te beginnen, download Liana van [de officiële Wizardsardine website](https://wizardsardine.com/Liana/), of van [de GitHub repository](https://github.com/wizardsardine/Liana/releases), waar je de authenticiteit van de software kunt controleren. Installeer de software en voer het uit. De versie die wij gebruiken is 0.9, dus de afbeeldingen kunnen veranderd zijn. Selecteer op het welkomstscherm de optie "Een bestaande Liana-wallet toevoegen".
 
 
 ![Ajouter portefeuille existant](assets/fr/34.webp)
@@ -378,7 +378,7 @@ Configureer hoe je verbinding wilt maken met het netwerk. Je kunt je eigen node 
 ![Sélectionner connexion réseau](assets/fr/35.webp)
 
 
-Als je je eigen knooppunt gebruikt, importeer dan de wallet Descriptor. Dit is een technische beschrijving van de rekening, waarmee je de fondsen op de rekening kunt ophalen. In ons geval is het de volgende informatie:
+Als je je eigen knooppunt gebruikt, importeer dan de wallet descriptor. Dit is een technische beschrijving van de rekening, waarmee je de fondsen op de rekening kunt ophalen. In ons geval is het de volgende informatie:
 
 
 ```plaintext
@@ -389,22 +389,22 @@ wsh(or_d(pk([3689a8e7/48'/0'/0'/2']xpub6FKYNH4XbbdADV98yTVxgZZrtB4eE2tiUPreEv5iJ
 ![Importer descripteur](assets/fr/36.webp)
 
 
-Liana vraagt u vervolgens een Mnemonic-zin in te voeren. Als je een werkend signatuurapparaat (hardware wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen aantal hoog is), raden we toch aan om een nieuwe Hardware wallet aan te schaffen en de Mnemonic te gebruiken om de sleutels erop te herstellen.
+Liana vraagt u vervolgens een Mnemonic-zin in te voeren. Als je een werkend signatuurapparaat (hardware wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen aantal hoog is), raden we toch aan om een nieuwe hardware wallet aan te schaffen en de Mnemonic te gebruiken om de sleutels erop te herstellen.
 
 
-In ons geval gebruiken we de Blockstream Jade Hardware wallet als herstelapparaat en kiezen we ervoor om deze stap over te slaan ("*Skip*").
+In ons geval gebruiken we de Blockstream Jade hardware wallet als herstelapparaat en kiezen we ervoor om deze stap over te slaan ("*Skip*").
 
 
 ![Passer phrase mnémotechnique](assets/fr/37.webp)
 
 
-Controleer en sla de Descriptor op in je handtekeningapparaat door het te selecteren op het scherm. Als uw Hardware wallet niet verschijnt, controleer dan of deze is aangesloten en ontgrendeld. Controleer en bevestig dat deze informatie is toegevoegd aan uw apparaat.
+Controleer en sla de descriptor op in je handtekeningapparaat door het te selecteren op het scherm. Als je hardware wallet niet verschijnt, controleer dan of deze is aangesloten en ontgrendeld. Controleer en bevestig dat deze informatie is toegevoegd aan je apparaat.
 
 
 ![Enregistrer descripteur sur l'appareil de récupération](assets/fr/38.webp)
 
 
-Configureer uw knooppunt. U kunt een bestaand knooppunt gebruiken of een *pruned knooppunt* op uw machine installeren. In ons geval hebben we een bestaand knooppunt gebruikt.
+Configureer je knooppunt. U kunt een bestaand knooppunt gebruiken of een *pruned knooppunt* op je machine installeren. In ons geval hebben we een bestaand knooppunt gebruikt.
 
 
 ![Choisir type de nœud](assets/fr/39.webp)
@@ -452,13 +452,13 @@ De transactie zou op het hoofdscherm moeten verschijnen. Eenmaal bevestigd, is h
 ![Écran principal après récupération](assets/fr/45.webp)
 
 
-## Bonus: Descriptor analyse
+## Bonus: descriptor analyse
 
 
-De Descriptor is een door mensen leesbare tekenreeks die een set adressen uitputtend beschrijft. Het combineert een aantal essentiële stukken informatie voor het ophalen van de onderdelen (UTXO) van een geavanceerde Wallet. De manier waarop de Descriptor is geschreven, is gebaseerd op [Miniscript syntax](https://bitbox.swiss/blog/understanding-Bitcoin-miniscript-part-2/), de scripttaal die in 2019 is ontwikkeld door Andrew Poelstra, Pieter Wuille en Sanket Kanjalkar.
+De descriptor is een door mensen leesbare tekenreeks die een set adressen uitputtend beschrijft. Het combineert een aantal essentiële stukken informatie voor het ophalen van de onderdelen (UTXO) van een geavanceerde Wallet. De manier waarop de descriptor is geschreven, is gebaseerd op [Miniscript syntax](https://bitbox.swiss/blog/understanding-Bitcoin-miniscript-part-2/), de scripttaal die in 2019 is ontwikkeld door Andrew Poelstra, Pieter Wuille en Sanket Kanjalkar.
 
 
-Om beter te begrijpen waarom deze tekenreeks belangrijk is, analyseren we de Descriptor in ons voorbeeld, die :
+Om beter te begrijpen waarom deze tekenreeks belangrijk is, analyseren we de descriptor in ons voorbeeld, die :
 
 
 ```plaintext
@@ -466,25 +466,25 @@ wsh(or_d(pk([3689a8e7/48'/0'/0'/2']xpub6FKYNH4XbbdADV98yTVxgZZrtB4eE2tiUPreEv5iJ
 ```
 
 
-De volgende informatie kan uit deze Descriptor worden gehaald:
+De volgende informatie kan uit deze descriptor worden gehaald:
 
 
 
 
 - `wsh` (afkorting van *witness script Hash*): Dit is het type transactionele uitvoer dat wordt gemaakt. Als we Taproot hadden gebruikt, zou de identifier `tr` zijn geweest.
 - `or_d`: Dit is een logische operator die aangeeft dat aan *één van de volgende twee* voorwaarden moet worden voldaan om de uitgave te accepteren (de `_d` geeft een bepaalde syntaxis aan).
-- `pk` (afkorting voor *publieke sleutel*): Deze operator controleert een gegeven handtekening tegen de volgende openbare sleutel en geeft het antwoord als een Booleaanse (TRUE of FALSE).
-- `[3689a8e7/48'/0'/0'/2']`: Dit element bevat de *vingerafdruk* van de hoofdsleutel voor de belangrijkste Hardware wallet (in dit geval de Nano S Plus), en het afleidingspad naar de gekoppelde uitgebreide privésleutel (waarvan alle andere privésleutels zijn afgeleid).
-- `xpub6FKY ... WQa`: Dit is de uitgebreide publieke sleutel die gekoppeld is aan de hoofd-Hardware wallet (hier de Nano S Plus)
+- `pk` (afkorting voor *publieke sleutel*): Deze operator controleert een gegeven handtekening tegen de volgende publieke sleutel en geeft het antwoord als een Booleaanse (TRUE of FALSE).
+- `[3689a8e7/48'/0'/0'/2']`: Dit element bevat de *vingerafdruk* van de hoofdsleutel voor de belangrijkste hardware wallet (in dit geval de Nano S Plus), en het afleidingspad naar de gekoppelde uitgebreide privésleutel (waarvan alle andere privésleutels zijn afgeleid).
+- `xpub6FKY ... WQa`: Dit is de uitgebreide publieke sleutel die gekoppeld is aan de hoofd-hardware wallet (hier de Nano S Plus)
 - `/<0;1>/*`: Dit zijn de afleidingspaden voor het verkrijgen van eenvoudige sleutels en adressen: `0` voor ontvangst, `1` voor interne operaties (*wijziging*), met een "wildcard" (`*`) die sequentiële afleiding van meerdere adressen op een configureerbare manier toestaat, vergelijkbaar met het "gap limit" beheer van klassieke wallet software.
 - en_v`: Dit is een logische operator die aangeeft dat *aan de volgende twee* voorwaarden moet worden voldaan om de uitgave te accepteren (de `_v` geeft een bepaalde syntaxis aan).
-- `v:pkh` (afkorting van *verifieer: openbare sleutel Hash*): Deze operator verifieert een gegeven handtekening en publieke sleutel tegen de publieke sleutel Hash (*Hash*) die volgt. Dit is in wezen dezelfde controle als voor P2PKH en P2WPKH scripts.
+- `v:pkh` (afkorting van *verifieer: publieke sleutel Hash*): Deze operator verifieert een gegeven handtekening en publieke sleutel tegen de publieke sleutel Hash (*Hash*) die volgt. Dit is in wezen dezelfde controle als voor P2PKH en P2WPKH scripts.
 - `[42e629dd/48'/0'/0'/2']`: Dit is hetzelfde element als hierboven (bestaande uit het spoor en het afleidingspad), behalve dat het spoor van de hoofdsleutel van de hardwareherstel wallet (in dit geval de Jade) wordt aangegeven.
 - `xpub6DpQ ... WQd`: Dit is de uitgebreide publieke sleutel gekoppeld aan de hardware recovery wallet (hier de Jade).
 - `older(6)` : Deze operator controleert of de aangemaakte transactionele uitvoer een leeftijd moet hebben die strikt groter is dan 6 blokken om uitgegeven te kunnen worden.
 
 
-Het laatste data-item (`8alrve5h`) is de Descriptor controlesom en komt overeen met de wallet identificatie.
+Het laatste data-item (`8alrve5h`) is de descriptor controlesom en komt overeen met de wallet identificatie.
 
 
 De scripts die door deze wallet worden aangemaakt, hebben de volgende vorm:

--- a/tutorials/wallet/liana/nl.md
+++ b/tutorials/wallet/liana/nl.md
@@ -20,10 +20,10 @@ Als je geld wilt terugkrijgen van een bestaande Liana-wallet, lees dan de onders
 ## Introductie van Liana software
 
 
-Liana is een open-source softwarepakket ontworpen voor het maken en beheren van geavanceerde wallets, met name als onderdeel van een geautomatiseerd overervingssysteem of een robuust back-upmechanisme. Het project wordt sinds 2022 ontwikkeld door Wizardsardine, een bedrijf dat mede is opgericht door Kévin Loaec en Antoine Poinsot. Op de officiële website wordt Liana gepresenteerd als "een eenvoudige wallet voor persoonlijke curatie, met herstel- en overervingsfunctionaliteiten". De software draait op computers -- Linux, MacOS, Windows -- en de (open) broncode is beschikbaar [op GitHub](https://github.com/wizardsardine/Liana).
+Liana is een softwarepakket open-source broncode, ontworpen voor het maken en beheren van geavanceerde wallets, met name als onderdeel van een geautomatiseerd opvolgingsmechanisme (erfenis) of een robuust back-upmechanisme. Het project wordt sinds 2022 ontwikkeld door Wizardsardine, een bedrijf dat mede-opgericht is door Kévin Loaec en Antoine Poinsot. Op de officiële website wordt Liana gepresenteerd als "een eenvoudige wallet voor persoonlijke custody, met herstel- en overervingsfunctionaliteiten". De software draait op computers -- Linux, MacOS, Windows -- en de (open) broncode is beschikbaar [op GitHub](https://github.com/wizardsardine/Liana).
 
 
-Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde wallet te maken. In het bijzonder maakt het gebruik van tijdsloten (*timelocks*), die het mogelijk maken om geld pas uit te geven als een bepaalde tijd verstreken is, en die betrokken zijn bij het terughalen van Bitcoins. Een Liana wallet bestaat dus uit meerdere uitgavenpaden:
+Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde wallet te maken. Met name maakt het gebruik van tijdsloten (*timelocks*), die het mogelijk maken om geld pas uit te geven als een bepaalde tijd verstreken is, en die een rol spelen bij het terughalen van je bitcoins. Een Liana wallet bestaat dus uit meerdere uitgavepaden:
 
 
 
@@ -32,30 +32,30 @@ Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde wall
 - Ten minste één herstelpad, dat na een bepaalde tijd toegankelijk wordt.
 
 
-Het onderstaande diagram illustreert de werking van een wallet met twee uitgavenpaden:
+Het onderstaande diagram illustreert de werking van een wallet met twee uitgavepaden:
 
 
 ![Schéma explicatif](assets/fr/01.webp)
 
 
-Met deze handeling kunt u verschillende configuraties instellen, waaronder :
+Met deze functionaliteit kun je verschillende configuraties instellen, waaronder:
 
 
 
 
-- Een successieplan, dat de erfgenamen in staat stelt om geld terug te krijgen als de gebruiker overlijdt. Voor meer informatie over dit onderwerp raden we aan [deel 4](https://planb.academy/courses/f3e3843d-1a1d-450c-96d6-d7232158b81f/233c88d3-2e8e-5eba-ac06-efe67a209038) van de BTC102-cursus te lezen.
-- Een versterkte back-up met een hersteltijd, zodat de gebruiker zijn wallet kan gebruiken zonder de bijbehorende geheime zin te hoeven bewaren en het risico te lopen dat deze wordt gestolen, bijvoorbeeld tijdens een inbraak.
-- Een vangnet voor mensen die beginnen met Bitcoin: ze beheren hun eigen Wallet, en hun "voogd" (een familielid, bijvoorbeeld) behoudt zich het recht voor om hun fondsen na een bepaalde periode terug te vorderen.
-- Een meerpartijen handtekeningschema (*Multisig*) met verminderde eisen in de tijd, om het verdwijnen van een of meer van de deelnemers op te vangen, zoals de partners van een bedrijf.
+- Een successieregeling, dat de erfgenamen in staat stelt om geld terug te krijgen als de gebruiker overlijdt. Voor meer informatie over dit onderwerp raden we aan [deel 4](https://planb.academy/courses/f3e3843d-1a1d-450c-96d6-d7232158b81f/233c88d3-2e8e-5eba-ac06-efe67a209038) van de BTC102-cursus te lezen.
+- Een versterkte back-up met een tijdslot, zodat de gebruiker zijn wallet kan gebruiken zonder de bijbehorende geheime zin te hoeven bewaren en het risico te lopen dat deze wordt gestolen, bijvoorbeeld tijdens een inbraak.
+- Een vangnet voor mensen die beginnen met Bitcoin: ze beheren hun eigen wallet, en hun "voogd" (een familielid, bijvoorbeeld) behoudt zich het recht voor om hun fondsen na een bepaalde periode terug te vorderen.
+- Een meerpartijen handtekeningschema (*multisig*) met verminderde handtekeningseisen in de tijd, om het verlies van een of meer van de deelnemers op te vangen, zoals de partners van een bedrijf.
 
 
-De grote kracht van Liana is dat het een gestandaardiseerde manier introduceert om het terugkrijgen van fondsen te garanderen in het geval van verlies van de hoofdsleutel, die gebruikt wordt voor lopende uitgaven. Dit is een enorme innovatie voor het schoon bewaren van fondsen, wat vol risico's zit, vooral als je niet goed geïnformeerd bent over het onderwerp. Liana zou daarom zelfs de meest risicomijdende gebruikers kunnen aanmoedigen om te stoppen met het gebruiken van een custodian (zoals een Exchange platform) om hun fondsen te bewaren en Ownership van hun geld terug te krijgen, in overeenstemming met Bitcoin's Cypherpunk ethos.
+De grote kracht van Liana is dat het een gestandaardiseerde manier introduceert om het terugkrijgen van fondsen te garanderen in het geval van verlies van de hoofdsleutel, die gebruikt wordt voor lopende uitgaven. Dit is een enorme innovatie voor het zelf beheren (self-custody) van fondsen, wat vol risico's zit, vooral als je niet goed geïnformeerd bent over het onderwerp. Liana kan daarom zelfs de meest risicomijdende gebruikers aanmoedigen om te stoppen met het gebruiken van een custodian (zoals een exchange-platform) om hun fondsen te bewaren en de controle (ownership) van hun geld terug te krijgen, in overeenstemming met Bitcoin's Cypherpunk ethos.
 
 
-Natuurlijk heeft Liana ook nadelen. Het eerste is dat je je wallet regelmatig moet bijwerken door een transactie uit te voeren op de Bitcoin Blockchain. Dit kan lastig zijn (afhankelijk van hoe vaak je de software gebruikt) en kostbaar (afhankelijk van de hoogte van de kosten op dat moment). Dit kan lastig zijn (afhankelijk van hoe vaak je de software gebruikt) en duur (afhankelijk van de hoogte van de kosten op dat moment), maar het is de prijs die je betaalt voor extra veiligheid.
+Natuurlijk heeft Liana ook nadelen. Het eerste is dat je je wallet regelmatig moet bijwerken door een transactie uit te voeren op de Bitcoin-blockchain. Dit kan lastig zijn (afhankelijk van hoe vaak je de software gebruikt) en duur (afhankelijk van de hoogte van de transactiekosten op dat moment), maar het is de prijs die je betaalt voor extra veiligheid.
 
 
-Een tweede negatief punt kan vertrouwelijkheid zijn. Als je iemand anders bij de configuratie betrekt, is hij of zij op de hoogte van al je adressen en kan hij of zij dus je activiteiten in de gaten houden. Dit is echter geen probleem als je kiest voor een versterkte back-up, of voor een opvolgingsplan waarbij je erfgenaam niet onmiddellijk op de hoogte is van de wallet gegevens.
+Een tweede negatief punt kan privacy zijn. Als je iemand anders bij de configuratie betrekt, is hij of zij op de hoogte van al je adressen en kan hij of zij dus je activiteiten in de gaten houden. Dit is echter geen probleem als je kiest voor een versterkte back-up, of voor een opvolgingsplan waarbij je erfgenaam niet onmiddellijk op de hoogte is van de walletgegevens.
 
 
 ## Voorbereiding
@@ -97,7 +97,7 @@ Als je wilt weten hoe je handmatig de authenticiteit en integriteit van software
 
 https://planb.academy/tutorials/computer-security/data/integrity-authenticity-21d0420a-be02-4663-94a3-8d487f23becc
 
-Installeer de software op uw machine en start het op. Kies de optie "*Maak een nieuwe Liana Wallet*" om uw wallet te configureren.
+Installeer de software op uw machine en start het op. Kies de optie "*Maak een nieuwe Liana wallet*" om uw wallet te configureren.
 
 
 ![Accueil Liana](assets/fr/03.webp)
@@ -148,7 +148,7 @@ Geef toestemming voor het delen van de uitgebreide openbare sleutel van het appa
 Stel vervolgens de terugbetalingsvertraging in, d.w.z. de tijd waarna het geld kan worden uitgegeven door de *erfgoedsleutel*. Deze vertraging wordt gedefinieerd in termen van blokken, waarbij elk blok wordt gescheiden door een gemiddelde van 10 minuten. Het kan variëren van 10 minuten (1 blok) tot ongeveer 15 maanden (65.535 blokken). Deze bovengrens is een beperking van het Bitcoin protocol, omdat de vergrendelingstijd gecodeerd is op 16 bits.
 
 
-Kies, behoudens speciale omstandigheden, voor de langste levertijd: 15 maanden of 65.535 blokken. Dit bespaart u kosten. We raden je echter aan om de updateprocedure (beschreven in het hoofdstuk "Updaten van Wallet") één keer per jaar uit te voeren, altijd op hetzelfde moment van het jaar, om deze praktijk te "ritualiseren" en te voorkomen dat je het vergeet.
+Kies, behoudens speciale omstandigheden, voor de langste levertijd: 15 maanden of 65.535 blokken. Dit bespaart u kosten. We raden je echter aan om de updateprocedure (beschreven in het hoofdstuk "Updaten van wallet") één keer per jaar uit te voeren, altijd op hetzelfde moment van het jaar, om deze praktijk te "ritualiseren" en te voorkomen dat je het vergeet.
 
 
 Hier hebben we een hersteltijd van een uur (6 blokken) ingesteld om onze tests uit te voeren.
@@ -201,7 +201,7 @@ Doe hetzelfde voor elk ondertekeningsapparaat. U moet controleren en bevestigen 
 ![Enregistrer descripteur Nano S Plus](assets/fr/14.webp)
 
 
-Je wallet informatie is nu geregistreerd en je hoeft alleen nog maar te configureren hoe je verbinding wilt maken met het Bitcoin netwerk. Je kunt ervoor kiezen om je eigen node te gebruiken (lokaal of op afstand) of om de infrastructuur van WizardSardine te gebruiken. In het laatste geval moet je een e-mail Address koppelen aan je Wallet, waarmee je de Descriptor kunt ophalen. WizardSardine heeft dan toegang tot al je transacties. De eerste optie wordt daarom aangeraden.
+Je wallet informatie is nu geregistreerd en je hoeft alleen nog maar te configureren hoe je verbinding wilt maken met het Bitcoin netwerk. Je kunt ervoor kiezen om je eigen node te gebruiken (lokaal of op afstand) of om de infrastructuur van WizardSardine te gebruiken. In het laatste geval moet je een e-mail Address koppelen aan je wallet, waarmee je de Descriptor kunt ophalen. WizardSardine heeft dan toegang tot al je transacties. De eerste optie wordt daarom aangeraden.
 
 
 ![Sélectionner connexion réseau](assets/fr/15.webp)
@@ -213,7 +213,7 @@ We hebben ervoor gekozen om ons eigen knooppunt te gebruiken. Je kunt een bestaa
 ![Choisir type de nœud](assets/fr/16.webp)
 
 
-Voor deze tutorial hebben we een bestaande (openbare) Electrum server gebruikt. Maar wees voorzichtig! Deze had toegang tot al onze activiteiten met de Liana Wallet. Gebruik dus je eigen node als je je privacy wilt beschermen.
+Voor deze tutorial hebben we een bestaande (openbare) Electrum server gebruikt. Maar wees voorzichtig! Deze had toegang tot al onze activiteiten met de Liana wallet. Gebruik dus je eigen node als je je privacy wilt beschermen.
 
 
 ![Connexion serveur Electrum public](assets/fr/17.webp)
@@ -277,7 +277,7 @@ Zodra het geld is overgemaakt, verschijnt de transactie op het hoofdscherm (eers
 ![Vérifier solde](assets/fr/23.webp)
 
 
-Je kunt de vervaldatum van je tegoeden controleren door naar het tabblad "*Munten*" te gaan. Dit tabblad toont je de verschillende munten (UTXO) in je Wallet. Hier kunnen we zien dat de 50.000 satoshis Coin, gecreëerd door onze transactie, op dezelfde dag verloopt (over een uur).
+Je kunt de vervaldatum van je tegoeden controleren door naar het tabblad "*Munten*" te gaan. Dit tabblad toont je de verschillende munten (UTXO) in je wallet. Hier kunnen we zien dat de 50.000 satoshis Coin, gecreëerd door onze transactie, op dezelfde dag verloopt (over een uur).
 
 
 ![Obtenir informations pièce](assets/fr/24.webp)
@@ -303,7 +303,7 @@ Liana biedt ook "Coin controle": je geeft aan welke Coin (UTXO) je wilt uitgeven
 ![Envoyer fonds clé principale](assets/fr/25.webp)
 
 
-Onderteken vervolgens de transactie met je handtekeningapparaat dat is gekoppeld aan de hoofdsleutel door op "*Teken*" te klikken. Je moet de transactie verifiëren en bevestigen op je Hardware Wallet. Hier hebben we de Nano S Plus gebruikt om de transactie te ondertekenen.
+Onderteken vervolgens de transactie met je handtekeningapparaat dat is gekoppeld aan de hoofdsleutel door op "*Teken*" te klikken. Je moet de transactie verifiëren en bevestigen op je hardware wallet. Hier hebben we de Nano S Plus gebruikt om de transactie te ondertekenen.
 
 
 ![Signer transaction clé principale](assets/fr/26.webp)
@@ -389,7 +389,7 @@ wsh(or_d(pk([3689a8e7/48'/0'/0'/2']xpub6FKYNH4XbbdADV98yTVxgZZrtB4eE2tiUPreEv5iJ
 ![Importer descripteur](assets/fr/36.webp)
 
 
-Liana vraagt u vervolgens een Mnemonic-zin in te voeren. Als je een werkend signatuurapparaat (Hardware Wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen aantal hoog is), raden we toch aan om een nieuwe Hardware wallet aan te schaffen en de Mnemonic te gebruiken om de sleutels erop te herstellen.
+Liana vraagt u vervolgens een Mnemonic-zin in te voeren. Als je een werkend signatuurapparaat (hardware wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen aantal hoog is), raden we toch aan om een nieuwe Hardware wallet aan te schaffen en de Mnemonic te gebruiken om de sleutels erop te herstellen.
 
 
 In ons geval gebruiken we de Blockstream Jade Hardware wallet als herstelapparaat en kiezen we ervoor om deze stap over te slaan ("*Skip*").
@@ -434,7 +434,7 @@ Geef de Coin uit in de wallet door het juiste vakje aan te vinken. Geef de BTC A
 ![Récupération des pièces](assets/fr/42.webp)
 
 
-Onderteken de transactie door op "*Teken*" te klikken en de transactie te valideren op je Hardware Wallet.
+Onderteken de transactie door op "*Teken*" te klikken en de transactie te valideren op je hardware wallet.
 
 
 ![Signer transaction clé de récupération](assets/fr/43.webp)

--- a/tutorials/wallet/liana/nl.md
+++ b/tutorials/wallet/liana/nl.md
@@ -8,22 +8,22 @@ description: Wallet instellen en gebruiken op Liana
 ![video](https://youtu.be/rTId6hfiRm0)
 
 
-In deze tutorial leggen we stap voor stap uit hoe je de Liana toepassing op een computer gebruikt. Je leert onder andere hoe je een geautomatiseerd opvolgingsplan instelt, bitcoins ontvangt en verstuurt in normale situaties, en geld ophaalt van een bestaande Wallet na een bepaalde periode.
+In deze tutorial leggen we stap voor stap uit hoe je de Liana toepassing op een computer gebruikt. Je leert onder andere hoe je een geautomatiseerd opvolgingsplan instelt, bitcoins ontvangt en verstuurt onder normale omstandigheden, en hoe je geld van een bestaande wallet ophaalt na een bepaalde periode.
 
 
-In januari 2025 waren de hardware wallets die compatibel waren met Liana: BitBox02, Blockstream Jade, Blockstream Jade Plus, COLDCARD MK4, COLDCARD Q, Ledger Nano S, Ledger Nano S Plus, Ledger Nano X, Ledger Flex, Specter DIY.
+In januari 2025 waren de volgende hardware wallets compatibel met Liana: BitBox02, Blockstream Jade, Blockstream Jade Plus, COLDCARD MK4, COLDCARD Q, Ledger Nano S, Ledger Nano S Plus, Ledger Nano X, Ledger Flex, Specter DIY.
 
 
-Als je geld wilt terugkrijgen van een bestaande Liana Wallet, lees dan de onderstaande presentatie en ga direct naar het gedeelte "Bitcoins terugkrijgen".
+Als je geld wilt terugkrijgen van een bestaande Liana-wallet, lees dan de onderstaande presentatie en ga direct naar het gedeelte "Bitcoins terugkrijgen".
 
 
 ## Introductie van Liana software
 
 
-Liana is een open-source softwarepakket ontworpen voor het maken en beheren van geavanceerde wallets, met name als onderdeel van een geautomatiseerd overervingssysteem of een robuust back-upmechanisme. Het project wordt sinds 2022 ontwikkeld door Wizardsardine, een bedrijf dat mede is opgericht door Kévin Loaec en Antoine Poinsot. Op de officiële website wordt Liana gepresenteerd als "een eenvoudige Wallet voor persoonlijke curatie, met herstel- en overervingsfunctionaliteiten". De software draait op computers -- Linux, MacOS, Windows -- en de (open) broncode is beschikbaar [op GitHub](https://github.com/wizardsardine/Liana).
+Liana is een open-source softwarepakket ontworpen voor het maken en beheren van geavanceerde wallets, met name als onderdeel van een geautomatiseerd overervingssysteem of een robuust back-upmechanisme. Het project wordt sinds 2022 ontwikkeld door Wizardsardine, een bedrijf dat mede is opgericht door Kévin Loaec en Antoine Poinsot. Op de officiële website wordt Liana gepresenteerd als "een eenvoudige wallet voor persoonlijke curatie, met herstel- en overervingsfunctionaliteiten". De software draait op computers -- Linux, MacOS, Windows -- en de (open) broncode is beschikbaar [op GitHub](https://github.com/wizardsardine/Liana).
 
 
-Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde Wallet te maken. In het bijzonder maakt het gebruik van tijdsloten (*timelocks*), die het mogelijk maken om geld pas uit te geven als een bepaalde tijd verstreken is, en die betrokken zijn bij het terughalen van Bitcoins. Een Liana Wallet bestaat dus uit meerdere uitgavenpaden:
+Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde wallet te maken. In het bijzonder maakt het gebruik van tijdsloten (*timelocks*), die het mogelijk maken om geld pas uit te geven als een bepaalde tijd verstreken is, en die betrokken zijn bij het terughalen van Bitcoins. Een Liana wallet bestaat dus uit meerdere uitgavenpaden:
 
 
 
@@ -32,7 +32,7 @@ Liana bouwt voort op de programmeerbaarheid van Bitcoin om een geavanceerde Wall
 - Ten minste één herstelpad, dat na een bepaalde tijd toegankelijk wordt.
 
 
-Het onderstaande diagram illustreert de werking van een Wallet met twee uitgavenpaden:
+Het onderstaande diagram illustreert de werking van een wallet met twee uitgavenpaden:
 
 
 ![Schéma explicatif](assets/fr/01.webp)
@@ -44,7 +44,7 @@ Met deze handeling kunt u verschillende configuraties instellen, waaronder :
 
 
 - Een successieplan, dat de erfgenamen in staat stelt om geld terug te krijgen als de gebruiker overlijdt. Voor meer informatie over dit onderwerp raden we aan [deel 4](https://planb.academy/courses/f3e3843d-1a1d-450c-96d6-d7232158b81f/233c88d3-2e8e-5eba-ac06-efe67a209038) van de BTC102-cursus te lezen.
-- Een versterkte back-up met een hersteltijd, zodat de gebruiker zijn Wallet kan gebruiken zonder de bijbehorende geheime zin te hoeven bewaren en het risico te lopen dat deze wordt gestolen, bijvoorbeeld tijdens een inbraak.
+- Een versterkte back-up met een hersteltijd, zodat de gebruiker zijn wallet kan gebruiken zonder de bijbehorende geheime zin te hoeven bewaren en het risico te lopen dat deze wordt gestolen, bijvoorbeeld tijdens een inbraak.
 - Een vangnet voor mensen die beginnen met Bitcoin: ze beheren hun eigen Wallet, en hun "voogd" (een familielid, bijvoorbeeld) behoudt zich het recht voor om hun fondsen na een bepaalde periode terug te vorderen.
 - Een meerpartijen handtekeningschema (*Multisig*) met verminderde eisen in de tijd, om het verdwijnen van een of meer van de deelnemers op te vangen, zoals de partners van een bedrijf.
 
@@ -52,10 +52,10 @@ Met deze handeling kunt u verschillende configuraties instellen, waaronder :
 De grote kracht van Liana is dat het een gestandaardiseerde manier introduceert om het terugkrijgen van fondsen te garanderen in het geval van verlies van de hoofdsleutel, die gebruikt wordt voor lopende uitgaven. Dit is een enorme innovatie voor het schoon bewaren van fondsen, wat vol risico's zit, vooral als je niet goed geïnformeerd bent over het onderwerp. Liana zou daarom zelfs de meest risicomijdende gebruikers kunnen aanmoedigen om te stoppen met het gebruiken van een custodian (zoals een Exchange platform) om hun fondsen te bewaren en Ownership van hun geld terug te krijgen, in overeenstemming met Bitcoin's Cypherpunk ethos.
 
 
-Natuurlijk heeft Liana ook nadelen. Het eerste is dat je je Wallet regelmatig moet bijwerken door een transactie uit te voeren op de Bitcoin Blockchain. Dit kan lastig zijn (afhankelijk van hoe vaak je de software gebruikt) en kostbaar (afhankelijk van de hoogte van de kosten op dat moment). Dit kan lastig zijn (afhankelijk van hoe vaak je de software gebruikt) en duur (afhankelijk van de hoogte van de kosten op dat moment), maar het is de prijs die je betaalt voor extra veiligheid.
+Natuurlijk heeft Liana ook nadelen. Het eerste is dat je je wallet regelmatig moet bijwerken door een transactie uit te voeren op de Bitcoin Blockchain. Dit kan lastig zijn (afhankelijk van hoe vaak je de software gebruikt) en kostbaar (afhankelijk van de hoogte van de kosten op dat moment). Dit kan lastig zijn (afhankelijk van hoe vaak je de software gebruikt) en duur (afhankelijk van de hoogte van de kosten op dat moment), maar het is de prijs die je betaalt voor extra veiligheid.
 
 
-Een tweede negatief punt kan vertrouwelijkheid zijn. Als je iemand anders bij de configuratie betrekt, is hij of zij op de hoogte van al je adressen en kan hij of zij dus je activiteiten in de gaten houden. Dit is echter geen probleem als je kiest voor een versterkte back-up, of voor een opvolgingsplan waarbij je erfgenaam niet onmiddellijk op de hoogte is van de Wallet gegevens.
+Een tweede negatief punt kan vertrouwelijkheid zijn. Als je iemand anders bij de configuratie betrekt, is hij of zij op de hoogte van al je adressen en kan hij of zij dus je activiteiten in de gaten houden. Dit is echter geen probleem als je kiest voor een versterkte back-up, of voor een opvolgingsplan waarbij je erfgenaam niet onmiddellijk op de hoogte is van de wallet gegevens.
 
 
 ## Voorbereiding
@@ -78,7 +78,7 @@ https://planb.academy/tutorials/wallet/hardware/ledger-nano-s-plus-75043cb3-2e8e
 https://planb.academy/tutorials/wallet/hardware/jade-7d62bf0c-f460-4e68-9635-af9b731dabc3
 
 
-- Twee opslagmedia (USB-sticks) om de Wallet Descriptor op te slaan;
+- Twee opslagmedia (USB-sticks) om de wallet Descriptor op te slaan;
 - Een opvolgingsbrief met instructies voor het terugvorderen van de fondsen;
 - Een genummerde verzegelde zak om er zeker van te zijn dat het terugwinningsapparaat (de Jade) niet is gebruikt.
 
@@ -97,13 +97,13 @@ Als je wilt weten hoe je handmatig de authenticiteit en integriteit van software
 
 https://planb.academy/tutorials/computer-security/data/integrity-authenticity-21d0420a-be02-4663-94a3-8d487f23becc
 
-Installeer de software op uw machine en start het op. Kies de optie "*Maak een nieuwe Liana Wallet*" om uw Wallet te configureren.
+Installeer de software op uw machine en start het op. Kies de optie "*Maak een nieuwe Liana Wallet*" om uw wallet te configureren.
 
 
 ![Accueil Liana](assets/fr/03.webp)
 
 
-Kies je Wallet type. Als je een verbeterde back-up met hersteltijd wilt instellen, kun je de optie "*Bouw je eigen*" selecteren en kiezen voor het standaardschema. Dit werkt op vrijwel dezelfde manier, behalve dat je de Hardware Wallet herstelzin niet hoeft te behouden.
+Kies je wallet type. Als je een verbeterde back-up met hersteltijd wilt instellen, kun je de optie "*Bouw je eigen*" selecteren en kiezen voor het standaardschema. Dit werkt op vrijwel dezelfde manier, behalve dat je de Hardware wallet herstelzin niet hoeft te behouden.
 
 
 We negeren hier het geval van de *Uitbreiding Multisig*, die een complexere configuratie opzet.
@@ -121,7 +121,7 @@ Hieronder volgt een korte uitleg.
 ![Rapide explication](assets/fr/05.webp)
 
 
-Als je de uitleg hebt gelezen, kun je de sleutels voor je Liana Wallet instellen. Dit is een cruciale stap, omdat het de bestedingskenmerken van je account bepaalt.
+Als je de uitleg hebt gelezen, kun je de sleutels voor je Liana wallet instellen. Dit is een cruciale stap, omdat het de bestedingskenmerken van je account bepaalt.
 
 
 ![Configurer clés](assets/fr/06.webp)
@@ -136,7 +136,7 @@ Deze keuze is optioneel: laat in geval van twijfel de standaardoptie staan (P2WS
 ![Choisir le type de descripteur](assets/fr/07.webp)
 
 
-Configureer vervolgens je primaire sleutel (*primary key*). Deze sleutel (of liever, deze set sleutels) zal worden gebruikt voor de huidige uitgave van fondsen, die niet onderhevig is aan enige tijdsvoorwaarden. Door op "*Set*" te klikken, kun je het bijbehorende *signing device* selecteren. In ons geval hebben we de Ledger Nano S Plus Hardware Wallet gekozen.
+Configureer vervolgens je primaire sleutel (*primary key*). Deze sleutel (of liever, deze set sleutels) zal worden gebruikt voor de huidige uitgave van fondsen, die niet onderhevig is aan enige tijdsvoorwaarden. Door op "*Set*" te klikken, kun je het bijbehorende *signing device* selecteren. In ons geval hebben we de Ledger Nano S Plus Hardware wallet gekozen.
 
 
 Geef toestemming voor het delen van de uitgebreide openbare sleutel van het apparaat. Geef deze sleutel een betekenisvolle naam (in dit geval "Nano S+"). Merk op dat alle toepassingen die op het apparaat geïnstalleerd zijn normaal blijven werken.
@@ -172,7 +172,7 @@ Zodra al deze acties zijn voltooid, controleer je of alles in orde is en klik je
 ![Confirmer clés](assets/fr/11.webp)
 
 
-De volgende stap is het opslaan van je Wallet Descriptor. Dit is de informatie die je nodig hebt om het geld op je rekening te vinden. In tegenstelling tot de Mnemonic zin, kun je met de Descriptor geen geld uitgeven, dus het vrijgeven ervan zal alleen een vertrouwelijkheidsprobleem opleveren (de persoon zal al je transacties kennen).
+De volgende stap is het opslaan van je wallet Descriptor. Dit is de informatie die je nodig hebt om het geld op je rekening te vinden. In tegenstelling tot de Mnemonic zin, kun je met de Descriptor geen geld uitgeven, dus het vrijgeven ervan zal alleen een vertrouwelijkheidsprobleem opleveren (de persoon zal al je transacties kennen).
 
 
 Bewaar twee kopieën van de Descriptor op elektronische media, zoals USB-sticks. Zorg ervoor dat je ook twee kopieën op papier afdrukt, zodat je er bij kunt in het geval van schade aan de elektronische media. Elke back-up moet gekoppeld zijn aan een handtekeningapparaat.
@@ -189,19 +189,19 @@ wsh(or_d(pk([3689a8e7/48'/0'/0'/2']xpub6FKYNH4XbbdADV98yTVxgZZrtB4eE2tiUPreEv5iJ
 ```
 
 
-De laatste stap in de initiële Wallet configuratie is het verifiëren van de Descriptor in elk van de hardware wallets die dienen als handtekeningapparaten.
+De laatste stap in de initiële wallet configuratie is het verifiëren van de Descriptor in elk van de hardware wallets die dienen als handtekeningapparaten.
 
 
 ![Enregistrer descripteur](assets/fr/13.webp)
 
 
-Doe hetzelfde voor elk ondertekeningsapparaat. U moet controleren en bevestigen dat de Descriptor aan elke Hardware Wallet is toegevoegd.
+Doe hetzelfde voor elk ondertekeningsapparaat. U moet controleren en bevestigen dat de Descriptor aan elke Hardware wallet is toegevoegd.
 
 
 ![Enregistrer descripteur Nano S Plus](assets/fr/14.webp)
 
 
-Je Wallet informatie is nu geregistreerd en je hoeft alleen nog maar te configureren hoe je verbinding wilt maken met het Bitcoin netwerk. Je kunt ervoor kiezen om je eigen node te gebruiken (lokaal of op afstand) of om de infrastructuur van WizardSardine te gebruiken. In het laatste geval moet je een e-mail Address koppelen aan je Wallet, waarmee je de Descriptor kunt ophalen. WizardSardine heeft dan toegang tot al je transacties. De eerste optie wordt daarom aangeraden.
+Je wallet informatie is nu geregistreerd en je hoeft alleen nog maar te configureren hoe je verbinding wilt maken met het Bitcoin netwerk. Je kunt ervoor kiezen om je eigen node te gebruiken (lokaal of op afstand) of om de infrastructuur van WizardSardine te gebruiken. In het laatste geval moet je een e-mail Address koppelen aan je Wallet, waarmee je de Descriptor kunt ophalen. WizardSardine heeft dan toegang tot al je transacties. De eerste optie wordt daarom aangeraden.
 
 
 ![Sélectionner connexion réseau](assets/fr/15.webp)
@@ -219,7 +219,7 @@ Voor deze tutorial hebben we een bestaande (openbare) Electrum server gebruikt. 
 ![Connexion serveur Electrum public](assets/fr/17.webp)
 
 
-Zodra de knooppuntconfiguratie voltooid is, opent het hoofdscherm, waarop je pas aangemaakte Liana Wallet te zien is.
+Zodra de knooppuntconfiguratie voltooid is, opent het hoofdscherm, waarop je pas aangemaakte Liana wallet te zien is.
 
 
 Maak van de gelegenheid gebruik om de bergingseenheid op een veilige plaats op te bergen. Bewaar het op een strategische plek, zodat je erfgenamen het kunnen vinden als je overlijdt.
@@ -236,7 +236,7 @@ In ons voorbeeld hebben we de volgende Elements samengesteld:
 - Blockstream Jade als handtekeningapparaat voor het landgoed;
 - Een USB-kabel om het apparaat aan te sluiten en op te laden;
 - Een papieren back-up van de zin in geval van storing of schade aan het apparaat (merk op dat het medium ook van metaal kan zijn, en dus beschermd tegen de Elements, zoals bijvoorbeeld het geval is met Cryptosteel capsules);
-- De USB-stick met de Wallet Descriptor ;
+- De USB-stick met de wallet Descriptor ;
 - Een papieren back-up van de Descriptor, in geval van storing of schade aan de USB-stick (deze back-up is hier niet gefotografeerd);
 - Een opvolgingsbrief waarin de stappen worden beschreven die moeten worden genomen om de fondsen terug te vorderen.
 
@@ -253,7 +253,7 @@ En we plaatsen deze items onder Seal!
 ## Ontvangst van fondsen
 
 
-Het hoofdscherm van Liana toont uw saldo en de transacties (verleden en huidig) die aan uw Wallet zijn gekoppeld. In ons geval is het saldo nul, wat normaal is.
+Het hoofdscherm van Liana toont uw saldo en de transacties (verleden en huidig) die aan uw wallet zijn gekoppeld. In ons geval is het saldo nul, wat normaal is.
 
 
 ![Écran principal](assets/fr/20.webp)
@@ -265,7 +265,7 @@ Om geld te ontvangen, ga je naar het tabblad "*Ontvangen*" en klik je op "*gener
 ![Générer nouvelle adresse](assets/fr/21.webp)
 
 
-Je moet deze Address verifiëren op je Hardware Wallet door te klikken op "*Verify on hardware device*".
+Je moet deze Address verifiëren op je Hardware wallet door te klikken op "*Verify on hardware device*".
 
 
 ![Vérifier adresse portefeuille matériel](assets/fr/22.webp)
@@ -324,7 +324,7 @@ De transactie verschijnt op het hoofdscherm en je saldo wordt bijgewerkt.
 ## Portefeuille-update
 
 
-Zoals hierboven uitgelegd, vereist de Liana Wallet dat u uw fondsen regelmatig bijwerkt door een transactie uit te voeren op de Blockchain. Als u dit niet doet, kan uw erfgenaam (of uw tweede apparaat in het geval van een uitgebreide back-up) uw fondsen terugvorderen. Als je dit niet doet, kan je geld worden teruggehaald door je erfgenaam (of door je tweede apparaat in het geval van een uitgebreide back-up). Deze situatie is niet extreem gevaarlijk, maar gaat wel in tegen het doel van dit mechanisme: controle houden over je bitcoins zonder een beroep te doen op een vertrouwde derde partij, terwijl je profiteert van een vangnet.
+Zoals hierboven uitgelegd, vereist de Liana wallet dat u uw fondsen regelmatig bijwerkt door een transactie uit te voeren op de Blockchain. Als u dit niet doet, kan uw erfgenaam (of uw tweede apparaat in het geval van een uitgebreide back-up) uw fondsen terugvorderen. Als je dit niet doet, kan je geld worden teruggehaald door je erfgenaam (of door je tweede apparaat in het geval van een uitgebreide back-up). Deze situatie is niet extreem gevaarlijk, maar gaat wel in tegen het doel van dit mechanisme: controle houden over je bitcoins zonder een beroep te doen op een vertrouwde derde partij, terwijl je profiteert van een vangnet.
 
 
 Er wordt een waarschuwing weergegeven voordat je geld (of een deel ervan) vervalt en kan worden uitgegeven door de herstelsleutel. Het zal aangeven dat je "herstelpad" (*herstelpad*) binnenkort beschikbaar zal zijn. Gezien de korte hersteltijd (een uur), wordt dit bericht in ons geval direct weergegeven.
@@ -339,7 +339,7 @@ Wanneer de deadline nadert, verschijnt er een knop die je vraagt om de betreffen
 ![Actualiser pièces depuis l'écran principal](assets/fr/30.webp)
 
 
-Om je munten bij te werken, ga je naar het tabblad "*Munten*" en klik je op "*Vernieuw Coin*" in het overeenkomstige Coin vakje. Als je meerdere munten hebt, moet je ze om redenen van vertrouwelijkheid één voor één en met relatief korte tussenpozen verversen. Om de kosten laag te houden, kun je je fondsen consolideren door de hele Wallet naar een nieuwe ontvangende Address te sturen, maar dit tast je vertrouwelijkheid aan.
+Om je munten bij te werken, ga je naar het tabblad "*Munten*" en klik je op "*Vernieuw Coin*" in het overeenkomstige Coin vakje. Als je meerdere munten hebt, moet je ze om redenen van vertrouwelijkheid één voor één en met relatief korte tussenpozen verversen. Om de kosten laag te houden, kun je je fondsen consolideren door de hele wallet naar een nieuwe ontvangende Address te sturen, maar dit tast je vertrouwelijkheid aan.
 
 
 ![Actualiser pièce](assets/fr/31.webp)
@@ -366,19 +366,19 @@ Eenmaal bevestigd, is uw Coin veilig! U kunt gerust zijn tot de volgende vervald
 Wanneer je geld terughaalt van de Liana Wallet, kun je te maken krijgen met één van twee situaties. Misschien heb je toegang tot de computer waarop de software geïnstalleerd is, in dat geval hoef je hem alleen maar te openen (wat zal gebeuren in het geval van het uitgebreide back-up model). Het is echter mogelijk dat je geen toegang hebt tot deze computer, dus beginnen we hier vanaf nul. Merk op dat de herstelprocedure in beide gevallen hetzelfde is.
 
 
-Om te beginnen, download Liana van [de officiële Wizardsardine website](https://wizardsardine.com/Liana/), of van [de GitHub repository](https://github.com/wizardsardine/Liana/releases), waar je de authenticiteit van de software kunt controleren. Installeer de software en voer het uit. De versie die wij gebruiken is 0.9, dus de afbeeldingen kunnen veranderd zijn. Selecteer op het welkomstscherm de optie "Een bestaande Liana Wallet toevoegen".
+Om te beginnen, download Liana van [de officiële Wizardsardine website](https://wizardsardine.com/Liana/), of van [de GitHub repository](https://github.com/wizardsardine/Liana/releases), waar je de authenticiteit van de software kunt controleren. Installeer de software en voer het uit. De versie die wij gebruiken is 0.9, dus de afbeeldingen kunnen veranderd zijn. Selecteer op het welkomstscherm de optie "Een bestaande Liana wallet toevoegen".
 
 
 ![Ajouter portefeuille existant](assets/fr/34.webp)
 
 
-Configureer hoe je verbinding wilt maken met het netwerk. Je kunt je eigen node gebruiken (lokaal of op afstand) of de infrastructuur van WizardSardine. In het laatste geval heb je de e-mail Address nodig die de Wallet maker gebruikt, zodat fondsen automatisch gelokaliseerd kunnen worden. Als je deze informatie niet hebt, kies dan de eerste optie.
+Configureer hoe je verbinding wilt maken met het netwerk. Je kunt je eigen node gebruiken (lokaal of op afstand) of de infrastructuur van WizardSardine. In het laatste geval heb je de e-mail Address nodig die de wallet maker gebruikt, zodat fondsen automatisch gelokaliseerd kunnen worden. Als je deze informatie niet hebt, kies dan de eerste optie.
 
 
 ![Sélectionner connexion réseau](assets/fr/35.webp)
 
 
-Als je je eigen knooppunt gebruikt, importeer dan de Wallet Descriptor. Dit is een technische beschrijving van de rekening, waarmee je de fondsen op de rekening kunt ophalen. In ons geval is het de volgende informatie:
+Als je je eigen knooppunt gebruikt, importeer dan de wallet Descriptor. Dit is een technische beschrijving van de rekening, waarmee je de fondsen op de rekening kunt ophalen. In ons geval is het de volgende informatie:
 
 
 ```plaintext
@@ -389,16 +389,16 @@ wsh(or_d(pk([3689a8e7/48'/0'/0'/2']xpub6FKYNH4XbbdADV98yTVxgZZrtB4eE2tiUPreEv5iJ
 ![Importer descripteur](assets/fr/36.webp)
 
 
-Liana vraagt u vervolgens een Mnemonic-zin in te voeren. Als je een werkend signatuurapparaat (Hardware Wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen aantal hoog is), raden we toch aan om een nieuwe Hardware Wallet aan te schaffen en de Mnemonic te gebruiken om de sleutels erop te herstellen.
+Liana vraagt u vervolgens een Mnemonic-zin in te voeren. Als je een werkend signatuurapparaat (Hardware Wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen aantal hoog is), raden we toch aan om een nieuwe Hardware wallet aan te schaffen en de Mnemonic te gebruiken om de sleutels erop te herstellen.
 
 
-In ons geval gebruiken we de Blockstream Jade Hardware Wallet als herstelapparaat en kiezen we ervoor om deze stap over te slaan ("*Skip*").
+In ons geval gebruiken we de Blockstream Jade Hardware wallet als herstelapparaat en kiezen we ervoor om deze stap over te slaan ("*Skip*").
 
 
 ![Passer phrase mnémotechnique](assets/fr/37.webp)
 
 
-Controleer en sla de Descriptor op in je handtekeningapparaat door het te selecteren op het scherm. Als uw Hardware Wallet niet verschijnt, controleer dan of deze is aangesloten en ontgrendeld. Controleer en bevestig dat deze informatie is toegevoegd aan uw apparaat.
+Controleer en sla de Descriptor op in je handtekeningapparaat door het te selecteren op het scherm. Als uw Hardware wallet niet verschijnt, controleer dan of deze is aangesloten en ontgrendeld. Controleer en bevestig dat deze informatie is toegevoegd aan uw apparaat.
 
 
 ![Enregistrer descripteur sur l'appareil de récupération](assets/fr/38.webp)
@@ -422,13 +422,13 @@ Zodra je het knooppunt hebt ingesteld, kom je op het hoofdscherm van de Wallet, 
 ![Accueil Liana récupération](assets/fr/40.webp)
 
 
-Om het geld in de Wallet terug te krijgen, ga naar Instellingen ("*Instellingen*") linksonder en klik op "*Terughalen*".
+Om het geld in de wallet terug te krijgen, ga naar Instellingen ("*Instellingen*") linksonder en klik op "*Terughalen*".
 
 
 ![Récupération dans paramètres](assets/fr/41.webp)
 
 
-Geef de Coin uit in de Wallet door het juiste vakje aan te vinken. Geef de BTC Address aan waarnaar je het geld wilt sturen, evenals de transactiekosten. Klik dan op "*Volgende*".
+Geef de Coin uit in de wallet door het juiste vakje aan te vinken. Geef de BTC Address aan waarnaar je het geld wilt sturen, evenals de transactiekosten. Klik dan op "*Volgende*".
 
 
 ![Récupération des pièces](assets/fr/42.webp)
@@ -474,20 +474,20 @@ De volgende informatie kan uit deze Descriptor worden gehaald:
 - `wsh` (afkorting van *witness script Hash*): Dit is het type transactionele uitvoer dat wordt gemaakt. Als we Taproot hadden gebruikt, zou de identifier `tr` zijn geweest.
 - `or_d`: Dit is een logische operator die aangeeft dat aan *één van de volgende twee* voorwaarden moet worden voldaan om de uitgave te accepteren (de `_d` geeft een bepaalde syntaxis aan).
 - `pk` (afkorting voor *publieke sleutel*): Deze operator controleert een gegeven handtekening tegen de volgende openbare sleutel en geeft het antwoord als een Booleaanse (TRUE of FALSE).
-- `[3689a8e7/48'/0'/0'/2']`: Dit element bevat de *vingerafdruk* van de hoofdsleutel voor de belangrijkste Hardware Wallet (in dit geval de Nano S Plus), en het afleidingspad naar de gekoppelde uitgebreide privésleutel (waarvan alle andere privésleutels zijn afgeleid).
-- `xpub6FKY ... WQa`: Dit is de uitgebreide publieke sleutel die gekoppeld is aan de hoofd-Hardware Wallet (hier de Nano S Plus)
-- `/<0;1>/*`: Dit zijn de afleidingspaden voor het verkrijgen van eenvoudige sleutels en adressen: `0` voor ontvangst, `1` voor interne operaties (*wijziging*), met een "wildcard" (`*`) die sequentiële afleiding van meerdere adressen op een configureerbare manier toestaat, vergelijkbaar met het "gap limit" beheer van klassieke Wallet software.
+- `[3689a8e7/48'/0'/0'/2']`: Dit element bevat de *vingerafdruk* van de hoofdsleutel voor de belangrijkste Hardware wallet (in dit geval de Nano S Plus), en het afleidingspad naar de gekoppelde uitgebreide privésleutel (waarvan alle andere privésleutels zijn afgeleid).
+- `xpub6FKY ... WQa`: Dit is de uitgebreide publieke sleutel die gekoppeld is aan de hoofd-Hardware wallet (hier de Nano S Plus)
+- `/<0;1>/*`: Dit zijn de afleidingspaden voor het verkrijgen van eenvoudige sleutels en adressen: `0` voor ontvangst, `1` voor interne operaties (*wijziging*), met een "wildcard" (`*`) die sequentiële afleiding van meerdere adressen op een configureerbare manier toestaat, vergelijkbaar met het "gap limit" beheer van klassieke wallet software.
 - en_v`: Dit is een logische operator die aangeeft dat *aan de volgende twee* voorwaarden moet worden voldaan om de uitgave te accepteren (de `_v` geeft een bepaalde syntaxis aan).
 - `v:pkh` (afkorting van *verifieer: openbare sleutel Hash*): Deze operator verifieert een gegeven handtekening en publieke sleutel tegen de publieke sleutel Hash (*Hash*) die volgt. Dit is in wezen dezelfde controle als voor P2PKH en P2WPKH scripts.
-- `[42e629dd/48'/0'/0'/2']`: Dit is hetzelfde element als hierboven (bestaande uit het spoor en het afleidingspad), behalve dat het spoor van de hoofdsleutel van de hardwareherstel Wallet (in dit geval de Jade) wordt aangegeven.
-- `xpub6DpQ ... WQd`: Dit is de uitgebreide publieke sleutel gekoppeld aan de hardware recovery Wallet (hier de Jade).
+- `[42e629dd/48'/0'/0'/2']`: Dit is hetzelfde element als hierboven (bestaande uit het spoor en het afleidingspad), behalve dat het spoor van de hoofdsleutel van de hardwareherstel wallet (in dit geval de Jade) wordt aangegeven.
+- `xpub6DpQ ... WQd`: Dit is de uitgebreide publieke sleutel gekoppeld aan de hardware recovery wallet (hier de Jade).
 - `older(6)` : Deze operator controleert of de aangemaakte transactionele uitvoer een leeftijd moet hebben die strikt groter is dan 6 blokken om uitgegeven te kunnen worden.
 
 
-Het laatste data-item (`8alrve5h`) is de Descriptor controlesom en komt overeen met de Wallet identificatie.
+Het laatste data-item (`8alrve5h`) is de Descriptor controlesom en komt overeen met de wallet identificatie.
 
 
-De scripts die door deze Wallet worden aangemaakt, hebben de volgende vorm:
+De scripts die door deze wallet worden aangemaakt, hebben de volgende vorm:
 
 
 ```plaintext
@@ -495,7 +495,7 @@ De scripts die door deze Wallet worden aangemaakt, hebben de volgende vorm:
 ```
 
 
-Omdat de veiligheid van je Bitcoin Wallet ook afhangt van je begrip van hoe het werkt, stel ik voor dat je de mechanismen van deterministische en hiërarchische wallets grondig bestudeert door deze gratis training over Plan ₿ Academy te volgen:
+Omdat de veiligheid van je Bitcoin wallet ook afhangt van je begrip van hoe het werkt, stel ik voor dat je de mechanismen van deterministische en hiërarchische wallets grondig bestudeert door deze gratis training over Plan ₿ Academy te volgen:
 
 
 https://planb.academy/courses/46b0ced2-9028-4a61-8fbc-3b005ee8d70f

--- a/tutorials/wallet/liana/nl.md
+++ b/tutorials/wallet/liana/nl.md
@@ -228,7 +228,7 @@ Maak van de gelegenheid gebruik om de herstel apparaten op een veilige plaats op
 Voor extra veiligheid kun je de onderdelen die je gebruikt voor herstel in een verzegelde zak doen (*tamper-evident bag*) en het serienummer ergens opschrijven. Dit zorgt ervoor dat niemand erbij kan en dat je apparaat geldig blijft.
 
 
-In ons voorbeeld hebben we de volgende elementen samengesteld:
+In ons voorbeeld hebben we de volgende onderdelen samengesteld:
 
 
 
@@ -259,31 +259,31 @@ Het hoofdscherm van Liana toont je saldo en de transacties (verleden en huidig) 
 ![Écran principal](assets/fr/20.webp)
 
 
-Om geld te ontvangen, ga je naar het tabblad "*Ontvangen*" en klik je op "*generate Address*". Een nieuwe Address zou op je scherm moeten verschijnen. Het is langer dan in conventionele portemonnees: het is een Address gekoppeld aan een zelfstandige Contract (P2WSH of Taproot).
+Om geld te ontvangen, ga je naar het tabblad "*Receive*" en klik je op "*Generate address*". Een nieuw adres zou op je scherm moeten verschijnen. Het is langer dan in conventionele wallets: het is een adres gekoppeld aan een stand-alone contract (P2WSH of Taproot).
 
 
 ![Générer nouvelle adresse](assets/fr/21.webp)
 
 
-Je moet deze Address verifiëren op je hardware wallet door te klikken op "*Verify on hardware device*".
+Je moet dit adres verifiëren op je hardware wallet door te klikken op "*Verify on hardware device*".
 
 
 ![Vérifier adresse portefeuille matériel](assets/fr/22.webp)
 
 
-Zodra het geld is overgemaakt, verschijnt de transactie op het hoofdscherm (eerst als onbevestigd, dan als bevestigd). Hier hebben we voor deze test 50.000 satoshis (iets meer dan $50 op het moment van de overdracht) overgemaakt. Het spreekt voor zich dat het overgemaakte bedrag in jouw geval een orde van grootte hoger zal moeten zijn dan deze waarde, vanwege de transactiekosten.
+Zodra het geld is ontvangen, verschijnt de transactie op het hoofdscherm (eerst als onbevestigd, dan als bevestigd). Hier hebben we voor deze test 50.000 satoshis (iets meer dan $50 op het moment van de ontvangst) overgemaakt. Het spreekt voor zich dat het overgemaakte bedrag in jouw geval een orde van grootte hoger zal moeten zijn dan deze waarde, vanwege de transactiekosten.
 
 
 ![Vérifier solde](assets/fr/23.webp)
 
 
-Je kunt de vervaldatum van je tegoeden controleren door naar het tabblad "*Munten*" te gaan. Dit tabblad toont je de verschillende munten (UTXO) in je wallet. Hier kunnen we zien dat de 50.000 satoshis Coin, gecreëerd door onze transactie, op dezelfde dag verloopt (over een uur).
+Je kunt de vervaldatum van je tegoeden controleren door naar het tabblad "*Coins*" te gaan. Dit tabblad toont je de verschillende munten (UTXO) in je wallet. Hier kunnen we zien dat de 50.000 satoshis UTXO, gecreëerd door onze transactie, op dezelfde dag verloopt (over een uur).
 
 
 ![Obtenir informations pièce](assets/fr/24.webp)
 
 
-Om het UTXO representatiemodel dat in Bitcoin gebruikt wordt beter te begrijpen, kun je het eerste deel van de cursus over vertrouwelijkheid in Bitcoin, geschreven door Loïc Morel, raadplegen:
+Om het UTXO-representatiemodel dat in Bitcoin gebruikt wordt beter te begrijpen, kun je het eerste deel van de cursus over privacy in Bitcoin, geschreven door Loïc Morel, raadplegen:
 
 
 https://planb.academy/courses/65c138b0-4161-4958-bbe3-c12916bc959c
@@ -291,25 +291,25 @@ https://planb.academy/courses/65c138b0-4161-4958-bbe3-c12916bc959c
 ## Lopende uitgaven
 
 
-Huidige uitgaven is de normale situatie voor het gebruik van Liana. Bitcoins versturen met de hoofdsleutel werkt zoals in alle klassieke Bitcoin wallets zoals Electrum of Sparrow.
+Lopende uitgaven is de normale situatie voor het gebruik van Liana. Bitcoins versturen met de hoofdsleutel werkt zoals in alle klassieke Bitcoin-wallets zoals Electrum of Sparrow.
 
 
-Ga naar de tab "*Versturen*" en voer de essentiële informatie in: de BTC Address van de ontvanger, het te versturen bedrag en het gewenste tarief. Een beschrijving (lokaal opgeslagen) kan ook worden toegevoegd voor je persoonlijk gemak. In ons voorbeeld stuurden we 10.000 satoshis naar een bepaalde Bob, voor een laadtarief van 4 sat/ov, of $0,67 op het moment van de transactie.
+Ga naar de tab "*Send*" en voer de essentiële informatie in: het BTC-adres van de ontvanger, het te versturen bedrag en het gewenste tarief. Een beschrijving (lokaal opgeslagen) kan ook worden toegevoegd voor je persoonlijk gemak. In ons voorbeeld stuurden we 10.000 satoshis naar een bepaalde Bob, voor een kost van 4 sat/vB, of $0,67 op het moment van de transactie.
 
 
-Liana biedt ook "Coin controle": je geeft aan welke Coin (UTXO) je wilt uitgeven. Hier hebben we gekozen voor de 50.000 satoshis die Coin eerder creëerde.
+Liana biedt ook "Coin controle": je geeft aan welke coin (UTXO) je wilt uitgeven. Hier hebben we gekozen voor de UTXO van 50.000 satoshis die we eerder creëerde.
 
 
 ![Envoyer fonds clé principale](assets/fr/25.webp)
 
 
-Onderteken vervolgens de transactie met je handtekeningapparaat dat is gekoppeld aan de hoofdsleutel door op "*Teken*" te klikken. Je moet de transactie verifiëren en bevestigen op je hardware wallet. Hier hebben we de Nano S Plus gebruikt om de transactie te ondertekenen.
+Onderteken vervolgens de transactie met je ondertekenapparaat dat is gekoppeld aan de hoofdsleutel door op "*Sign*" te klikken. Je moet de transactie verifiëren en bevestigen op je hardware wallet. Hier hebben we de Nano S Plus gebruikt om de transactie te ondertekenen.
 
 
 ![Signer transaction clé principale](assets/fr/26.webp)
 
 
-Zend ten slotte de transactie over het netwerk uit door op "*Zend uit*" te klikken. Merk op dat het verzenden van fondsen de hersteltijd voor gebruikte munten zal resetten.
+Zend ten slotte de transactie uit over het netwerk door op "*Broadcast*" te klikken. Merk op dat het verzenden van fondsen de hersteltijd voor gebruikte munten zal resetten.
 
 
 ![Diffuser transaction clé principale](assets/fr/27.webp)
@@ -321,13 +321,13 @@ De transactie verschijnt op het hoofdscherm en je saldo wordt bijgewerkt.
 ![Solde après dépense](assets/fr/28.webp)
 
 
-## Portefeuille-update
+## Wallet bijwerken
 
 
-Zoals hierboven uitgelegd, vereist de Liana-wallet dat u je fondsen regelmatig bijwerkt door een transactie uit te voeren op de Blockchain. Als u dit niet doet, kan je erfgenaam (of je tweede apparaat in het geval van een uitgebreide back-up) je fondsen terugvorderen. Als je dit niet doet, kan je geld worden teruggehaald door je erfgenaam (of door je tweede apparaat in het geval van een uitgebreide back-up). Deze situatie is niet extreem gevaarlijk, maar gaat wel in tegen het doel van dit mechanisme: controle houden over je bitcoins zonder een beroep te doen op een vertrouwde derde partij, terwijl je profiteert van een vangnet.
+Zoals hierboven uitgelegd, vereist de Liana-wallet dat je je fondsen regelmatig bijwerkt door een transactie uit te voeren op de blockchain. Als je dit niet doet, kan je erfgenaam (of je tweede apparaat in het geval van een uitgebreide back-up) je fondsen terugvorderen. Deze situatie is niet extreem gevaarlijk, maar gaat wel in tegen het doel van dit mechanisme: controle houden over je bitcoins zonder een beroep te doen op een vertrouwde derde partij, terwijl je profiteert van een vangnet.
 
 
-Er wordt een waarschuwing weergegeven voordat je geld (of een deel ervan) vervalt en kan worden uitgegeven door de herstelsleutel. Het zal aangeven dat je "herstelpad" (*herstelpad*) binnenkort beschikbaar zal zijn. Gezien de korte hersteltijd (een uur), wordt dit bericht in ons geval direct weergegeven.
+Er wordt een waarschuwing weergegeven voordat je geld (of een deel ervan) vervalt en kan worden uitgegeven door de herstelsleutel (recovery key). Het zal aangeven dat je "recovery path" (*herstelpad*) binnenkort beschikbaar zal zijn. Gezien de korte hersteltijd (een uur), wordt dit bericht in ons geval direct weergegeven.
 
 
 ![Avertissement chemin récupération](assets/fr/29.webp)
@@ -339,46 +339,46 @@ Wanneer de deadline nadert, verschijnt er een knop die je vraagt om de betreffen
 ![Actualiser pièces depuis l'écran principal](assets/fr/30.webp)
 
 
-Om je munten bij te werken, ga je naar het tabblad "*Munten*" en klik je op "*Vernieuw Coin*" in het overeenkomstige Coin vakje. Als je meerdere munten hebt, moet je ze om redenen van vertrouwelijkheid één voor één en met relatief korte tussenpozen verversen. Om de kosten laag te houden, kun je je fondsen consolideren door de hele wallet naar een nieuwe ontvangende Address te sturen, maar dit tast je vertrouwelijkheid aan.
+Om je munten bij te werken, ga je naar het tabblad "*Coins*" en klik je op "*Refresh Coin*" in het overeenkomstige coin vakje. Als je meerdere munten hebt, moet je ze om redenen van privacy één voor één en met relatief korte tussenpozen verversen. Om de kosten laag te houden, kun je je fondsen consolideren door de hele wallet naar een nieuwe ontvangstadres te sturen, maar dit tast je privacy aan.
 
 
 ![Actualiser pièce](assets/fr/31.webp)
 
 
-Geef het gewenste tarief voor de transactie aan. Aangezien dit een overboeking naar jezelf is, kun je een vrij laag tarief instellen, vooral als je dit enkele dagen voor de vervaldatum doet.
+Geef het gewenste tarief voor de transactie op. Aangezien dit een overboeking naar jezelf is, kun je een vrij laag tarief instellen, vooral als je dit enkele dagen voor de vervaldatum doet.
 
 
 ![Transfert à soi-même](assets/fr/32.webp)
 
 
-De transactie (met het label "*zelftransfer*") zal alleen zichtbaar zijn in het tabblad "*transacties*".
+De transactie (met het label "*Self-transfer*") zal alleen zichtbaar zijn in het tabblad "*Transactions*".
 
 
 ![Transactions après auto-transfert](assets/fr/33.webp)
 
 
-Eenmaal bevestigd, is je Coin veilig! U kunt gerust zijn tot de volgende vervaldatum.
+Eenmaal bevestigd, is je munt (UTXO) veilig! Je kunt gerust zijn tot de volgende vervaldatum.
 
 
-## Bitcoin herstel
+## Herstel (recovery) van bitcoins
 
 
 Wanneer je geld terughaalt van de Liana Wallet, kun je te maken krijgen met één van twee situaties. Misschien heb je toegang tot de computer waarop de software geïnstalleerd is, in dat geval hoef je hem alleen maar te openen (wat zal gebeuren in het geval van het uitgebreide back-up model). Het is echter mogelijk dat je geen toegang hebt tot deze computer, dus beginnen we hier vanaf nul. Merk op dat de herstelprocedure in beide gevallen hetzelfde is.
 
 
-Om te beginnen, download Liana van [de officiële Wizardsardine website](https://wizardsardine.com/Liana/), of van [de GitHub repository](https://github.com/wizardsardine/Liana/releases), waar je de authenticiteit van de software kunt controleren. Installeer de software en voer het uit. De versie die wij gebruiken is 0.9, dus de afbeeldingen kunnen veranderd zijn. Selecteer op het welkomstscherm de optie "Een bestaande Liana-wallet toevoegen".
+Om te beginnen, download Liana van [de officiële Wizardsardine website](https://wizardsardine.com/Liana/), of van [de GitHub repository](https://github.com/wizardsardine/Liana/releases), waar je de authenticiteit van de software kunt controleren. Installeer de software en voer het uit. De versie die wij gebruiken is 0.9, dus de afbeeldingen kunnen veranderd zijn. Selecteer op het welkomstscherm de optie "Add an existing Liana wallet".
 
 
 ![Ajouter portefeuille existant](assets/fr/34.webp)
 
 
-Configureer hoe je verbinding wilt maken met het netwerk. Je kunt je eigen node gebruiken (lokaal of op afstand) of de infrastructuur van WizardSardine. In het laatste geval heb je de e-mail Address nodig die de wallet maker gebruikt, zodat fondsen automatisch gelokaliseerd kunnen worden. Als je deze informatie niet hebt, kies dan de eerste optie.
+Configureer hoe je verbinding wilt maken met het netwerk. Je kunt je eigen node gebruiken (lokaal of op afstand) of de infrastructuur van WizardSardine. In het laatste geval heb je het e-mailadres nodig dat de maker van de wallet heeft gebruikt, zodat fondsen automatisch gelokaliseerd kunnen worden. Als je deze informatie niet hebt, kies dan de eerste optie.
 
 
 ![Sélectionner connexion réseau](assets/fr/35.webp)
 
 
-Als je je eigen knooppunt gebruikt, importeer dan de wallet descriptor. Dit is een technische beschrijving van de rekening, waarmee je de fondsen op de rekening kunt ophalen. In ons geval is het de volgende informatie:
+Als je je eigen node gebruikt, importeer dan de wallet descriptor. Dit is een technische beschrijving van de rekening, waarmee je de fondsen op de rekening kunt ophalen. In ons geval is het de volgende informatie:
 
 
 ```plaintext
@@ -389,7 +389,7 @@ wsh(or_d(pk([3689a8e7/48'/0'/0'/2']xpub6FKYNH4XbbdADV98yTVxgZZrtB4eE2tiUPreEv5iJ
 ![Importer descripteur](assets/fr/36.webp)
 
 
-Liana vraagt u vervolgens een Mnemonic-zin in te voeren. Als je een werkend signatuurapparaat (hardware wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen aantal hoog is), raden we toch aan om een nieuwe hardware wallet aan te schaffen en de Mnemonic te gebruiken om de sleutels erop te herstellen.
+Liana vraagt je vervolgens een mnemonische zin in te voeren. Als je een werkend ondertekenapparaat (hardware wallet) hebt, kun je dit deel overslaan. Als je apparaat ontbreekt of beschadigd is, maar je hebt wel de corresponderende 12 of 24 woorden, dan kun je deze optie nog steeds gebruiken. Om het zekere voor het onzekere te nemen (als het te herstellen bedrag hoog is), raden we toch aan om een nieuwe hardware wallet aan te schaffen en de mnemonische zin te gebruiken om de sleutels erop te herstellen.
 
 
 In ons geval gebruiken we de Blockstream Jade hardware wallet als herstelapparaat en kiezen we ervoor om deze stap over te slaan ("*Skip*").
@@ -398,43 +398,43 @@ In ons geval gebruiken we de Blockstream Jade hardware wallet als herstelapparaa
 ![Passer phrase mnémotechnique](assets/fr/37.webp)
 
 
-Controleer en sla de descriptor op in je handtekeningapparaat door het te selecteren op het scherm. Als je hardware wallet niet verschijnt, controleer dan of deze is aangesloten en ontgrendeld. Controleer en bevestig dat deze informatie is toegevoegd aan je apparaat.
+Controleer en sla de descriptor op in je ondertekenapparaat door het te selecteren op het scherm. Als je hardware wallet niet verschijnt, controleer dan of deze is aangesloten en ontgrendeld. Controleer en bevestig dat deze informatie is toegevoegd aan je apparaat.
 
 
 ![Enregistrer descripteur sur l'appareil de récupération](assets/fr/38.webp)
 
 
-Configureer je knooppunt. U kunt een bestaand knooppunt gebruiken of een *pruned knooppunt* op je machine installeren. In ons geval hebben we een bestaand knooppunt gebruikt.
+Configureer je node. Je kunt een bestaande node gebruiken of een *pruned node* op je machine installeren. In ons geval hebben we een bestaande node gebruikt.
 
 
 ![Choisir type de nœud](assets/fr/39.webp)
 
 
-Voor deze tutorial gebruikten we een publieke Electrum server. Deze had echter toegang tot al onze activiteiten met de Liana Wallet. Als je je privacy wilt beschermen, kun je beter je eigen node gebruiken.
+Voor deze tutorial gebruikten we een publieke Electrum-server. Deze had echter toegang tot al onze activiteiten met de Liana-Wallet. Als je je privacy wilt beschermen, kun je beter je eigen node gebruiken.
 
 
 ![Connexion serveur Electrum public](assets/fr/17.webp)
 
 
-Zodra je het knooppunt hebt ingesteld, kom je op het hoofdscherm van de Wallet, waar je het saldo en eerdere transacties kunt bekijken die aan de rekening zijn gekoppeld. Je kunt ook zien of fondsen kunnen worden opgehaald. Hier zien we dat een Coin kan worden opgehaald.
+Zodra je de node hebt ingesteld, kom je op het hoofdscherm van de wallet, waar je het saldo en eerdere transacties kunt bekijken die aan de rekening zijn gekoppeld. Je kunt ook zien of fondsen kunnen worden opgehaald. Hier zien we dat een munt (coin) kan worden opgehaald.
 
 
 ![Accueil Liana récupération](assets/fr/40.webp)
 
 
-Om het geld in de wallet terug te krijgen, ga naar Instellingen ("*Instellingen*") linksonder en klik op "*Terughalen*".
+Om het geld in de wallet terug te krijgen, ga naar "*Settings*" linksonder en klik op "*Recover*".
 
 
 ![Récupération dans paramètres](assets/fr/41.webp)
 
 
-Geef de Coin uit in de wallet door het juiste vakje aan te vinken. Geef de BTC Address aan waarnaar je het geld wilt sturen, evenals de transactiekosten. Klik dan op "*Volgende*".
+Geef de coin uit in de wallet door het juiste vakje aan te vinken. Geef het BTC-adres aan waarnaar je het geld wilt sturen, evenals de transactiekosten. Klik dan op "*Next*".
 
 
 ![Récupération des pièces](assets/fr/42.webp)
 
 
-Onderteken de transactie door op "*Teken*" te klikken en de transactie te valideren op je hardware wallet.
+Onderteken de transactie door op "*Sign*" te klikken en de transactie te valideren op je hardware wallet.
 
 
 ![Signer transaction clé de récupération](assets/fr/43.webp)
@@ -455,10 +455,10 @@ De transactie zou op het hoofdscherm moeten verschijnen. Eenmaal bevestigd, is h
 ## Bonus: descriptor analyse
 
 
-De descriptor is een door mensen leesbare tekenreeks die een set adressen uitputtend beschrijft. Het combineert een aantal essentiële stukken informatie voor het ophalen van de onderdelen (UTXO) van een geavanceerde Wallet. De manier waarop de descriptor is geschreven, is gebaseerd op [Miniscript syntax](https://bitbox.swiss/blog/understanding-Bitcoin-miniscript-part-2/), de scripttaal die in 2019 is ontwikkeld door Andrew Poelstra, Pieter Wuille en Sanket Kanjalkar.
+De descriptor is een door mensen leesbare tekenreeks die een set adressen volledig beschrijft. Het combineert een aantal essentiële stukken informatie voor het ophalen van de onderdelen (UTXO's) van een geavanceerde wallet. De manier waarop de descriptor is geschreven, is gebaseerd op [Miniscript syntax](https://bitbox.swiss/blog/understanding-Bitcoin-miniscript-part-2/), de scripttaal die in 2019 is ontwikkeld door Andrew Poelstra, Pieter Wuille en Sanket Kanjalkar.
 
 
-Om beter te begrijpen waarom deze tekenreeks belangrijk is, analyseren we de descriptor in ons voorbeeld, die :
+Om beter te begrijpen waarom deze tekenreeks belangrijk is, analyseren we de descriptor in ons voorbeeld:
 
 
 ```plaintext
@@ -471,20 +471,20 @@ De volgende informatie kan uit deze descriptor worden gehaald:
 
 
 
-- `wsh` (afkorting van *witness script Hash*): Dit is het type transactionele uitvoer dat wordt gemaakt. Als we Taproot hadden gebruikt, zou de identifier `tr` zijn geweest.
+- `wsh` (afkorting van *witness Script Hash*): Dit is het type transactie output dat wordt gemaakt. Als we Taproot hadden gebruikt, zou de identifier `tr` zijn geweest.
 - `or_d`: Dit is een logische operator die aangeeft dat aan *één van de volgende twee* voorwaarden moet worden voldaan om de uitgave te accepteren (de `_d` geeft een bepaalde syntaxis aan).
-- `pk` (afkorting voor *publieke sleutel*): Deze operator controleert een gegeven handtekening tegen de volgende publieke sleutel en geeft het antwoord als een Booleaanse (TRUE of FALSE).
-- `[3689a8e7/48'/0'/0'/2']`: Dit element bevat de *vingerafdruk* van de hoofdsleutel voor de belangrijkste hardware wallet (in dit geval de Nano S Plus), en het afleidingspad naar de gekoppelde uitgebreide privésleutel (waarvan alle andere privésleutels zijn afgeleid).
+- `pk` (afkorting voor *public key*): Deze operator controleert een gegeven handtekening tegen de volgende publieke sleutel en geeft het antwoord als een Booleaanse (TRUE of FALSE).
+- `[3689a8e7/48'/0'/0'/2']`: Dit element bevat de *fingerprint* van de hoofdsleutel (master key) voor de belangrijkste hardware wallet (in dit geval de Nano S Plus), en het afleidingspad naar de gekoppelde uitgebreide privésleutel (waarvan alle andere privésleutels zijn afgeleid).
 - `xpub6FKY ... WQa`: Dit is de uitgebreide publieke sleutel die gekoppeld is aan de hoofd-hardware wallet (hier de Nano S Plus)
-- `/<0;1>/*`: Dit zijn de afleidingspaden voor het verkrijgen van eenvoudige sleutels en adressen: `0` voor ontvangst, `1` voor interne operaties (*wijziging*), met een "wildcard" (`*`) die sequentiële afleiding van meerdere adressen op een configureerbare manier toestaat, vergelijkbaar met het "gap limit" beheer van klassieke wallet software.
-- en_v`: Dit is een logische operator die aangeeft dat *aan de volgende twee* voorwaarden moet worden voldaan om de uitgave te accepteren (de `_v` geeft een bepaalde syntaxis aan).
-- `v:pkh` (afkorting van *verifieer: publieke sleutel Hash*): Deze operator verifieert een gegeven handtekening en publieke sleutel tegen de publieke sleutel Hash (*Hash*) die volgt. Dit is in wezen dezelfde controle als voor P2PKH en P2WPKH scripts.
-- `[42e629dd/48'/0'/0'/2']`: Dit is hetzelfde element als hierboven (bestaande uit het spoor en het afleidingspad), behalve dat het spoor van de hoofdsleutel van de hardwareherstel wallet (in dit geval de Jade) wordt aangegeven.
+- `/<0;1>/*`: Dit zijn de afleidingspaden voor het verkrijgen van eenvoudige sleutels en adressen: `0` voor ontvangst, `1` voor interne operaties (*change*), met een "wildcard" (`*`) die sequentiële afleiding van meerdere adressen op een configureerbare manier toestaat, vergelijkbaar met het "gap limit" beheer van klassieke wallet software.
+- `and_v`: Dit is een logische operator die aangeeft dat *aan de volgende twee* voorwaarden moet worden voldaan om de uitgave te accepteren (de `_v` geeft een bepaalde syntaxis aan).
+- `v:pkh` (afkorting van *Verify: Public Key Hash*): Deze operator verifieert een gegeven handtekening en publieke sleutel tegen de publieke sleutel Hash (*Hash*) die volgt. Dit is in wezen dezelfde controle als voor P2PKH en P2WPKH scripts.
+- `[42e629dd/48'/0'/0'/2']`: Dit is hetzelfde element als hierboven (bestaande uit het spoor en het afleidingspad), behalve dat het spoor van de hoofdsleutel van de herstel-hardware wallet (in dit geval de Jade) wordt aangegeven.
 - `xpub6DpQ ... WQd`: Dit is de uitgebreide publieke sleutel gekoppeld aan de hardware recovery wallet (hier de Jade).
-- `older(6)` : Deze operator controleert of de aangemaakte transactionele uitvoer een leeftijd moet hebben die strikt groter is dan 6 blokken om uitgegeven te kunnen worden.
+- `older(6)` : Deze operator controleert of de aangemaakte transactie output een leeftijd moet hebben die strikt groter is dan 6 blokken om uitgegeven te kunnen worden.
 
 
-Het laatste data-item (`8alrve5h`) is de descriptor controlesom en komt overeen met de wallet identificatie.
+Het laatste data-item (`8alrve5h`) is de descriptor-controlesom en komt overeen met de walletidentificatie.
 
 
 De scripts die door deze wallet worden aangemaakt, hebben de volgende vorm:
@@ -495,7 +495,7 @@ De scripts die door deze wallet worden aangemaakt, hebben de volgende vorm:
 ```
 
 
-Omdat de veiligheid van je Bitcoin wallet ook afhangt van je begrip van hoe het werkt, stel ik voor dat je de mechanismen van deterministische en hiërarchische wallets grondig bestudeert door deze gratis training over Plan ₿ Academy te volgen:
+Omdat de veiligheid van je Bitcoin-wallet ook afhangt van je begrip van hoe het werkt, stel ik voor dat je de mechanismen van deterministische en hiërarchische wallets grondig bestudeert door deze gratis training over Plan ₿ Academy te volgen:
 
 
 https://planb.academy/courses/46b0ced2-9028-4a61-8fbc-3b005ee8d70f

--- a/tutorials/wallet/phoenix/nl.md
+++ b/tutorials/wallet/phoenix/nl.md
@@ -1,6 +1,6 @@
 ---
 name: Phoenix
-description: Phoenix Wallet installeren en gebruiken
+description: Phoenix wallet installeren en gebruiken
 ---
 ![cover](assets/cover.webp)
 
@@ -8,13 +8,13 @@ description: Phoenix Wallet installeren en gebruiken
 ![video](https://youtu.be/TpwnoPUyumA)
 
 
-Phoenix is een self-custodial Lightning Wallet en node ontwikkeld door ACINQ, een Frans bedrijf gespecialiseerd in Lightning-gebaseerde software-oplossingen. In tegenstelling tot custodial Lightning wallets zoals Wallet of Satoshi, waar bitcoins worden bewaard door een derde partij, stelt Phoenix gebruikers in staat om de volledige controle over hun privésleutels te behouden.
+Phoenix is een self-custodial Lightning-wallet en node ontwikkeld door ACINQ, een Frans bedrijf gespecialiseerd in Lightning-gebaseerde software-oplossingen. In tegenstelling tot custodial Lightning-wallets zoals Wallet of Satoshi, waar bitcoins worden bewaard door een derde partij, stelt Phoenix gebruikers in staat om de volledige controle over hun privésleutels te behouden.
 
 
-Phoenix werkt als een echte Lightning-node in je telefoon en opent automatisch een kanaal met ACINQ's Lightning-node. De applicatie is gebaseerd op Lightning-KMP, een cross-platform implementatie van de Lightning Network in Kotlin, geoptimaliseerd voor mobiele portemonnees. In tegenstelling tot andere Lightning-node-oplossingen vereenvoudigt Phoenix het beheer aanzienlijk. De gebruiker hoeft niet te zorgen voor het openen en sluiten van kanalen, een Bitcoin node te draaien of liquiditeit op de Lightning Network te beheren. Phoenix zorgt voor al deze technische handelingen op de achtergrond.
+Phoenix werkt als een echte Lightning-node in je telefoon en opent automatisch een kanaal met ACINQ's Lightning-node. De applicatie is gebaseerd op Lightning-KMP, een cross-platform implementatie van het Lightning Network in Kotlin, geoptimaliseerd voor mobiele wallets. In tegenstelling tot andere Lightning-node-oplossingen vereenvoudigt Phoenix het beheer aanzienlijk. De gebruiker hoeft niet te zorgen voor het openen en sluiten van kanalen, een Bitcoin-node te draaien of liquiditeit op het Lightning Network te beheren. Phoenix zorgt voor al deze technische handelingen op de achtergrond.
 
 
-Deze toepassing combineert het gebruiksgemak en gemak van mobiele Lightning wallets met de veiligheid en soevereiniteit van een echt persoonlijk Lightning knooppunt. Phoenix maakt het mogelijk om de Lightning Network veilig, efficiënt en autonoom te gebruiken, terwijl je geniet van een vloeiende, intuïtieve gebruikerservaring.
+Deze toepassing combineert het gebruiksgemak en gemak van mobiele Lightning wallets met de veiligheid en soevereiniteit van een echt persoonlijke Lightning-node. Phoenix maakt het mogelijk om het Lightning Network veilig, efficiënt en autonoom te gebruiken, terwijl je geniet van een vloeiende, intuïtieve gebruikerservaring.
 
 
 Daar staan bepaalde kosten tegenover:
@@ -22,12 +22,12 @@ Daar staan bepaalde kosten tegenover:
 
 
 
-- Versturen via Lightning kost 0,4% van het bedrag plus 4 Sats ;
+- Versturen via Lightning kost 0,4% van het bedrag plus 4 sats ;
 - Als er contant geld nodig is om via Lightning te ontvangen, wordt 1% van het bedrag in rekening gebracht;
-- Elk kanaal kost 1000 Sats om te openen.
+- Elk kanaal kost 1000 sats om te openen.
 
 
-Naar mijn mening is Phoenix een uitstekende tussenoplossing tussen custodial Lightning wallets en het handmatig beheren van een Lightning node. Deze toepassing is even geschikt voor beginners als voor gevorderde gebruikers die zich liever niet bezighouden met de details van het beheer van hun eigen LND of Core Lightning. Laten we eens kijken hoe we het kunnen gebruiken!
+Naar mijn mening is Phoenix een uitstekende tussenoplossing tussen custodial Lightning-wallets en het handmatig beheren van een Lightning-node. Deze toepassing is even geschikt voor beginners als voor gevorderde gebruikers die zich liever niet bezighouden met de details van het beheer van hun eigen LND of Core Lightning. Laten we eens kijken hoe we het kunnen gebruiken!
 
 
 ![Image](assets/fr/01.webp)
@@ -36,7 +36,7 @@ Naar mijn mening is Phoenix een uitstekende tussenoplossing tussen custodial Lig
 ## De toepassing installeren
 
 
-Ga naar je applicatiewinkel en installeer Phoenix :
+Installeer Phoenix via de app store van je telefoon:
 
 
 
@@ -54,7 +54,7 @@ Je kunt de applicatie ook installeren [met het apk-bestand op hun GitHub reposit
 ![Image](assets/fr/03.webp)
 
 
-## Portfolio maken
+## Wallet aanmaken
 
 
 Zodra de toepassing is gestart, klik je op de knop "*Volgende*" om de presentatie over te slaan en vervolgens op "*Start*".
@@ -63,54 +63,54 @@ Zodra de toepassing is gestart, klik je op de knop "*Volgende*" om de presentati
 ![Image](assets/fr/04.webp)
 
 
-Selecteer "*Maak een nieuwe Wallet*".
+Selecteer "*Maak een nieuwe wallet*".
 
 
 ![Image](assets/fr/05.webp)
 
 
-En dat is het, je Lightning Wallet en knooppunt zijn nu aangemaakt.
+En dat is het, je Lightning-wallet en node zijn nu aangemaakt.
 
 
 ![Image](assets/fr/06.webp)
 
 
-## Mnemonic zin opslaan
+## Mnemonische zin (seed phrase) opslaan
 
 
-Voordat we beginnen, moeten we onze Mnemonic zin van 12 woorden opslaan. Deze zin geeft volledige, onbeperkte toegang tot al je bitcoins. Iedereen die in het bezit is van deze zin kan je tegoeden stelen, zelfs zonder fysieke toegang tot je telefoon.
+Voordat we beginnen, moeten we onze mnemonische zin van 12 woorden opslaan. Deze zin geeft volledige en onbeperkte toegang tot al je bitcoins. Iedereen die in het bezit is van deze zin kan je tegoeden stelen, zelfs zonder fysieke toegang tot je telefoon.
 
 
-De 12-woorden zin herstelt de toegang tot je bitcoins in geval van verlies, diefstal of breuk van je telefoon. Het is daarom erg belangrijk om het zorgvuldig op te slaan en op een veilige plek te bewaren.
+De 12-woorden zin herstelt de toegang tot je bitcoins in geval van verlies, diefstal of een defecte telefoon. Het is daarom erg belangrijk om het zorgvuldig op te slaan en op een veilige plek te bewaren.
 
 
-Je kunt het op papier schrijven of, voor extra veiligheid, op roestvrij staal graveren om het te beschermen tegen brand, overstroming of instorting. De keuze van het medium voor je Mnemonic hangt af van je beveiligingsstrategie, maar als je Phoenix gebruikt als een uitgaven Wallet met gematigde hoeveelheden, zou papier voldoende moeten zijn.
+Je kunt het op papier schrijven of, voor extra veiligheid, op roestvrij staal graveren om het te beschermen tegen brand, overstroming of instorting. De keuze van het medium voor je mnemonische zin hangt af van je beveiligingsstrategie. Als je Phoenix gebruikt als een portemonnee voor uitgaven met gematigde bedragen, zou papier voldoende moeten zijn.
 
 
-Voor meer informatie over de juiste manier om je Mnemonic zinsdeel op te slaan en te beheren, raad ik je aan deze andere tutorial te volgen, vooral als je een beginner bent:
+Voor meer informatie over de juiste manier om je mnemonische zin op te slaan en te beheren, raad ik je aan deze andere tutorial te volgen, vooral als je een beginner bent:
 
 
 https://planb.academy/tutorials/wallet/backup/backup-mnemonic-22c0ddfa-fb9f-4e3a-96f9-46e2a7954270
 
-Klik op het bericht bovenaan de Interface "*Sla je Wallet op...*".
+Klik op het bericht bovenaan het scherm "*Sla je Wallet op...*".
 
 
 ![Image](assets/fr/07.webp)
 
 
-Klik dan op "*Bewaar mijn Wallet*".
+Klik dan op "*Bewaar mijn wallet*".
 
 
 ![Image](assets/fr/08.webp)
 
 
-Klik dan op "*Bekijk mijn sleutel*" en sla je Mnemonic zin op een fysieke drager op.
+Klik dan op "*Bekijk mijn sleutel*" en sla je mnemonische zin op op een fysieke drager.
 
 
 ![Image](assets/fr/09.webp)
 
 
-Controleer de twee vakjes onderaan de Interface om te bevestigen dat de back-up met succes is voltooid.
+Controleer de twee selectievakjes onderaan het scherm om te bevestigen dat de back-up met succes is voltooid.
 
 
 ![Image](assets/fr/10.webp)
@@ -119,13 +119,13 @@ Controleer de twee vakjes onderaan de Interface om te bevestigen dat de back-up 
 ## Toepassing instellen
 
 
-Voordat je je eerste transacties maakt, kun je de instellingen aanpassen door op het tandwielpictogram linksonder op de Interface te klikken.
+Voordat je je eerste transacties maakt, kun je de instellingen aanpassen door op het tandwielpictogram linksonder op het scherm te klikken.
 
 
 ![Image](assets/fr/11.webp)
 
 
-In het menu "*Display*" kun je het thema van de applicatie kiezen, de denominatie die gebruikt wordt voor Bitcoin en je lokale fiatvaluta.
+In het menu "*Display*" kun je het thema van de applicatie kiezen, de denominatie die gebruikt wordt voor bitcoin en je lokale fiatvaluta.
 
 
 ![Image](assets/fr/12.webp)
@@ -137,19 +137,19 @@ In "*Betalingsopties*" vind je verschillende geavanceerde instellingen voor Ligh
 ![Image](assets/fr/13.webp)
 
 
-In "*Kanaalbeheer*" stelt u de maximale vergoeding in die u bereid bent te betalen voor het openen van een Lightning-kanaal.
+In "*Channel management*" stel je de maximale vergoeding in die je bereid bent te betalen voor het openen van een Lightning-kanaal.
 
 
 ![Image](assets/fr/14.webp)
 
 
-In het menu "*Toegangsbeheer*" raad ik je sterk aan om een authenticatiesysteem te activeren om de toegang tot de applicatie op je telefoon te beveiligen. Dit voorkomt dat iemand met toegang tot je niet-vergrendelde telefoon Phoenix kan openen en je bitcoins kan stelen.
+In het menu "*App Access*" raad ik je sterk aan om een authenticatiesysteem te activeren om de toegang tot de applicatie op je telefoon te beveiligen. Dit voorkomt dat iemand met toegang tot je niet-vergrendelde telefoon Phoenix kan openen en je bitcoins kan stelen.
 
 
 ![Image](assets/fr/15.webp)
 
 
-In het menu "*Electrum server*" kun je, als je een Electrs server hebt, deze verbinden om je transacties uit te zenden.
+In het menu "*Electrum server*" kun je, als je een Electrs-server hebt, deze verbinden om je transacties uit te zenden.
 
 
 ![Image](assets/fr/16.webp)
@@ -161,7 +161,7 @@ Om de vertrouwelijkheid van je verbindingen te verbeteren, kun je verbindingen v
 ![Image](assets/fr/17.webp)
 
 
-## Bitcoins ontvangen On-Chain
+## On-chain bitcoins ontvangen 
 
 
 Bij het eerste gebruik heb je de optie om je Phoenix Wallet te laden met On-Chain fondsen. Je kunt deze eerste storting ook direct vanuit Lightning doen (zie volgende sectie), maar in beide gevallen gelden extra kosten voor het openen van je eerste kanaal.
@@ -239,7 +239,7 @@ Je hebt verschillende opties tot je beschikking. Door op "*Scan QR code*" te kli
 ![Image](assets/fr/28.webp)
 
 
-Je kunt deze informatie ook handmatig invoeren via het toetsenbord in het veld bovenaan de Interface, of een Lightning Address (BOLT12 of LNURL) invoeren. Je kunt de informatie ook direct plakken met de knop "*Paste*".
+Je kunt deze informatie ook handmatig invoeren via het toetsenbord in het veld bovenaan het scherm, of een Lightning Address (BOLT12 of LNURL) invoeren. Je kunt de informatie ook direct plakken met de knop "*Paste*".
 
 
 ![Image](assets/fr/29.webp)

--- a/tutorials/wallet/phoenix/nl.md
+++ b/tutorials/wallet/phoenix/nl.md
@@ -164,28 +164,28 @@ Om de vertrouwelijkheid van je verbindingen te verbeteren, kun je verbindingen v
 ## On-chain bitcoins ontvangen 
 
 
-Bij het eerste gebruik heb je de optie om je Phoenix Wallet te laden met On-Chain fondsen. Je kunt deze eerste storting ook direct vanuit Lightning doen (zie volgende sectie), maar in beide gevallen gelden extra kosten voor het openen van je eerste kanaal.
+Bij het eerste gebruik heb je de optie om je Phoenix-wallet te laden met nn-chain fondsen. Je kunt deze eerste storting ook direct vanuit Lightning doen (zie volgende sectie), maar in beide gevallen betaal je extra kosten voor het openen van je eerste kanaal.
 
 
-Klik op de knop "*Ontvangen*".
+Klik op de knop "*Receive*".
 
 
 ![Image](assets/fr/18.webp)
 
 
-Veeg de QR-code naar links om een Bitcoin te onthullen die Address ontvangt. Stuur het bedrag dat je in Phoenix wilt storten naar die Address.
+Veeg de QR-code naar links om een ontvangstadres voor Bitcoin te onthullen. Stuur het bedrag dat je in Phoenix wilt storten naar dat adres.
 
 
 ![Image](assets/fr/19.webp)
 
 
-Het ontvangen bedrag On-Chain verschijnt eerst als 'pending' onder je Wallet saldo. Het duurt 3 bevestigingen voordat het geld beschikbaar is voor gebruik.
+Het ontvangen on-chain bedrag verschijnt in je wallet-saldo eerst als 'pending'. Het duurt 3 bevestigingen voordat het geld beschikbaar is voor gebruik.
 
 
 ![Image](assets/fr/20.webp)
 
 
-Zodra het geld is ontvangen, opent Phoenix automatisch een Lightning-kanaal voor je. Je kunt nu bitcoins verzenden en ontvangen via de Lightning Network.
+Zodra het geld is ontvangen, opent Phoenix automatisch een Lightning-kanaal voor je. Je kunt nu bitcoins verzenden en ontvangen via het Lightning Network.
 
 
 ![Image](assets/fr/21.webp)
@@ -194,31 +194,31 @@ Zodra het geld is ontvangen, opent Phoenix automatisch een Lightning-kanaal voor
 ## Bitcoins ontvangen via Lightning
 
 
-Om Sats via de Lightning Network te ontvangen, klik je op de knop "*Ontvangen*".
+Om sats via het Lightning Network te ontvangen, klik je op de knop "*Receive*".
 
 
 ![Image](assets/fr/22.webp)
 
 
-Phoenix genereert een Lightning Invoice. Je kunt het scannen of opsturen naar de persoon die Sats aan jou wil overdragen.
+Phoenix genereert een Lightning-invoice. Je kunt het scannen of opsturen naar de persoon die sats aan jou wil overdragen.
 
 
 ![Image](assets/fr/23.webp)
 
 
-Door op de "*Edit*" knop te klikken, kun je een omschrijving toevoegen die zichtbaar zal zijn voor de betaler op de Invoice, en een specifiek bedrag definiëren dat de betaler moet overmaken.
+Door op de "*Edit*" knop te klikken, kun je een omschrijving toevoegen die zichtbaar zal zijn voor de betaler op de invoice, en een specifiek bedrag definiëren dat de betaler moet overmaken.
 
 
 ![Image](assets/fr/24.webp)
 
 
-De bovengenoemde klassieke facturen kunnen maar één keer worden gebruikt. Voor een herbruikbare betalingsoptie kun je je herbruikbare QR-code gebruiken, wat een BOLT12-aanbieding is.
+De bovengenoemde klassieke facturen kunnen slechts één keer worden gebruikt. Voor een herbruikbare betalingsoptie kun je je herbruikbare QR-code gebruiken, wat een BOLT12-aanbieding is.
 
 
 ![Image](assets/fr/25.webp)
 
 
-Zodra de Invoice of BOLT12 aanbieding is vereffend, verschijnt de transactie op je Lightning Wallet.
+Zodra de invoice of BOLT12-aanbieding is vereffend, verschijnt de transactie op je Lightning-wallet.
 
 
 ![Image](assets/fr/26.webp)
@@ -227,25 +227,25 @@ Zodra de Invoice of BOLT12 aanbieding is vereffend, verschijnt de transactie op 
 ## Bitcoins versturen via Lightning
 
 
-Nu je Sats op Phoenix hebt, ben je klaar om betalingen via de Lightning Network te doen. Klik eerst op de knop "*Versturen*".
+Nu je sats op Phoenix hebt, ben je klaar om betalingen via het Lightning Network te doen. Klik eerst op de knop "*Send*".
 
 
 ![Image](assets/fr/27.webp)
 
 
-Je hebt verschillende opties tot je beschikking. Door op "*Scan QR code*" te klikken, kun je een Lightning Invoice, een BOLT12 aanbieding of zelfs een ontvangen Address voor On-Chain betaling scannen.
+Je hebt verschillende opties tot je beschikking. Door op "*Scan QR code*" te klikken, kun je een Lightning-invoice, een BOLT12-aanbieding of zelfs een on-chain ontvangstadres scannen om te betalen.
 
 
 ![Image](assets/fr/28.webp)
 
 
-Je kunt deze informatie ook handmatig invoeren via het toetsenbord in het veld bovenaan het scherm, of een Lightning Address (BOLT12 of LNURL) invoeren. Je kunt de informatie ook direct plakken met de knop "*Paste*".
+Je kunt deze informatie ook handmatig invoeren via het toetsenbord in het veld bovenaan het scherm, of een Lightning-adres (BOLT12 of LNURL) invoeren. Je kunt de informatie ook direct plakken met de knop "*Paste*".
 
 
 ![Image](assets/fr/29.webp)
 
 
-In dit voorbeeld heb ik een Invoice gescand voor 10.000 Sats. Om de betaling uit te voeren, klik je op "*Betalen*".
+In dit voorbeeld heb ik een invoice gescand voor 10.000 sats. Om de betaling uit te voeren, klik je op "*Pay*".
 
 
 ![Image](assets/fr/30.webp)
@@ -257,7 +257,7 @@ De transactie is voltooid.
 ![Image](assets/fr/31.webp)
 
 
-Gefeliciteerd, je weet nu hoe je Phoenix moet configureren en gebruiken. Als je deze tutorial nuttig vond, zou ik je dankbaar zijn als je hieronder een Green duim achterlaat. Voel je vrij om dit artikel te delen op je sociale netwerken. Bedankt voor het delen!
+Gefeliciteerd, je weet nu hoe je Phoenix moet configureren en gebruiken. Als je deze tutorial nuttig vond, zou ik je dankbaar zijn als je hieronder een groene duim achterlaat. Voel je vrij om dit artikel te delen op je sociale netwerken. Bedankt voor het delen!
 
 
 Als je nog een stapje verder wilt gaan, bekijk dan deze tutorial over Alby Hub, een andere innovatieve en gebruiksvriendelijke oplossing voor het lanceren van je eigen Lightning-node:


### PR DESCRIPTION
I have reviewed the following tutorials: Alby, Alby Go, Phenix, Aqua, Blue Wallet, BullBitcoin, Envoy, Liana.

**Comments on Alby Go**: the content of the FR tutorial is in English

**Comments on Bull Bitcoin**:
- EN
    - Line 12 EN: "how to move Bitcoin between them." --> Bitcoin here refers to money, so it should start with a lower case?
    - Line 16 EN : same comment as line 12 + dot at the end needed --> "for managing your Bitcoin across all major networks" --> to be corrected as "for managing your bitcoin across all major networks."
    - Line 93 through 95: suggestion to improve readability by indenting the 3 lines
    - Line 121 & 122: formatting --> `**` to be put at the beginning of the line? --> propose correction: `- **`App Unlock PIN`:**`
    - Line 227: formatting: 2 missing `**` at the end? --> Suggestion for improvement: `**Default Mode (URI with additional input parameters)**`
    - Line 246: same comment as line 227
    - Line 248: ``With the `Copy or scan Address only option` enabled`` --> suggestion for improvement : ``With the `Copy or scan Address only` option enabled``
    - Line 304 through 306: formatting --> `**` to be put at the beginning of the line
    - Line 318 : formatting: proposed correction: ``you can tap on the `Send` button down right``
    - Line 430: formatting : proposed correction: ``...then tap `Broadcast Transaction`.``
- FR
    - Line 31 through 34: formatting: missing `**` at the beginning of the lines
    - Lines 79 & 81 : these should belong together with line 77?
    - Line 177 & 178: formatting --> `**` to be put at the beginning of tine? --> propose correction: `- **`App Unlock PIN`:**`
    - Line 259 through 264: formatting: missing `**` at the beginning of the lines
    - Line 331: formatting: 2 missing `**` at the end? --> Suggestion for improvement: `**Mode par défaut (URI avec paramètres d'entrée supplémentaires)**`
    - Line 338 through 341: formatting: missing `**` at the beginning of the lines
    - Line 358: same comment as line 331
    - Line 399 & 400: formatting --> `**` to be put at the beginning of the line 
    - Line 427 through 433: formatting --> `**` to be put at the beginning of the line 
    - Line 439 through 443: formatting --> `**` to be put at the beginning of the line
    - Line 441: for consistency with the other points, correct as follows:  ``2. `ajouter une note`**(Optionnel):``

**Comments on Envoy wallet**:
- EN
    - Line 258: formatting: start phrase with uppercase + bold & italic like in FR version.
    - Line 306: formatting: missing quote  --> to be corrected as: ### "*Account*" menu
    - Line 328: same comment --> to be corrected as : ### "More" menu
    - Line 330: same comment --> to be corrected as : ### "Settings" menu
    - Line 382: Sparrow needs to be replaced by Envoy in the following sentence? Make sure that the address displayed on the Passport corresponds exactly to the one shown on Sparrow, and that "*Verified*" appears.
- FR
    - Line 376: Sparrow needs to be replaced by Envoy in the following sentence? Assurez-vous que l'adresse affichée sur le Passport corresponde exactement à celle indiquée sur Sparrow et que la mention "*Verified*" apparaisse.


**Comments on Liana:**
- EN
    - Line 19: bitcoin should be with lower case as it refers to currency --> proposed correction: ... and which are involved in the recovery of bitcoins
    - Line 204: sats/ov --> should be sats/vB (for a charge rate of 4 sat/ov) 
    - Line 329: formatting: ` missing at the beginning of the line --> Should be:  - `and_v`: This is a logical...
    - Line 310 --> insert translation from French version --> Proposal:	 
```
## Videos
If you'd like to learn more about Liana, there is video content that will give you a clearer idea of how it works. Here is a presentation video about Liana with Kévin Loaec and Antoine Poinsot:  

![Vidéo de présentation avec Kévin Loaec et Antoine Poinsot](https://youtu.be/siuLmQo1lM8)

And here is a Liana tutorial, with Antoine Poinsot:  

![Vidéo-tutoriel avec Antoine Poinsot](https://youtu.be/JrG4WMVPZDQ)

The operations shown in this last video are similar to what has been presented in this tutorial.
```

   
- FR
    - Line 204: sats/ov --> should be sats/vB (pour un taux de frais de 4 sat/ov, )
    - Line 310 through 320: this is not translated in the English version of the tutorial

Closes #4281