### PR TITLE
[SCRIPTS] add format validation scripts and schemas

### DIFF
--- a/docs/PBN-template-repo/tutorials/this-folder-is-a-tutorial-category/awesome-tutorial/tutorial.yml
+++ b/docs/PBN-template-repo/tutorials/this-folder-is-a-tutorial-category/awesome-tutorial/tutorial.yml
@@ -2,9 +2,7 @@
 # generate a random uuid v4
 id: bf76be99-bf95-4606-8103-e7a072839ee9
 
-# insert when the tutorial received a big content update, see below
-# 2 options avilable: the date of first publication, the date of last relevant edit
-last_update_date: YYYY-MM-DD
+# Characteristic of tutorial
 
 # Project
 # Write the project name
@@ -85,6 +83,8 @@ license: CC-BY-SA-V4
 # - urgency: level of urgency from 1 (low urgency) to X (high urgency)
 # - contributor_names: list of contributors PBN ids
 # - reward: amount of sats available for reward
+licence: CC-BY-SA-V4
+
 original_language: en
 proofreading:
   - language: en

--- a/scripts/validation-format/README.md
+++ b/scripts/validation-format/README.md
@@ -1,0 +1,129 @@
+# PlanB Network Content Validator
+
+A modular, centralized validation system for all content types in the repository.
+
+## Quick Start
+
+```bash
+# Activate the virtual environment (required)
+source .venv/bin/activate
+
+# Validate a single content folder
+python scripts/validation-format/validate.py courses/btc101
+python scripts/validation-format/validate.py tutorials/wallet/sparrow-wallet
+python scripts/validation-format/validate.py resources/papers/bitcoin-a-peer-to-peer-electronic-cash-system
+
+# Validate all content folders
+python scripts/validation-format/validate_all.py
+
+# Validate specific content types
+python scripts/validation-format/validate_all.py --courses-only
+python scripts/validation-format/validate_all.py --tutorials-only
+python scripts/validation-format/validate_all.py --resources-only
+python scripts/validation-format/validate_all.py --type resources/papers
+```
+
+## Requirements
+
+```bash
+pip install jsonschema pyyaml python-frontmatter
+```
+
+## Scripts
+
+### validate.py
+
+Validates a single content folder against its JSON schema.
+
+```bash
+# Basic usage
+python scripts/validation-format/validate.py <content-folder>
+
+# JSON output for CI/CD
+python scripts/validation-format/validate.py courses/btc101 --json
+```
+
+**Exit codes:**
+- `0` - Validation passed
+- `1` - Validation failed (errors found)
+- `2` - Validation passed with warnings
+
+### validate_all.py
+
+Validates all content folders in the repository.
+
+```bash
+# Validate everything
+python scripts/validation-format/validate_all.py
+
+# Filter by content type
+python scripts/validation-format/validate_all.py --courses-only
+python scripts/validation-format/validate_all.py --tutorials-only
+python scripts/validation-format/validate_all.py --professors-only
+python scripts/validation-format/validate_all.py --events-only
+python scripts/validation-format/validate_all.py --resources-only
+
+# Validate a specific resource type
+python scripts/validation-format/validate_all.py --type resources/papers
+python scripts/validation-format/validate_all.py --type resources/books
+
+# Output options
+python scripts/validation-format/validate_all.py --json          # JSON output
+python scripts/validation-format/validate_all.py --summary-only  # Hide individual errors
+python scripts/validation-format/validate_all.py --verbose       # Show all results
+```
+
+## Supported Content Types
+
+| Content Type | Metadata File | Schema File |
+|--------------|---------------|-------------|
+| courses | `course.yml` | `course-scheme.json` |
+| tutorials | `tutorial.yml` | `tutorial-scheme.json` |
+| professors | `professor.yml` | `professor-scheme.json` |
+| events | `event.yml` | `event-scheme.json` |
+| resources/bet | `bet.yml` | `bet-scheme.json` |
+| resources/books | `book.yml` | `book-scheme.json` |
+| resources/channels | `channel.yml` | `channel-scheme.json` |
+| resources/conferences | `conference.yml` | `conference-scheme.json` |
+| resources/glossary | `word.yml` | `word-scheme.json` |
+| resources/movies | `movie.yml` | `movie-scheme.json` |
+| resources/newsletters | `newsletter.yml` | `newsletter-scheme.json` |
+| resources/papers | `paper.yml` | `paper-scheme.json` |
+| resources/podcasts | `podcast.yml` | `podcast-scheme.json` |
+| resources/projects | `project.yml` | `project-scheme.json` |
+
+## Directory Structure
+
+```
+scripts/validation-format/
+├── README.md           # This file
+├── TODO.md             # Implementation progress
+├── validate.py         # Single folder validator
+├── validate_all.py     # Bulk validator
+└── schemas/            # JSON Schema definitions
+    ├── course-scheme.json
+    ├── course-content-scheme.json
+    ├── tutorial-scheme.json
+    ├── tutorial-content-scheme.json
+    ├── professor-scheme.json
+    ├── professor-content-scheme.json
+    ├── event-scheme.json
+    ├── paper-scheme.json
+    └── ... (other schemas)
+```
+
+## CI/CD Integration
+
+Both scripts support JSON output and exit codes suitable for CI/CD pipelines:
+
+```bash
+# Run validation and check exit code
+python scripts/validation-format/validate_all.py --json > results.json
+if [ $? -eq 0 ]; then
+    echo "All validations passed"
+elif [ $? -eq 1 ]; then
+    echo "Validation errors found"
+else
+    echo "Validation passed with warnings"
+fi
+```

--- a/scripts/validation-format/TODO.md
+++ b/scripts/validation-format/TODO.md
@@ -1,0 +1,207 @@
+# Validation Format - Implementation Plan
+
+## Overview
+
+Create a modular, centralized validation system for all content types in the repository.
+
+**Goal**: A single script that takes a content folder path (relative to repo root), auto-detects the content type, and validates it against the corresponding schema.
+
+**Location**: `scripts/validation-format/`
+
+---
+
+## Phase 1: Setup & Reorganization ✓
+
+### 1.1 Create folder structure
+- [x] Create `scripts/validation-format/` directory
+- [x] Create `scripts/validation-format/schemas/` directory for all JSON schemas
+
+### 1.2 Move and consolidate schemas
+- [x] Move course schemas from `docs/PBN-template-repo/courses/`
+  - `course-scheme.json`
+  - `course-content-scheme.json`
+- [x] Move tutorial schemas from `docs/PBN-template-repo/tutorials/`
+  - `tutorial-scheme.json`
+  - `tutorial-content-scheme.json`
+- [x] Move professor schemas from `docs/PBN-template-repo/professors/`
+  - `professor-scheme.json`
+  - `professor-content-scheme.json`
+- [x] Move event schemas from `docs/PBN-template-repo/events/`
+  - `event-scheme.json`
+- [x] Move resource schemas from `docs/PBN-template-repo/resources/`
+  - `bet-scheme.json`, `bet-content-scheme.json`
+  - `book-scheme.json`, `book-content-scheme.json`
+  - `channel-scheme.json`
+  - `conference-scheme.json`
+  - `movie-scheme.json`
+  - `newsletter-scheme.json`
+  - `podcast-scheme.json`
+  - `project-scheme.json` (non-community-builder-scheme.json)
+  - `word-scheme.json` (glossary)
+- [x] Move quiz schemas
+  - `quizz-question-scheme.json`
+  - `quizz-translation-scheme.json`
+
+### 1.3 Move validator script
+- [x] Copy `docs/PBN-template-repo/scripts/schema_validator.py` to `scripts/validation-format/validate.py`
+- [x] Update schema path resolution to use new `schemas/` directory
+- [ ] Remove old script from `docs/PBN-template-repo/scripts/` (deferred - keep for backward compatibility)
+
+---
+
+## Phase 2: Create Paper Schema ✓
+
+### 2.1 Analyze paper structure
+- [x] Document all fields found in existing `paper.yml` files:
+  - `title` (required, string)
+  - `original_language` (required, string, ISO 639-1)
+  - `authors` (required, array of strings)
+  - `abstract` (required, string, multiline)
+  - `publication_date` (optional, string, YYYY-MM-DD)
+  - `paper_type` (required, enum: whitepaper, conference, academic, pre-print, review, PhD Thesis, book)
+  - `source` (optional, string)
+  - `type` (optional, enum: SCI, SCIE, SSCI)
+  - `category` (optional, string)
+  - `topics` (required, array of strings)
+  - `pdf_url` (required, string, URL format)
+  - `id` (required, string, UUID format)
+
+### 2.2 Create paper schema
+- [x] Create `scripts/validation-format/schemas/paper-scheme.json`
+- [x] Follow same JSON Schema format as other schemas (draft-07)
+- [x] Define required vs optional fields
+- [x] Add proper validation patterns (UUID, date, URL)
+
+---
+
+## Phase 3: Update Validator Script ✓
+
+### 3.1 Add paper support
+- [x] Add `resources/papers` to CONTENT_TYPES mapping
+- [x] Map to `paper.yml` and `paper-scheme.json`
+
+### 3.2 Fix schema path resolution
+- [x] Update all schema path lookups to use `scripts/validation-format/schemas/`
+- [x] Ensure relative path resolution works from any working directory
+
+### 3.3 Verify all content types work
+- [x] Test courses validation (btc101: 0 errors)
+- [x] Test tutorials validation (sparrow-wallet: runs correctly)
+- [x] Test professors validation (runs correctly)
+- [x] Test events validation (runs correctly)
+- [x] Test resources/bet validation (runs correctly)
+- [x] Test resources/books validation (runs correctly)
+- [x] Test resources/channels validation (0 errors)
+- [x] Test resources/conferences validation (runs correctly)
+- [x] Test resources/glossary validation (runs correctly)
+- [x] Test resources/movies validation (runs correctly)
+- [x] Test resources/newsletters validation (runs correctly)
+- [x] Test resources/papers validation (0 errors)
+- [x] Test resources/podcasts validation (runs correctly)
+- [x] Test resources/projects validation (runs correctly)
+
+Note: Some content types show validation errors due to schema drift (schemas need updating to match current content structure). The validator itself works correctly for all types.
+
+---
+
+## Phase 4: Enhance Output Options ✓
+
+### 4.1 Add JSON output flag
+- [x] Add `--json` / `-j` flag for JSON output
+- [x] Structure JSON output with:
+  - `folder`: content path validated
+  - `results`: array with file, valid, errors, warnings
+  - `total_errors`: total error count
+  - `total_warnings`: total warning count
+
+### 4.2 Add exit codes
+- [x] Exit code 0: validation passed
+- [x] Exit code 1: validation failed (errors)
+- [x] Exit code 2: validation passed with warnings only
+
+### 4.3 Keep terminal output as default
+- [x] Colored output for human readability (ANSI codes)
+- [x] Summary statistics at the end
+
+---
+
+## Phase 5: Create Validate-All Wrapper ✓
+
+### 5.1 Create bulk validation script
+- [x] Create `scripts/validation-format/validate_all.py`
+- [x] Iterate over all content folders
+- [x] Call `validate.py` for each
+- [x] Aggregate results
+- [x] Support filtering by content type (`--courses-only`, `--tutorials-only`, `--resources-only`, `--type`)
+
+### 5.2 Generate reports
+- [x] Summary report in terminal (with progress bar)
+- [x] JSON output (`--json`)
+- [ ] Optional HTML report (`--html-report`) - deferred
+
+---
+
+## Phase 6: Cleanup
+
+### 6.1 Remove old files
+- [ ] Remove `docs/PBN-template-repo/scripts/schema_validator.py` - deferred (template may be standalone)
+- [ ] Remove old `scripts/validate_all.py` (if exists) - deferred (has HTML report feature)
+- [ ] Remove schemas from `docs/PBN-template-repo/` subdirectories - deferred (template is self-contained)
+
+### 6.2 Update documentation
+- [x] Update any references to old script locations (none found)
+- [x] Add usage documentation to `scripts/validation-format/README.md`
+
+---
+
+## Content Types Reference
+
+| Content Type | Metadata File | Schema File | Content Files |
+|--------------|---------------|-------------|---------------|
+| courses | `course.yml` | `course-scheme.json` | `{lang}.md` |
+| tutorials | `tutorial.yml` | `tutorial-scheme.json` | `{lang}.md` |
+| professors | `professor.yml` | `professor-scheme.json` | `{lang}.md` |
+| events | `event.yml` | `event-scheme.json` | - |
+| resources/bet | `bet.yml` | `bet-scheme.json` | `{lang}.yml` |
+| resources/books | `book.yml` | `book-scheme.json` | `{lang}.yml` |
+| resources/channels | `channel.yml` | `channel-scheme.json` | - |
+| resources/conferences | `conference.yml` | `conference-scheme.json` | - |
+| resources/glossary | `word.yml` | `word-scheme.json` | - |
+| resources/movies | `movie.yml` | `movie-scheme.json` | - |
+| resources/newsletters | `newsletter.yml` | `newsletter-scheme.json` | - |
+| resources/papers | `paper.yml` | `paper-scheme.json` | - |
+| resources/podcasts | `podcast.yml` | `podcast-scheme.json` | - |
+| resources/projects | `project.yml` | `project-scheme.json` | `{lang}.yml` |
+
+---
+
+## Usage (Target)
+
+```bash
+# Validate a single content folder
+python scripts/validation-format/validate.py courses/btc101
+python scripts/validation-format/validate.py tutorials/wallet/bitbox02
+python scripts/validation-format/validate.py resources/papers/bitcoin-a-peer-to-peer-electronic-cash-system
+
+# JSON output for CI/CD
+python scripts/validation-format/validate.py courses/btc101 --json
+
+# Validate all content
+python scripts/validation-format/validate_all.py
+
+# Validate only specific types
+python scripts/validation-format/validate_all.py --courses-only
+python scripts/validation-format/validate_all.py --resources-only
+```
+
+---
+
+## Progress Tracking
+
+**Status Legend**:
+- [ ] Not started
+- [x] Completed
+
+**Current Phase**: Phase 6.2 Complete (documentation)
+
+**Last Updated**: 2026-01-16 - Phase 1-5 completed, Phase 6.2 documentation complete (schemas centralized, paper schema added, validator with JSON output and exit codes, bulk validation wrapper, README.md)

--- a/scripts/validation-format/schemas/bet-content-scheme.json
+++ b/scripts/validation-format/schemas/bet-content-scheme.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "bet-content-characteristics",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of this BET content."
+    },
+    "description": {
+      "type": "string",
+      "description": "A description of the BET content. Supports multiline text."
+    }
+  },
+  "required": ["name", "description"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/bet-scheme.json
+++ b/scripts/validation-format/schemas/bet-scheme.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "bet-characteristics",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the BET content (UUID v4).",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "type": {
+      "type": "string",
+      "description": "The type of BET content.",
+      "enum": ["Educational Content", "Visual Content"]
+    },
+    "links": {
+      "type": "object",
+      "description": "Links for downloading and viewing the content.",
+      "properties": {
+        "download": {
+          "type": "string",
+          "description": "Plan B Network public link to a folder for downloading the contents."
+        },
+        "view": {
+          "type": "array",
+          "description": "List of language-specific viewable document links.",
+          "items": {
+            "type": "object",
+            "description": "Language-specific view link where the key is the language code.",
+            "additionalProperties": {
+              "type": "string",
+              "description": "Plan B Network public link to a readable document."
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of contributors who helped format, review, or translate the content, identified by their GitHub usernames.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "project_id": {
+      "type": "string",
+      "description": "UUID of the associated project that organizes this content.",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "original_language": {
+      "type": "string",
+      "description": "The original language of the content (ISO 639-1 code)."
+    },
+    "proofreading": {
+      "type": "array",
+      "description": "Proofreading metadata for each language version.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "Language code for the version being proofread."
+          },
+          "last_contribution_date": {
+            "type": "string",
+            "description": "The date when last contribution was received (YYYY-MM-DD format).",
+            "pattern": "^(YYYY-MM-DD|[0-9]{4}-[0-9]{2}-[0-9]{2})$"
+          },
+          "urgency": {
+            "type": "integer",
+            "description": "Level of urgency from 1 (low) to higher values (high urgency).",
+            "minimum": 1
+          },
+          "contributor_names": {
+            "type": "array",
+            "description": "List of contributor GitHub usernames for this proofreading.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "reward": {
+            "type": "integer",
+            "description": "Amount of sats available for reward.",
+            "minimum": 0
+          }
+        },
+        "required": ["language", "last_contribution_date", "urgency", "contributor_names", "reward"],
+        "additionalProperties": false
+      }
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of associated tags to this content from the PlanB Network tag list.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "license": {
+      "type": "string",
+      "description": "License for the content.",
+      "enum": ["CC-BY-SA-V4", "MIT"]
+    }
+  },
+  "assets_rules": {
+    "description": "Required image assets for BET content.",
+    "files": [
+      {
+        "path": "assets/logo.webp",
+        "required": true,
+        "format": "WebP",
+        "dimensions": {
+          "aspect_ratio": "1:1",
+          "recommended": "800x800 pixels"
+        },
+        "description": "BET content logo/thumbnail"
+      }
+    ]
+  },
+  "required": ["id", "type", "contributor_names", "original_language", "proofreading", "tags", "license"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/book-content-scheme.json
+++ b/scripts/validation-format/schemas/book-content-scheme.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "book-content-characteristics",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "The complete title of the book."
+    },
+    "publication_year": {
+      "type": "integer",
+      "description": "The year when the book was published."
+    },
+    "cover": {
+      "type": "string",
+      "description": "The corresponding cover file for the translated cover."
+    },
+    "original": {
+      "type": "boolean",
+      "description": "Indicates if the language used in this file is the original language of the book."
+    },
+    "description": {
+      "type": "string",
+      "description": "A description of the book."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "List of contributors who helped format, review, or translate the book, identified by their UUID.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["title", "publication_year", "cover", "original", "description", "contributors"],
+  "additionalProperties": false
+}
+

--- a/scripts/validation-format/schemas/book-scheme.json
+++ b/scripts/validation-format/schemas/book-scheme.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "book-characteristics",
+  "type": "object",
+  "properties": {
+    "author": {
+      "type": "string",
+      "description": "The author of the book."
+    },
+    "level": {
+      "type": "string",
+      "description": "The difficulty level of the book.",
+      "enum": ["beginner", "intermediate", "expert", "wizard"]
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of tags associated with the book.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["author", "level", "tags"],
+  "additionalProperties": false
+}
+

--- a/scripts/validation-format/schemas/channel-scheme.json
+++ b/scripts/validation-format/schemas/channel-scheme.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "channel-characteristics",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "UUID v4 identifier for the channel."
+    },
+    "name": {
+      "type": "string",
+      "description": "Complete name of the channel."
+    },
+    "language": {
+      "type": "string",
+      "description": "Main language of the channel using ISO 639-1 language code (e.g., en, es, zh-Hans)."
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the channel's main page."
+        },
+        "trailer": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the pinned video or most viewed video on the channel."
+        }
+      },
+      "required": ["channel"],
+      "additionalProperties": false
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the channel content. Multiline allowed."
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of contributor GitHub usernames who helped format, review, and translate the content.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "contributors": {
+      "type": "array",
+      "description": "List of contributor UUIDs (alternative to contributor_names for main repo).",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "minItems": 1
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of associated tags from the predefined 52 PlanB Network tags.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "license": {
+      "type": "string",
+      "description": "License for the content.",
+      "enum": ["CC-BY-SA-V4", "MIT"]
+    },
+    "project_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "UUID v4 linking this channel to a PlanB Network project."
+    }
+  },
+  "assets_rules": {
+    "description": "Required image assets for channels.",
+    "files": [
+      {
+        "path": "assets/thumbnail.webp",
+        "required": true,
+        "format": "WebP",
+        "dimensions": {
+          "width": 1280,
+          "height": 720,
+          "aspect_ratio": "16:9"
+        },
+        "orientation": "horizontal",
+        "description": "Channel thumbnail image."
+      }
+    ]
+  },
+  "required": ["id", "name", "language", "links", "description", "tags"],
+  "oneOf": [
+    {
+      "required": ["contributor_names"]
+    },
+    {
+      "required": ["contributors"]
+    }
+  ],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/conference-scheme.json
+++ b/scripts/validation-format/schemas/conference-scheme.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "conference-characteristics",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Complete name of the conference including the year to avoid duplication."
+    },
+    "year": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}$",
+      "description": "The year and month when the conference was held, format: YYYY-MM."
+    },
+    "builder": {
+      "type": "string",
+      "description": "The name of the builder associated with the conference. This will be changed to a UUID in the future."
+    },
+    "location": {
+      "type": "string",
+      "description": "The location of the conference, format: Town, Country."
+    },
+    "language": {
+      "type": "array",
+      "description": "Defines the languages spoken during the conference, using ISO 639-1 language codes.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "website": {
+          "type": "string",
+          "description": "URL of the conference's main website."
+        },
+        "twitter": {
+          "type": "string",
+          "description": "URL of the conference's Twitter profile."
+        }
+      },
+      "required": ["website"],
+      "additionalProperties": false
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of associated tags with the conference. Specific list of tags to be defined.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "assets_rules": {
+    "description": "Required image assets for conference content.",
+    "files": [
+      {
+        "path": "assets/thumbnail.webp",
+        "required": true,
+        "format": "WebP",
+        "dimensions": {
+          "width": 1280,
+          "height": 720,
+          "aspect_ratio": "16:9",
+          "orientation": "horizontal"
+        },
+        "description": "Conference banner or promotional image"
+      }
+    ]
+  },
+  "required": ["name", "year", "builder", "location", "language", "links", "tags"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/course-content-scheme.json
+++ b/scripts/validation-format/schemas/course-content-scheme.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Course Content Markdown",
+  "description": "Schema for validating course markdown content files (e.g., en.md, fr.md). These files contain YAML front-matter and structured markdown content.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Short, explicit name of the course. Should be concise but descriptive.",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "goal": {
+      "type": "string",
+      "description": "The main end goal of the course expressed in one sentence. Describes what students will achieve upon completion.",
+      "minLength": 1
+    },
+    "objectives": {
+      "type": "array",
+      "description": "Learning objectives for the course. Should use action verbs to define skills students will acquire. Recommended: 3-4 objectives.",
+      "items": {
+        "type": "string",
+        "description": "A single learning objective starting with an action verb (e.g., 'Understand', 'Learn', 'Master', 'Implement', 'Analyze').",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "maxItems": 10
+    }
+  },
+  "required": ["name", "goal", "objectives"],
+  "additionalProperties": false,
+  "content_rules": {
+    "description": "Structural rules for the markdown body content. JSON Schema cannot fully validate markdown structure, but these rules document the required format.",
+    "structure": {
+      "description_section": {
+        "description": "The content between the YAML front-matter closing '---' and the '+++' separator serves as the course description page.",
+        "rules": [
+          "Must start with an H1 heading (# Title) immediately after the front-matter",
+          "Contains introductory text about the course",
+          "Should state approximate time to complete the course",
+          "Should mention prerequisites if applicable",
+          "The thumbnail.webp image from assets/ folder will be displayed here"
+        ]
+      },
+      "separator": {
+        "description": "The '+++' marker is REQUIRED and separates the description section from the main course content.",
+        "pattern": "^\\+\\+\\+$",
+        "required": true
+      },
+      "parts": {
+        "description": "Parts are major sections of the course, defined by H1 headings (#).",
+        "rules": [
+          "Each part MUST have a <partId>UUID</partId> tag immediately after the heading",
+          "UUID format: 8-4-4-4-12 hexadecimal characters (e.g., 97ccb669-12a0-5eed-83ac-c2f51839d998)",
+          "Parts separate the course into themes or main subjects",
+          "UUIDs must be identical across translations of the same content"
+        ],
+        "example": "# Part Title\n\n<partId>97ccb669-12a0-5eed-83ac-c2f51839d998</partId>"
+      },
+      "chapters": {
+        "description": "Chapters are sub-sections within parts, defined by H2 headings (##).",
+        "rules": [
+          "Each chapter MUST have a <chapterId>UUID</chapterId> tag immediately after the heading",
+          "UUID format: 8-4-4-4-12 hexadecimal characters",
+          "Each chapter is displayed on its own page on Plan B Academy",
+          "A part must contain at least one chapter",
+          "UUIDs must be identical across translations of the same content"
+        ],
+        "example": "## Chapter Title\n\n<chapterId>4dc58281-5179-507c-afde-8c9204cbd3fd</chapterId>"
+      },
+      "sections": {
+        "description": "Sections are optional sub-divisions within chapters, defined by H3 headings (###).",
+        "rules": [
+          "Sections do NOT require UUID tags",
+          "Used to separate chapter content into sub-topics for clarity",
+          "Optional - chapters can exist without sections"
+        ],
+        "example": "### Section Title"
+      }
+    },
+    "media": {
+      "video_embeds": {
+        "description": "Video content can be embedded using two syntaxes.",
+        "formats": [
+          {
+            "type": "directive",
+            "pattern": ":::video id=UUID:::",
+            "description": "Preferred format for internal video references",
+            "example": ":::video id=de7236a0-2985-41ef-86f7-3fa0b7f94531:::"
+          },
+          {
+            "type": "markdown_image",
+            "pattern": "![description](https://www.youtube.com/watch?v=VIDEO_ID)",
+            "description": "Alternative format using markdown image syntax for YouTube videos",
+            "example": "![Awesome music](https://www.youtube.com/watch?v=IO-tUpkygaI)"
+          }
+        ]
+      },
+      "images": {
+        "description": "Images should be stored in the assets/ folder and referenced with relative paths.",
+        "rules": [
+          "Images with text: ./assets/{language_code}/filename.webp (e.g., ./assets/en/diagram.webp)",
+          "Images without text: ./assets/no-txt/filename.webp",
+          "Preferred format: WebP for storage efficiency",
+          "Alternative formats accepted but WebP conversion recommended"
+        ],
+        "patterns": {
+          "with_text": "^\\./assets/[a-z]{2}(-[A-Z]{2})?/.+\\.webp$",
+          "without_text": "^\\./assets/no-txt/.+\\.webp$"
+        },
+        "examples": [
+          "![BTC 101 curriculum](./assets/en/btc101-curriculum.webp)",
+          "![Plan B Academy logo](./assets/no-txt/PBN-logo.webp)"
+        ]
+      }
+    },
+    "special_markers": {
+      "description": "Special HTML-like tags that mark specific chapter types for platform functionality.",
+      "markers": {
+        "isCourseReview": {
+          "description": "Marks a chapter as the course review section",
+          "pattern": "<isCourseReview>true</isCourseReview>",
+          "placement": "Immediately after the chapterId tag",
+          "optional": true
+        },
+        "isCourseExam": {
+          "description": "Marks a chapter as the final exam section",
+          "pattern": "<isCourseExam>true</isCourseExam>",
+          "placement": "Immediately after the chapterId tag",
+          "optional": true
+        },
+        "isCourseConclusion": {
+          "description": "Marks a chapter as the course conclusion",
+          "pattern": "<isCourseConclusion>true</isCourseConclusion>",
+          "placement": "Immediately after the chapterId tag",
+          "optional": true
+        }
+      },
+      "example": "## Course Review\n\n<chapterId>f551b514-6ba5-11f0-833e-b33af48c067b</chapterId>\n\n<isCourseReview>true</isCourseReview>"
+    },
+    "uuid_format": {
+      "description": "UUID format specification used for partId and chapterId tags.",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "example": "97ccb669-12a0-5eed-83ac-c2f51839d998",
+      "notes": [
+        "UUIDs are version 4 (random)",
+        "Must be lowercase hexadecimal",
+        "Python scripts are available to generate UUIDs",
+        "Reviewers can also add UUIDs during PR review"
+      ]
+    }
+  },
+  "presentation_md": {
+    "description": "Optional presentation.md file for in-person/live courses. Serves as a landing page with marketing and logistics information.",
+    "applies_when": "Course has format field in course.yml (online, inperson, or hybrid)",
+    "location": "Course root directory alongside course.yml",
+    "structure": {
+      "description": "Pure markdown file without YAML front-matter",
+      "rules": [
+        "Starts with H1 heading (# Title) describing the course",
+        "Contains marketing/presentation content for the course landing page",
+        "Should describe target audience and who the course is for",
+        "Should outline course format and structure (sections, duration)",
+        "Should list prerequisites (can be 'none required')",
+        "Should include logistics section with date, time, location, price, and registration info",
+        "Images can be included from assets/ folder",
+        "No partId or chapterId tags required - this is not course content"
+      ],
+      "recommended_sections": [
+        "# Course Title - Main heading with course description",
+        "### Target Audience - Who should attend",
+        "### Course Format - Structure and sections outline",
+        "## Prerequisites - Required knowledge or 'no prerequisites'",
+        "# Logistics - Date, time, location, price, registration details"
+      ]
+    },
+    "example_structure": "# Course Title\n\nIntroductory paragraph...\n\n![Course image](assets/image.webp)\n\n### Target Audience\n- Bullet points...\n\n### Course Format\n**Section 1 - ...**\n**Section 2 - ...**\n\n## Prerequisites\nNo prerequisites required...\n\n# Logistics\n**When:** Date and time\n**Where:** Location\n**Price:** Cost or FREE\n"
+  },
+  "examples": [
+    {
+      "description": "Minimal valid front-matter",
+      "yaml": "---\nname: Introduction to Bitcoin\ngoal: Understand the basics of Bitcoin technology\nobjectives:\n  - Learn what Bitcoin is\n  - Understand blockchain fundamentals\n  - Know how to secure bitcoins\n---"
+    },
+    {
+      "description": "Complete front-matter with detailed objectives",
+      "yaml": "---\nname: Advanced Lightning Network Development\ngoal: Master Lightning Network protocol implementation and channel management\nobjectives:\n  - Understand the Lightning Network architecture and its relationship with Bitcoin\n  - Implement payment channels and HTLCs\n  - Deploy and manage Lightning nodes in production\n  - Develop applications using Lightning Network APIs\n---"
+    }
+  ]
+}

--- a/scripts/validation-format/schemas/course-scheme.json
+++ b/scripts/validation-format/schemas/course-scheme.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "course-characteristics",
+  "description": "Schema for validating course metadata (course.yml)",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the course (UUID format)",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "topic": {
+      "type": "string",
+      "description": "Main topic of the course (lowercase)",
+      "enum": ["bitcoin", "business", "mining", "protocol", "security", "sociology", "sovereignty", "social studies"]
+    },
+    "subtopic": {
+      "type": "string",
+      "description": "Subtopic of the course (lowercase), depends on the main topic",
+      "enum": [
+        "bitcoin",
+        "business",
+        "accounting",
+        "data-analysis",
+        "entrepreneurship",
+        "finance",
+        "point-of-sale",
+        "point-of-sales",
+        "mining",
+        "energy",
+        "protocol",
+        "client-side-validation",
+        "client side validation",
+        "script",
+        "sidechain",
+        "lightning",
+        "lightning network",
+        "network",
+        "security",
+        "cryptography",
+        "sociology",
+        "economy",
+        "history",
+        "philosophy",
+        "social studies",
+        "sovereignty",
+        "do-it-yourself",
+        "open-source",
+        "development"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "description": "Type of course content",
+      "enum": ["theory", "practice"]
+    },
+    "level": {
+      "type": "string",
+      "description": "Difficulty level of the course",
+      "enum": ["beginner", "intermediate", "advanced", "expert", "wizard"]
+    },
+    "hours": {
+      "type": "integer",
+      "description": "Estimated number of hours to complete the course",
+      "minimum": 1
+    },
+    "teaching_format": {
+      "type": "string",
+      "description": "How the course is delivered",
+      "enum": ["self_paced", "professor_led"]
+    },
+    "professors_id": {
+      "type": "array",
+      "description": "List of professor UUIDs who teach this course",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+      },
+      "minItems": 1
+    },
+    "project_id": {
+      "type": "string",
+      "description": "UUID of the project associated with this course",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of contributor GitHub usernames",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "published_at": {
+      "type": "string",
+      "description": "Date when the course was published (YYYY-MM-DD format)",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "original_language": {
+      "type": "string",
+      "description": "ISO 639-1 language code of the original course language",
+      "pattern": "^[a-z]{2}(-[A-Za-z]{2,4})?$"
+    },
+    "proofreading": {
+      "type": "array",
+      "description": "Proofreading metadata for each language version",
+      "items": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "ISO 639-1 language code for this proofreading entry",
+            "pattern": "^[a-z]{2}(-[A-Za-z]{2,4})?$"
+          },
+          "last_contribution_date": {
+            "type": ["string", "null"],
+            "description": "Date of the last contribution in YYYY-MM-DD format",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "urgency": {
+            "type": "integer",
+            "description": "Level of urgency for proofreading, 1 being low urgency",
+            "minimum": 1
+          },
+          "contributor_names": {
+            "type": ["array", "null"],
+            "description": "List of contributor GitHub usernames",
+            "items": {
+              "type": "string"
+            }
+          },
+          "reward": {
+            "type": "number",
+            "description": "Amount of sats available for reward",
+            "minimum": 0
+          }
+        },
+        "required": ["language", "urgency", "reward"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of tags associated with this course from the PlanB Network tag list",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "license": {
+      "type": "string",
+      "description": "License of the course content",
+      "enum": ["CC-BY-SA-V4", "MIT"]
+    },
+    "test_only": {
+      "type": "boolean",
+      "description": "If true, course is only published on testnet; if false, on mainnet"
+    },
+    "format": {
+      "type": "string",
+      "description": "Delivery format for live/in-person courses (only for courses with presentation.md)",
+      "enum": ["online", "inperson", "hybrid"]
+    },
+    "address_city_country": {
+      "type": "string",
+      "description": "City and country for in-person courses (e.g., 'Paris, France')"
+    },
+    "address_line_2": {
+      "type": "string",
+      "description": "Detailed address for in-person courses (e.g., '3 rue de Montyon, 9eme arrondissement')"
+    },
+    "start_date": {
+      "type": "string",
+      "description": "Start date of the course in YYYY-MM-DD format",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "end_date": {
+      "type": "string",
+      "description": "End date of the course in YYYY-MM-DD format",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "requires_payment": {
+      "type": "boolean",
+      "description": "Whether the course requires payment for registration"
+    },
+    "inperson_price_dollars": {
+      "type": "number",
+      "description": "Price in USD for in-person attendance (0 for free courses)",
+      "minimum": 0
+    },
+    "payment_expiration_date": {
+      "type": "string",
+      "description": "Last date for payment/registration in YYYY-MM-DD format",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "available_seats": {
+      "type": "integer",
+      "description": "Number of available seats for the course",
+      "minimum": 1
+    },
+    "paid_description": {
+      "type": "string",
+      "description": "Description shown for paid/registered users"
+    },
+    "is_gdpr_compliance": {
+      "type": "boolean",
+      "description": "Whether GDPR compliance is required for registration"
+    },
+    "custom_tc_disclaimer": {
+      "type": "string",
+      "description": "Custom terms and conditions disclaimer for registration"
+    },
+    "videos": {
+      "type": "array",
+      "description": "Optional list of video content associated with course chapters",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "UUID identifier for the video entry",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          },
+          "youtube": {
+            "type": "array",
+            "description": "List of YouTube video IDs by language",
+            "items": {
+              "type": "object",
+              "description": "Language code to YouTube video ID mapping",
+              "additionalProperties": {
+                "type": "string",
+                "description": "YouTube video ID"
+              }
+            }
+          },
+          "peertube": {
+            "type": "array",
+            "description": "List of PeerTube video IDs by language",
+            "items": {
+              "type": "object",
+              "description": "Language code to PeerTube video ID mapping",
+              "additionalProperties": {
+                "type": "string",
+                "description": "PeerTube video ID"
+              }
+            }
+          },
+          "rumble": {
+            "type": "array",
+            "description": "List of Rumble video IDs by language",
+            "items": {
+              "type": "object",
+              "description": "Language code to Rumble video ID mapping",
+              "additionalProperties": {
+                "type": "string",
+                "description": "Rumble video ID"
+              }
+            }
+          }
+        },
+        "required": ["id"],
+        "anyOf": [
+          { "required": ["youtube"] },
+          { "required": ["peertube"] },
+          { "required": ["rumble"] }
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "id",
+    "topic",
+    "subtopic",
+    "level",
+    "hours",
+    "professors_id",
+    "original_language",
+    "proofreading"
+  ],
+  "additionalProperties": true,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "format": { "enum": ["inperson", "hybrid"] }
+        },
+        "required": ["format"]
+      },
+      "then": {
+        "required": [
+          "address_city_country",
+          "start_date",
+          "end_date",
+          "requires_payment",
+          "available_seats"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "format": { "const": "online" }
+        },
+        "required": ["format"]
+      },
+      "then": {
+        "required": [
+          "start_date",
+          "end_date",
+          "requires_payment"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "requires_payment": { "const": true }
+        },
+        "required": ["requires_payment"]
+      },
+      "then": {
+        "required": [
+          "payment_expiration_date"
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/validation-format/schemas/event-scheme.json
+++ b/scripts/validation-format/schemas/event-scheme.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "event-characteristics",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "Unique identifier for the event, UUID v4 format."
+    },
+    "start_date": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$",
+      "description": "Start date and time of the event, format: YYYY-MM-DD hh:mm:ss."
+    },
+    "end_date": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$",
+      "description": "End date and time of the event, format: YYYY-MM-DD hh:mm:ss."
+    },
+    "timezone": {
+      "type": "string",
+      "description": "IANA timezone identifier for the event location (e.g., Europe/Zurich, America/New_York)."
+    },
+    "address_city_country": {
+      "type": "string",
+      "description": "Primary address including street, city, postal code, and country. Critical for map display."
+    },
+    "address_line_2": {
+      "type": "string",
+      "description": "Additional location details such as floor or building name."
+    },
+    "address_line_3": {
+      "type": "string",
+      "description": "Additional location details such as room number."
+    },
+    "name": {
+      "type": "string",
+      "description": "Complete name of the event including the year to avoid duplication."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["workshop", "course", "conference", "lecture", "meetup"],
+      "description": "Category of the event."
+    },
+    "description": {
+      "type": "string",
+      "description": "Main description of the event content and purpose."
+    },
+    "language": {
+      "type": "array",
+      "description": "Languages spoken during the event, using ISO 639-1 codes or extended codes (zh-hans, zh-hant).",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z]{2}(-[a-z]+)?$"
+      },
+      "minItems": 1
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "website": {
+          "type": "string",
+          "description": "URL of the event's main website."
+        },
+        "replay_url": {
+          "type": "string",
+          "description": "URL for the event recording or replay."
+        },
+        "live_url": {
+          "type": "string",
+          "description": "URL for live streaming of the event."
+        }
+      },
+      "additionalProperties": false
+    },
+    "project_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "UUID of the project that organizes this event."
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of contributor names associated with this event.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "available_seats": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of available seats for the event."
+    },
+    "custom_tc_disclaimer": {
+      "type": "string",
+      "description": "Custom terms and conditions disclaimer for the event."
+    },
+    "is_gdpr_compliance": {
+      "type": "boolean",
+      "description": "Whether the event is GDPR compliant."
+    },
+    "test_only": {
+      "type": "boolean",
+      "description": "Whether this is a test event."
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of associated tags for the event from the PlanB Network tag list.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "book_online": {
+      "type": "boolean",
+      "description": "Whether online booking is available for the event."
+    },
+    "book_in_person": {
+      "type": "boolean",
+      "description": "Whether in-person booking is available for the event."
+    },
+    "price_dollars": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Price of the event in US dollars."
+    }
+  },
+  "required": [
+    "id",
+    "start_date",
+    "end_date",
+    "timezone",
+    "address_city_country",
+    "name",
+    "type",
+    "description",
+    "language",
+    "links",
+    "tags"
+  ],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/movie-scheme.json
+++ b/scripts/validation-format/schemas/movie-scheme.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "movie-characteristics",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the movie, UUID v4 format."
+    },
+    "title": {
+      "type": "string",
+      "description": "Complete title of the movie or documentary."
+    },
+    "author": {
+      "type": "string",
+      "description": "Full name of the director or creator(s)."
+    },
+    "publication_year": {
+      "type": "integer",
+      "minimum": 1900,
+      "maximum": 2100,
+      "description": "The year the movie was published or released."
+    },
+    "duration": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Duration of the movie in minutes."
+    },
+    "language": {
+      "type": "string",
+      "description": "Original audio language of the content, using ISO 639-1 language codes (e.g., en, es, fr)."
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "platform": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the main viewing platform (YouTube, Prime Video, etc.)."
+        },
+        "trailer": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the movie trailer."
+        }
+      },
+      "required": ["platform"],
+      "additionalProperties": false
+    },
+    "description": {
+      "type": "string",
+      "description": "Multiline description of the movie content."
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of contributors identified by their GitHub usernames.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of associated tags for the movie. Tags must be from the predefined list of 51 items.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "license": {
+      "type": "string",
+      "enum": ["CC-BY-SA-V4", "MIT"],
+      "description": "License for the content. CC-BY-SA-V4 is the default with share-alike clause. MIT allows almost unrestricted use."
+    }
+  },
+  "assets_rules": {
+    "description": "Required image assets for movies.",
+    "files": [
+      {
+        "path": "assets/thumbnail.webp",
+        "required": true,
+        "format": "WebP",
+        "dimensions": {
+          "width": 1280,
+          "height": 720,
+          "aspect_ratio": "16:9"
+        },
+        "orientation": "horizontal",
+        "description": "Movie thumbnail image. Should be a movie poster or representative frame."
+      }
+    ]
+  },
+  "required": ["id", "title", "author", "publication_year", "duration", "language", "links", "description", "contributor_names", "tags"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/newsletter-scheme.json
+++ b/scripts/validation-format/schemas/newsletter-scheme.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "newsletter-characteristics",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the newsletter in UUID v4 format.",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "title": {
+      "type": "string",
+      "description": "Complete title of the newsletter."
+    },
+    "author": {
+      "type": "string",
+      "description": "Full name of the author(s) of the newsletter."
+    },
+    "level": {
+      "type": "string",
+      "description": "Difficulty level of the newsletter content from user's perspective.",
+      "enum": ["beginner", "intermediate", "advanced", "expert"]
+    },
+    "publication_date": {
+      "type": "string",
+      "description": "Date when the newsletter started, format: YYYY-MM-DD.",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "link": {
+      "type": "array",
+      "description": "List of links associated with the newsletter.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "website": {
+            "type": "string",
+            "description": "URL of the newsletter's website."
+          }
+        },
+        "required": ["website"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "language": {
+      "type": "string",
+      "description": "Language of the newsletter using ISO 639-1 language codes (e.g., en, es, zh-Hans)."
+    },
+    "description": {
+      "type": "string",
+      "description": "Multiline description of the newsletter content."
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of contributors identified by their GitHub usernames.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of tags associated with the newsletter from the PlanB tags list.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "license": {
+      "type": "string",
+      "description": "License for the newsletter content.",
+      "enum": ["CC-BY-SA-V4", "MIT"]
+    },
+    "project_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "UUID v4 linking this newsletter to a PlanB Network project."
+    }
+  },
+  "assets_rules": {
+    "description": "Required image assets for newsletters.",
+    "files": [
+      {
+        "path": "assets/thumbnail.webp",
+        "required": true,
+        "format": "WebP",
+        "dimensions": {
+          "width": 1280,
+          "height": 720,
+          "aspect_ratio": "16:9"
+        },
+        "orientation": "horizontal",
+        "description": "Newsletter thumbnail image."
+      }
+    ]
+  },
+  "required": ["id", "title", "author", "level", "publication_date", "link", "language", "description", "contributor_names", "tags"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/paper-scheme.json
+++ b/scripts/validation-format/schemas/paper-scheme.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Paper Schema",
+  "description": "Schema for validating paper.yml metadata files in resources/papers/",
+  "type": "object",
+  "required": [
+    "title",
+    "original_language",
+    "authors",
+    "abstract",
+    "paper_type",
+    "topics",
+    "pdf_url",
+    "id"
+  ],
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "The title of the paper",
+      "minLength": 1
+    },
+    "original_language": {
+      "type": "string",
+      "description": "ISO 639-1 language code of the original paper",
+      "pattern": "^[a-z]{2}(-[A-Z]{2})?$",
+      "default": "en"
+    },
+    "authors": {
+      "type": "array",
+      "description": "List of paper authors",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "abstract": {
+      "type": "string",
+      "description": "Paper abstract or summary",
+      "minLength": 10
+    },
+    "publication_date": {
+      "type": "string",
+      "description": "Publication date in YYYY-MM-DD format",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "paper_type": {
+      "type": "string",
+      "description": "Type of paper",
+      "enum": [
+        "whitepaper",
+        "conference",
+        "academic",
+        "pre-print",
+        "review",
+        "PhD Thesis",
+        "book"
+      ]
+    },
+    "source": {
+      "type": "string",
+      "description": "Publication source (journal, conference, website)",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "description": "Academic index type",
+      "enum": ["SCI", "SCIE", "SSCI"]
+    },
+    "category": {
+      "type": "string",
+      "description": "Academic category classification"
+    },
+    "topics": {
+      "type": "array",
+      "description": "List of topics covered by the paper",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "pdf_url": {
+      "type": "string",
+      "description": "URL to the PDF version of the paper",
+      "format": "uri"
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique identifier (UUID format)",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/podcast-scheme.json
+++ b/scripts/validation-format/schemas/podcast-scheme.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "podcast-characteristics",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "Unique identifier using UUID v4 format."
+    },
+    "name": {
+      "type": "string",
+      "description": "Complete name of the podcast."
+    },
+    "host": {
+      "type": "string",
+      "description": "Names of all hosts of the podcast."
+    },
+    "language": {
+      "type": "string",
+      "description": "Language of the podcast using ISO 639-1 language code (e.g. en, es, th) or extended codes (e.g. sr-Latn, zh-Hans)."
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "podcast": {
+          "type": "string",
+          "description": "Direct link to audio feed via the streaming service platform (e.g. Apple Podcasts, Spotify, Fountain)."
+        },
+        "twitter": {
+          "type": "string",
+          "description": "URL of the podcast's Twitter/X profile."
+        },
+        "website": {
+          "type": "string",
+          "description": "URL of the podcast's website."
+        },
+        "facebook": {
+          "type": "string",
+          "description": "URL of the podcast's Facebook page."
+        },
+        "youtube": {
+          "type": "string",
+          "description": "URL of the podcast's YouTube channel."
+        }
+      },
+      "required": ["podcast"],
+      "additionalProperties": false
+    },
+    "description": {
+      "type": "string",
+      "description": "Main description of the podcast content."
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of associated tags to the podcast from the PlanB Network tag list.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of contributors identified by their GitHub usernames who helped format, review and translate the content.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "license": {
+      "type": "string",
+      "enum": ["CC-BY-SA-V4", "MIT"],
+      "description": "License for the content. CC-BY-SA-V4 is the default (share-alike clause). MIT allows almost unrestricted use."
+    }
+  },
+  "assets_rules": {
+    "description": "Required image assets for podcasts.",
+    "files": [
+      {
+        "path": "assets/logo.webp",
+        "required": true,
+        "format": "WebP",
+        "dimensions": {
+          "width": 800,
+          "height": 800,
+          "aspect_ratio": "1:1"
+        },
+        "orientation": "square",
+        "description": "Podcast logo image. Recommended 800x800 pixels."
+      }
+    ]
+  },
+  "required": ["id", "name", "host", "language", "links", "description", "tags", "contributor_names"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/professor-content-scheme.json
+++ b/scripts/validation-format/schemas/professor-content-scheme.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "professor-content-characteristics",
+  "type": "object",
+  "properties": {
+    "bio": {
+      "type": "string",
+      "description": "Full biography of the professor. Multiline text allowed."
+    },
+    "short_bio": {
+      "type": "string",
+      "description": "A short one-line biography or tagline for the professor."
+    }
+  },
+  "required": ["bio", "short_bio"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/professor-scheme.json
+++ b/scripts/validation-format/schemas/professor-scheme.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Professor",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Full name of the professor"
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier (UUID) for the professor"
+    },
+    "links": {
+      "type": "object",
+      "description": "Online presence of the professor",
+      "properties": {
+        "twitter": {
+          "type": "string",
+          "format": "url",
+          "description": "Twitter URL of the professor"
+        },
+        "website": {
+          "type": "string",
+          "format": "url",
+          "description": "Personal or professional website of the professor"
+        }
+      },
+      "additionalProperties": true
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of tags associated with the professor's expertise and interests",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tips": {
+      "type": "object",
+      "description": "Information for direct tips to the professor",
+      "properties": {
+        "lightning_address": {
+          "type": "string",
+          "description": "Lightning network address for tips"
+        },
+        "silent_payment": {
+          "type": "string",
+          "description": "Silent payment address for tips"
+        }
+      },
+      "additionalProperties": true
+    },
+    "company": {
+      "type": "string",
+      "description": "Name of the company the professor is affiliated with"
+    },
+    "affiliations": {
+      "type": "array",
+      "description": "List of affiliations the professor has within the industry or elsewhere",
+      "items": {
+        "type": "string"
+      }
+    },
+    "assets_rules": {
+      "type": "object",
+      "description": "Documentation of required asset files for professors",
+      "properties": {
+        "profile": {
+          "type": "object",
+          "description": "Professor profile picture requirements",
+          "properties": {
+            "path": {
+              "type": "string",
+              "const": "assets/profile.webp",
+              "description": "Path to the profile image file"
+            },
+            "required": {
+              "type": "boolean",
+              "const": true,
+              "description": "This asset is required"
+            },
+            "format": {
+              "type": "string",
+              "const": "webp",
+              "description": "Image format must be WebP"
+            },
+            "aspect_ratio": {
+              "type": "string",
+              "const": "1:1",
+              "description": "Square aspect ratio required"
+            },
+            "recommended_dimensions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": ["400x400", "800x800"],
+              "description": "Recommended pixel dimensions"
+            },
+            "content": {
+              "type": "string",
+              "const": "Professor's face or avatar",
+              "description": "What the image should contain"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["name", "id"],
+  "additionalProperties": false
+}
+

--- a/scripts/validation-format/schemas/project-content-scheme.json
+++ b/scripts/validation-format/schemas/project-content-scheme.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "language-specific-builder-characteristics",
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "A detailed description of the builder, which can span multiple lines."
+    }
+  },
+  "required": ["description"],
+  "additionalProperties": false
+}
+

--- a/scripts/validation-format/schemas/project-scheme.json
+++ b/scripts/validation-format/schemas/project-scheme.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "project-scheme",
+  "description": "Schema for project (non-community-builder) content in the PlanB Network repository.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the project (UUID format).",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Project's complete name."
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "wallet", "Wallet",
+        "infrastructure", "Infrastructure",
+        "exchange", "Exchange",
+        "education", "Education",
+        "service", "Service",
+        "conference", "Conference",
+        "privacy", "Privacy",
+        "investment", "Investment",
+        "node", "Node",
+        "mining", "Mining",
+        "news", "News",
+        "manufacturer", "Manufacturer",
+        "communities", "Communities",
+        "merchant", "Merchant",
+        "payment", "Payment"
+      ],
+      "description": "Define project category. Only specific categories are allowed."
+    },
+    "licence": {
+      "type": "string",
+      "description": "License type for the project content (e.g., CC-BY-SA-V4)."
+    },
+    "language": {
+      "type": ["string", "array"],
+      "description": "Primary language(s) of the project."
+    },
+    "links": {
+      "type": ["object", "array"],
+      "properties": {
+        "website": {
+          "type": ["string", "null"],
+          "description": "URL of the project's website."
+        },
+        "twitter": {
+          "type": ["string", "null"],
+          "description": "URL of the project's Twitter profile."
+        },
+        "github": {
+          "type": ["string", "null"],
+          "description": "URL of the project's Github profile."
+        },
+        "Github": {
+          "type": ["string", "null"],
+          "description": "URL of the project's Github profile (alternate casing)."
+        },
+        "youtube": {
+          "type": ["string", "null"],
+          "description": "URL of the project's YouTube channel."
+        },
+        "nostr": {
+          "type": ["string", "null"],
+          "description": "Nostr public key or NIP-05 identifier."
+        },
+        "Nostr": {
+          "type": ["string", "null"],
+          "description": "Nostr public key or NIP-05 identifier (alternate casing)."
+        },
+        "nost": {
+          "type": ["string", "null"],
+          "description": "Nostr public key (typo variant)."
+        },
+        "instagram": {
+          "type": ["string", "null"],
+          "description": "URL of the project's Instagram profile."
+        },
+        "linkedin": {
+          "type": ["string", "null"],
+          "description": "URL of the project's LinkedIn profile."
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags associated with links.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of associated tags to the project.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "original_language": {
+      "type": ["string", "array"],
+      "description": "ISO 639-1 language code of the original content language."
+    },
+    "proofreading": {
+      "type": "array",
+      "description": "Proofreading metadata for each language translation. Must include at least the original language.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "ISO 639-1 language code for this translation.",
+            "pattern": "^[a-z]{2}(-[A-Za-z]{2,4})?$"
+          },
+          "last_contribution_date": {
+            "type": ["string", "null"],
+            "description": "Date of last contribution in YYYY-MM-DD format.",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "urgency": {
+            "type": ["integer", "null"],
+            "description": "Urgency level for proofreading (1-5).",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "contributor_names": {
+            "type": ["array", "null"],
+            "description": "List of contributor usernames for this translation.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "reward": {
+            "type": ["number", "null"],
+            "description": "Reward amount for proofreading this translation."
+          }
+        },
+        "required": ["language"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "contributor_names": {
+      "type": "array",
+      "description": "List of all contributor usernames for this project.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "address_line_1": {
+      "type": ["string", "null"],
+      "description": "First line of physical address (for physical locations)."
+    },
+    "address_line_2": {
+      "type": ["string", "null"],
+      "description": "Second line of physical address."
+    },
+    "address_line_3": {
+      "type": ["string", "null"],
+      "description": "Third line of physical address."
+    },
+    "address_city_country": {
+      "type": ["string", "null"],
+      "description": "City and country of physical address."
+    }
+  },
+  "assets_rules": {
+    "description": "Required image assets for project content.",
+    "files": [
+      {
+        "path": "assets/logo.webp",
+        "required": true,
+        "format": "WebP",
+        "dimensions": {
+          "aspect_ratio": "1:1",
+          "recommended": "800x800 pixels"
+        },
+        "description": "Project logo"
+      }
+    ]
+  },
+  "required": ["id", "name", "category", "links", "original_language", "proofreading"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/quizz-question-scheme.json
+++ b/scripts/validation-format/schemas/quizz-question-scheme.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "quiz-question",
+  "type": "object",
+  "properties": {
+    "chapterId": {
+      "type": "string",
+      "description": "Defines the chapter this question is related to, using the chapterId."
+    },
+    "difficulty": {
+      "type": "string",
+      "description": "Difficulty level of the question.",
+      "enum": ["easy", "intermediate", "hard", "expert"]
+    },
+    "author": {
+      "type": "string",
+      "description": "The contribution-id of the author of the question."
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of tags associated with the question.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["chapterId", "difficulty", "author", "tags"],
+  "additionalProperties": false
+}
+

--- a/scripts/validation-format/schemas/quizz-translation-scheme.json
+++ b/scripts/validation-format/schemas/quizz-translation-scheme.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "quiz-question-content",
+  "type": "object",
+  "properties": {
+    "question": {
+      "type": "string",
+      "description": "The complete question text."
+    },
+    "answer": {
+      "type": "string",
+      "description": "The correct answer to the question."
+    },
+    "wrong_answers": {
+      "type": "array",
+      "description": "A list of three incorrect answers to the question.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "explanation": {
+      "type": "string",
+      "description": "Additional information explaining why the correct answer is true and why the other answers are incorrect."
+    },
+    "reviewed": {
+      "type": "boolean",
+      "description": "Indicates whether the question has been reviewed by at least two different persons."
+    }
+  },
+  "required": ["question", "answer", "wrong_answers", "explanation", "reviewed"],
+  "additionalProperties": false
+}
+

--- a/scripts/validation-format/schemas/tutorial-content-scheme.json
+++ b/scripts/validation-format/schemas/tutorial-content-scheme.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tutorial-content",
+  "description": "Schema for validating tutorial markdown content files (e.g., en.md, fr.md)",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Tutorial title/name displayed as the main heading",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "description": {
+      "type": "string",
+      "description": "Brief description of what the tutorial covers, used for SEO and previews",
+      "maxLength": 1000
+    }
+  },
+  "required": ["name", "description"],
+  "additionalProperties": false,
+  "content_rules": {
+    "description": "Structural requirements for tutorial markdown content following YAML front-matter",
+    "cover_image": {
+      "required": true,
+      "description": "Cover image MUST appear within the first 10 lines after YAML front-matter closing '---'.",
+      "pattern": "![{any-alt-text}](assets/cover.webp)",
+      "pattern_regex": "!\\[.*\\]\\(assets/cover\\.webp\\)",
+      "alt_text": "Any text is allowed as alt text",
+      "path": "assets/cover.webp (must be exact)",
+      "format": "WebP only",
+      "aspect_ratio": "1280x720 (16:9)"
+    },
+    "video_embeds": {
+      "required": false,
+      "description": "Optional video embeds using YouTube URLs",
+      "patterns": [
+        "![video](https://youtu.be/VIDEO_ID)",
+        "![video](https://www.youtube.com/watch?v=VIDEO_ID)"
+      ]
+    },
+    "headings": {
+      "h1": {
+        "allowed": false,
+        "reason": "Title comes from YAML 'name' field, do NOT use H1 in content",
+        "exception": "H1 headings inside code blocks (fenced with ``` or ~~~, or indented) are allowed and not validated"
+      },
+      "h2": {
+        "allowed": true,
+        "description": "Main chapters - appears in sidebar navigation",
+        "pattern": "## Chapter Title"
+      },
+      "h3": {
+        "allowed": true,
+        "description": "Sub-sections within chapters",
+        "pattern": "### Sub-section Title"
+      }
+    },
+    "lists": {
+      "unordered": {
+        "marker": "-",
+        "description": "Use dash (-) for unordered lists, NEVER asterisk (*)",
+        "reason": "Asterisk conflicts with translation systems and bold formatting"
+      },
+      "ordered": {
+        "marker": "1.",
+        "description": "Use numbered format for ordered lists"
+      }
+    },
+    "notes": {
+      "description": "Emphasized callout notes using bold prefix",
+      "patterns": [
+        "**Note**:",
+        "**Info**:",
+        "**Attention**:",
+        "**Warning**:",
+        "**Tip**:"
+      ]
+    },
+    "internal_links": {
+      "description": "Links to other PlanB Network content",
+      "format": "Must be on their own line with empty lines before and after",
+      "example": "\n\nhttps://planb.network/tutorials/wallet/sparrow\n\n"
+    },
+    "images": {
+      "format": "WebP only (.webp extension)",
+      "types": {
+        "cover": {
+          "path": "assets/cover.webp",
+          "required": true,
+          "dimensions": "1280x720 aspect ratio",
+          "alt_text": "Any text allowed",
+          "position": "Must appear within first 10 lines after front-matter"
+        },
+        "language_specific": {
+          "path_pattern": "assets/{lang}/{number}.webp",
+          "examples": ["assets/en/01.webp", "assets/fr/01.webp"],
+          "description": "Screenshots with text that needs translation"
+        },
+        "universal": {
+          "path_pattern": "assets/notext/{number}.webp",
+          "examples": ["assets/notext/1.webp", "assets/notext/2.webp"],
+          "description": "Images without text, shared across all languages"
+        }
+      },
+      "alt_text": {
+        "required": true,
+        "description": "All images should have descriptive alt text"
+      }
+    },
+    "yaml_front_matter": {
+      "required": true,
+      "description": "YAML front-matter block at the start of the file",
+      "format": "Delimited by --- on separate lines",
+      "example": "---\nname: Tutorial Name\ndescription: Tutorial description\n---"
+    }
+  }
+}

--- a/scripts/validation-format/schemas/tutorial-scheme.json
+++ b/scripts/validation-format/schemas/tutorial-scheme.json
@@ -40,7 +40,9 @@
         "operating system",
         "data",
         "tutorial",
-        "resource"
+        "resource",
+        "content",
+        "explorer"
       ]
     },
     "professor_id": {
@@ -69,11 +71,6 @@
       "type": "string",
       "description": "ISO 639-1 language code of the original tutorial language",
       "pattern": "^[a-z]{2}(-[A-Za-z]{2,4})?$"
-    },
-    "last_update_date": {
-      "type": "string",
-      "description": "Date of the last content update in YYYY-MM-DD format",
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
     },
     "proofreading": {
       "type": "array",
@@ -243,7 +240,6 @@
     "professor_id",
     "license",
     "original_language",
-    "last_update_date",
     "proofreading"
   ],
   "additionalProperties": false

--- a/scripts/validation-format/schemas/word-content-scheme.json
+++ b/scripts/validation-format/schemas/word-content-scheme.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "glossary-word-content",
+  "description": "Schema for validating glossary word markdown files (e.g., en.md, fr.md). These files contain YAML front-matter with the term field and markdown content defining the glossary term.",
+  "type": "object",
+  "properties": {
+    "frontmatter": {
+      "type": "object",
+      "description": "YAML front-matter block enclosed by --- delimiters at the start of the file",
+      "properties": {
+        "term": {
+          "type": "string",
+          "description": "The glossary term in UPPERCASE. May include parenthetical additions for abbreviations, opcodes, or clarifications (e.g., 'SATOSHI (SAT)', 'OP_ROLL (0X7A)', 'HOT WALLET (SOFTWARE)'). Numbers should be written out (e.g., '51 PERCENT ATTACK' not '51%').",
+          "pattern": "^[A-Z0-9][A-Z0-9 _+-]*(?:\\s*\\([A-Z0-9 ]+\\))?$",
+          "examples": [
+            "WALLET",
+            "SATOSHI (SAT)",
+            "51 PERCENT ATTACK",
+            "OP_ROLL (0X7A)",
+            "SHA256",
+            "C++ (PLUS PLUS)",
+            "API"
+          ]
+        }
+      },
+      "required": ["term"],
+      "additionalProperties": false
+    },
+    "content_rules": {
+      "type": "object",
+      "description": "Documentation of markdown content structural requirements. This property describes validation rules that should be enforced by content validators.",
+      "properties": {
+        "definition_paragraph": {
+          "type": "object",
+          "description": "The primary definition paragraph immediately following the YAML front-matter",
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "const": true,
+              "description": "A definition paragraph is required immediately after the front-matter"
+            },
+            "position": {
+              "type": "string",
+              "const": "immediately_after_frontmatter",
+              "description": "Must appear directly after the closing --- of the front-matter"
+            },
+            "guidelines": {
+              "type": "array",
+              "description": "Content guidelines for the definition paragraph",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "Defines what the term is in clear, technical language",
+                "For acronyms, start with: Acronym for \"[Full Name]\".",
+                "Should be comprehensive but concise",
+                "Use backticks for technical terms: `scriptPubKey`, `SHA256`"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "additional_paragraphs": {
+          "type": "object",
+          "description": "Optional extended explanation paragraphs",
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "const": false,
+              "description": "Additional paragraphs are optional"
+            },
+            "guidelines": {
+              "type": "array",
+              "description": "Content guidelines for additional paragraphs",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "Provide deeper technical explanation if needed",
+                "Include examples, use cases, or historical context",
+                "May include bulleted or numbered lists"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "code_formatting": {
+          "type": "object",
+          "description": "Rules for inline code and code blocks",
+          "properties": {
+            "inline_code": {
+              "type": "string",
+              "const": "backticks",
+              "description": "Use single backticks for technical terms: `scriptPubKey`, `SHA256`, `HASH160`"
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "`scriptPubKey`",
+                "`SHA256`",
+                "`RIPEMD160`",
+                "`OP_CHECKSIG`"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "math_formulas": {
+          "type": "object",
+          "description": "Rules for mathematical formulas using LaTeX notation",
+          "properties": {
+            "inline_format": {
+              "type": "string",
+              "const": "$formula$",
+              "description": "Single dollar signs for inline math"
+            },
+            "block_format": {
+              "type": "string",
+              "const": "$$formula$$",
+              "description": "Double dollar signs for block/display math"
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "$y^2 = x^3 + 7$",
+                "$H(m_1) = H(m_2)$",
+                "$$s_A = n_A + t + H(N_A + T \\parallel P_A \\parallel m_A) \\cdot p_A$$"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "images": {
+          "type": "object",
+          "description": "Rules for including images in glossary definitions",
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "const": false,
+              "description": "Images are optional"
+            },
+            "format": {
+              "type": "string",
+              "const": "![](relative/path/to/image.webp)",
+              "description": "Standard markdown image syntax with empty alt text"
+            },
+            "path_pattern": {
+              "type": "string",
+              "const": "../../dictionnaire/assets/XX.webp",
+              "description": "Relative path from word directory to assets folder"
+            },
+            "preferred_format": {
+              "type": "string",
+              "const": "webp",
+              "description": "Preferred image format is WebP"
+            }
+          },
+          "additionalProperties": false
+        },
+        "alternative_names_blockquote": {
+          "type": "object",
+          "description": "Optional blockquote at the END of the file containing alternative names, translations, or etymology",
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "const": false,
+              "description": "Alternative names blockquote is optional"
+            },
+            "position": {
+              "type": "string",
+              "const": "end_of_file",
+              "description": "MUST appear at the very end of the file if present"
+            },
+            "format": {
+              "type": "string",
+              "const": "> *text in italics*",
+              "description": "Blockquote with arrow symbol and italicized text"
+            },
+            "pattern": {
+              "type": "string",
+              "const": "^> ► \\*.*\\*$",
+              "description": "Regex pattern: starts with '> ► *' and ends with '*'"
+            },
+            "content_types": {
+              "type": "array",
+              "description": "Types of content that appear in the alternative names blockquote",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "Alternative English names for the term",
+                "French translation or equivalent term",
+                "Etymology or origin notes",
+                "Related terminology clarifications"
+              ]
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "> ► *This attack is also known as the \"Goldfinger attack\".*",
+                "> ► *In French, this is translated as \"interface de programmation d'applications\" or simply \"interface de programmation.\"*",
+                "> ► *In English, it is referred to as a \"hash function\".*"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "links": {
+          "type": "object",
+          "description": "Rules for hyperlinks in content",
+          "properties": {
+            "format": {
+              "type": "string",
+              "const": "[text](url)",
+              "description": "Standard markdown link syntax"
+            },
+            "guidelines": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "Use descriptive link text, not raw URLs",
+                "Prefer linking to primary sources (BIPs, papers, official repos)",
+                "External links should point to stable, reliable resources"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["frontmatter"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/schemas/word-scheme.json
+++ b/scripts/validation-format/schemas/word-scheme.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "word-characteristics",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the glossary word using UUID v4 format",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "en_word": {
+      "type": "string",
+      "description": "The word in English, typically in uppercase. This is the basis for identifying the word in the glossary"
+    },
+    "related_words": {
+      "type": ["array", "null"],
+      "description": "List of related words in the glossary, using their en_word names",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "description": "List of tags associated with the word, chosen from the predefined PlanB tags list",
+      "items": {
+        "type": "string"
+      }
+    },
+    "original_language": {
+      "type": "string",
+      "description": "ISO 639-1 language code indicating the original language of the word definition",
+      "pattern": "^[a-z]{2}(-[A-Z]{2}|-[A-Za-z]{4})?$"
+    },
+    "license": {
+      "type": "string",
+      "description": "License under which the content is distributed",
+      "enum": ["CC-BY-SA-V4", "MIT"]
+    },
+    "proofreading": {
+      "type": "array",
+      "description": "Proofreading metadata for each language translation",
+      "items": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "ISO 639-1 language code for this proofreading entry",
+            "pattern": "^[a-z]{2}(-[A-Z]{2}|-[A-Za-z]{4})?$"
+          },
+          "last_contribution_date": {
+            "description": "Date of the last contribution in YYYY-MM-DD format, or null if not yet contributed"
+          },
+          "urgency": {
+            "type": "integer",
+            "description": "Level of urgency for proofreading, 1 being low urgency",
+            "minimum": 1
+          },
+          "contributor_names": {
+            "type": ["array", "null"],
+            "description": "List of contributor GitHub usernames who have proofread this language",
+            "items": {
+              "type": "string"
+            }
+          },
+          "reward": {
+            "type": "number",
+            "description": "Amount of sats available as reward for proofreading",
+            "minimum": 0
+          }
+        },
+        "required": ["language", "urgency", "reward"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["id", "en_word", "original_language", "proofreading"],
+  "additionalProperties": false
+}

--- a/scripts/validation-format/validate.py
+++ b/scripts/validation-format/validate.py
@@ -1,0 +1,881 @@
+#!/usr/bin/env python3
+"""
+PlanB Network Content Schema Validator
+
+Validates content folders against JSON schema definitions.
+Checks both YAML metadata files and markdown content files.
+
+The validator auto-detects the repository root and uses centralized schemas
+from scripts/validation-format/schemas/.
+
+Usage:
+    python validate.py <folder_path>
+    python validate.py courses/btc101
+    python validate.py tutorials/wallet/sparrow-wallet
+    python validate.py professors/pbn-author
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    import jsonschema
+    from jsonschema import Draft7Validator, ValidationError as JsonSchemaError
+except ImportError:
+    print("Error: jsonschema package required. Install with: pip install jsonschema")
+    sys.exit(1)
+
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML package required. Install with: pip install pyyaml")
+    sys.exit(1)
+
+try:
+    import frontmatter
+except ImportError:
+    print("Error: python-frontmatter package required. Install with: pip install python-frontmatter")
+    sys.exit(1)
+
+
+# ANSI color codes for terminal output
+class Colors:
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    BLUE = "\033[94m"
+    CYAN = "\033[96m"
+    BOLD = "\033[1m"
+    END = "\033[0m"
+
+
+@dataclass
+class ValidationResult:
+    """Holds validation results for a single file or content check."""
+    file_path: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+    def add_error(self, msg: str):
+        self.errors.append(msg)
+
+    def add_warning(self, msg: str):
+        self.warnings.append(msg)
+
+
+@dataclass
+class ContentTypeConfig:
+    """Configuration for a content type."""
+    name: str
+    yaml_file: str  # e.g., "tutorial.yml", "professor.yml"
+    schema_file: str  # e.g., "tutorial-scheme.json"
+    content_schema_file: Optional[str] = None  # e.g., "tutorial-content-scheme.json"
+    has_markdown_content: bool = True
+    content_uses_frontmatter: bool = True  # True for .md files with YAML frontmatter
+    content_uses_yml: bool = False  # True for .yml content files (e.g., books, bet)
+    has_quizzes: bool = False  # True for content types with quizz subfolder
+
+
+# Content type configurations
+CONTENT_TYPES: dict[str, ContentTypeConfig] = {
+    "tutorials": ContentTypeConfig(
+        name="Tutorial",
+        yaml_file="tutorial.yml",
+        schema_file="tutorial-scheme.json",
+        content_schema_file="tutorial-content-scheme.json",
+    ),
+    "courses": ContentTypeConfig(
+        name="Course",
+        yaml_file="course.yml",
+        schema_file="course-scheme.json",
+        content_schema_file="course-content-scheme.json",
+        has_quizzes=True,
+    ),
+    "professors": ContentTypeConfig(
+        name="Professor",
+        yaml_file="professor.yml",
+        schema_file="professor-scheme.json",
+        content_schema_file="professor-content-scheme.json",
+    ),
+    "events": ContentTypeConfig(
+        name="Event",
+        yaml_file="event.yml",
+        schema_file="event-scheme.json",
+        has_markdown_content=False,
+    ),
+    "resources/bet": ContentTypeConfig(
+        name="BET",
+        yaml_file="bet.yml",
+        schema_file="bet-scheme.json",
+        content_schema_file="bet-content-scheme.json",
+        content_uses_yml=True,
+    ),
+    "resources/books": ContentTypeConfig(
+        name="Book",
+        yaml_file="book.yml",
+        schema_file="book-scheme.json",
+        content_schema_file="book-content-scheme.json",
+        content_uses_yml=True,
+    ),
+    "resources/channels": ContentTypeConfig(
+        name="Channel",
+        yaml_file="channel.yml",
+        schema_file="channel-scheme.json",
+        has_markdown_content=False,
+    ),
+    "resources/conferences": ContentTypeConfig(
+        name="Conference",
+        yaml_file="conference.yml",
+        schema_file="conference-scheme.json",
+        has_markdown_content=False,
+    ),
+    "resources/glossary": ContentTypeConfig(
+        name="Glossary Word",
+        yaml_file="word.yml",
+        schema_file="word-scheme.json",
+        content_schema_file="word-content-scheme.json",
+    ),
+    "resources/movies": ContentTypeConfig(
+        name="Movie",
+        yaml_file="movie.yml",
+        schema_file="movie-scheme.json",
+        has_markdown_content=False,
+    ),
+    "resources/newsletters": ContentTypeConfig(
+        name="Newsletter",
+        yaml_file="newsletter.yml",
+        schema_file="newsletter-scheme.json",
+        has_markdown_content=False,
+    ),
+    "resources/podcasts": ContentTypeConfig(
+        name="Podcast",
+        yaml_file="podcast.yml",
+        schema_file="podcast-scheme.json",
+        has_markdown_content=False,
+    ),
+    "resources/projects": ContentTypeConfig(
+        name="Project",
+        yaml_file="project.yml",
+        schema_file="project-scheme.json",
+        content_schema_file="project-content-scheme.json",
+        content_uses_yml=True,
+    ),
+    "resources/papers": ContentTypeConfig(
+        name="Paper",
+        yaml_file="paper.yml",
+        schema_file="paper-scheme.json",
+        has_markdown_content=False,
+    ),
+}
+
+
+class SchemaValidator:
+    """Validates content folders against JSON schemas."""
+
+    def __init__(self, base_path: str):
+        self.base_path = Path(base_path).resolve()
+        # Schema path is now centralized in scripts/validation-format/schemas/
+        self.schema_path = self.base_path / "scripts" / "validation-format" / "schemas"
+        self.results: list[ValidationResult] = []
+
+    def _find_repo_root(self, folder_path: Path) -> Path:
+        """Find the repository root by looking for .git directory (primary) or known directories (fallback)."""
+        current = folder_path
+        # First pass: look for .git (most reliable)
+        for _ in range(15):  # Max 15 levels up
+            if (current / ".git").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+
+        # Second pass: fallback to known directory structure
+        current = folder_path
+        for _ in range(15):
+            if all((current / d).exists() for d in ["courses", "tutorials", "professors"]):
+                # Make sure we're not in a template/docs subfolder
+                if "docs" not in current.parts[-3:] and "PBN-template-repo" not in current.parts:
+                    return current
+            if current.parent == current:
+                break
+            current = current.parent
+        return folder_path
+
+    def detect_content_type(self, folder_path: Path) -> Optional[ContentTypeConfig]:
+        """Detect content type from folder path."""
+        # First, find the repo root relative to the folder
+        repo_root = self._find_repo_root(folder_path)
+
+        try:
+            rel_path = str(folder_path.relative_to(repo_root))
+        except ValueError:
+            # If folder is not relative to found repo root, try using base_path
+            try:
+                rel_path = str(folder_path.relative_to(self.base_path))
+            except ValueError:
+                # Last resort: use folder name parts to detect type
+                rel_path = str(folder_path)
+
+        # Check for nested content types (tutorials have category subfolder)
+        parts = rel_path.split(os.sep)
+
+        # Try matching from most specific to least specific
+        for content_path, config in CONTENT_TYPES.items():
+            content_parts = content_path.split("/")
+            if parts[:len(content_parts)] == content_parts:
+                return config
+
+        return None
+
+    def find_schema_file(self, config: ContentTypeConfig) -> Optional[Path]:
+        """Find the schema file for the content type from centralized location."""
+        schema_file = self.schema_path / config.schema_file
+        if schema_file.exists():
+            return schema_file
+        return None
+
+    def find_content_schema_file(self, config: ContentTypeConfig) -> Optional[Path]:
+        """Find the content schema file for the content type from centralized location."""
+        if not config.content_schema_file:
+            return None
+
+        schema_file = self.schema_path / config.content_schema_file
+        if schema_file.exists():
+            return schema_file
+        return None
+
+    def load_json_schema(self, schema_path: Path) -> dict:
+        """Load a JSON schema file."""
+        with open(schema_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    def load_yaml_file(self, yaml_path: Path) -> dict:
+        """Load a YAML file."""
+        with open(yaml_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f) or {}
+        # Convert datetime objects to strings for JSON schema validation
+        return self._convert_dates_to_strings(data)
+
+    def _convert_dates_to_strings(self, obj: Any) -> Any:
+        """Recursively convert datetime.date and datetime.datetime objects to ISO format strings."""
+        if isinstance(obj, datetime):
+            return obj.strftime("%Y-%m-%d %H:%M:%S")
+        elif isinstance(obj, date):
+            return obj.strftime("%Y-%m-%d")
+        elif isinstance(obj, dict):
+            return {k: self._convert_dates_to_strings(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._convert_dates_to_strings(item) for item in obj]
+        return obj
+
+    def _find_and_remove_null_values(self, obj: Any, path: str = "") -> tuple[Any, list[str]]:
+        """
+        Recursively find null values and remove them from the data structure.
+        Returns the cleaned object and a list of paths where null values were found.
+        """
+        null_paths = []
+
+        if obj is None:
+            return None, [path] if path else []
+        elif isinstance(obj, dict):
+            cleaned = {}
+            for k, v in obj.items():
+                current_path = f"{path} -> {k}" if path else k
+                if v is None:
+                    null_paths.append(current_path)
+                    # Don't include null values in cleaned dict
+                else:
+                    cleaned_v, sub_nulls = self._find_and_remove_null_values(v, current_path)
+                    null_paths.extend(sub_nulls)
+                    if cleaned_v is not None:
+                        cleaned[k] = cleaned_v
+            return cleaned, null_paths
+        elif isinstance(obj, list):
+            cleaned = []
+            for i, item in enumerate(obj):
+                current_path = f"{path}[{i}]"
+                if item is None:
+                    null_paths.append(current_path)
+                else:
+                    cleaned_item, sub_nulls = self._find_and_remove_null_values(item, current_path)
+                    null_paths.extend(sub_nulls)
+                    if cleaned_item is not None:
+                        cleaned.append(cleaned_item)
+            return cleaned, null_paths
+        return obj, null_paths
+
+    def validate_yaml_against_schema(self, yaml_data: dict, schema: dict, file_path: str) -> ValidationResult:
+        """Validate YAML data against a JSON schema."""
+        result = ValidationResult(file_path=file_path)
+
+        # Find and remove null values, reporting them as warnings
+        cleaned_data, null_paths = self._find_and_remove_null_values(yaml_data)
+        for null_path in null_paths:
+            result.add_warning(f"[{null_path}] Empty/null value")
+
+        validator = Draft7Validator(schema)
+        errors = list(validator.iter_errors(cleaned_data))
+
+        for error in errors:
+            path = " -> ".join(str(p) for p in error.absolute_path) if error.absolute_path else "root"
+            result.add_error(f"[{path}] {error.message}")
+
+        return result
+
+    def validate_markdown_content(self, md_path: Path, content_schema: dict) -> ValidationResult:
+        """Validate markdown content file against content schema."""
+        result = ValidationResult(file_path=str(md_path))
+
+        try:
+            post = frontmatter.load(md_path)
+        except Exception as e:
+            result.add_error(f"Failed to parse markdown file: {e}")
+            return result
+
+        # Validate frontmatter against schema properties
+        schema_props = content_schema.get("properties", {})
+        required_fields = content_schema.get("required", [])
+
+        # Check required frontmatter fields
+        for field in required_fields:
+            if field not in post.metadata:
+                result.add_error(f"Missing required frontmatter field: '{field}'")
+
+        # Validate frontmatter field types and constraints
+        for field, value in post.metadata.items():
+            if field in schema_props:
+                field_schema = schema_props[field]
+                self._validate_field(result, field, value, field_schema)
+
+        # Validate content rules if present
+        content_rules = content_schema.get("content_rules", {})
+        if content_rules:
+            self._validate_content_rules(result, post.content, content_rules, md_path)
+
+        return result
+
+    def _validate_field(self, result: ValidationResult, field: str, value: Any, schema: dict):
+        """Validate a single field against its schema."""
+        expected_type = schema.get("type")
+
+        type_mapping = {
+            "string": str,
+            "integer": int,
+            "number": (int, float),
+            "boolean": bool,
+            "array": list,
+            "object": dict,
+        }
+
+        if expected_type and expected_type in type_mapping:
+            expected = type_mapping[expected_type]
+            if not isinstance(value, expected):
+                result.add_error(f"Field '{field}' should be {expected_type}, got {type(value).__name__}")
+
+        # Check minLength/maxLength for strings
+        if expected_type == "string" and isinstance(value, str):
+            min_len = schema.get("minLength")
+            max_len = schema.get("maxLength")
+            if min_len and len(value) < min_len:
+                result.add_error(f"Field '{field}' is too short (min {min_len} chars)")
+            if max_len and len(value) > max_len:
+                result.add_error(f"Field '{field}' is too long (max {max_len} chars)")
+
+        # Check enum values
+        if "enum" in schema and value not in schema["enum"]:
+            result.add_error(f"Field '{field}' has invalid value '{value}'. Allowed: {schema['enum']}")
+
+    def _validate_content_rules(self, result: ValidationResult, content: str, rules: dict, md_path: Path):
+        """Validate markdown content against content rules."""
+        lines = content.split('\n')
+
+        # Check cover image
+        cover_rule = rules.get("cover_image", {})
+        if cover_rule.get("required", False):
+            # Cover must appear within the first 10 lines after frontmatter
+            # Pattern: ![any-alt-text](cover.webp) or ![any-alt-text](assets/cover.webp)
+            cover_pattern = re.compile(r'!\[.*?\]\((?:assets/)?cover\.webp\)')
+            first_10_lines = '\n'.join(lines[:10])
+            if not cover_pattern.search(first_10_lines):
+                result.add_error("Cover image ![...](cover.webp) or ![...](assets/cover.webp) must appear within the first 10 lines after YAML front-matter")
+
+        # Check headings
+        heading_rules = rules.get("headings", {})
+        h1_rule = heading_rules.get("h1", {})
+        if h1_rule.get("allowed") is False:
+            # Remove code blocks before checking for H1 headings
+            # Remove fenced code blocks (``` or ~~~)
+            content_no_code = re.sub(r'```[\s\S]*?```', '', content)
+            content_no_code = re.sub(r'~~~[\s\S]*?~~~', '', content_no_code)
+            # Remove indented code blocks (4 spaces or 1 tab at line start)
+            content_no_code = re.sub(r'^(?:    |\t).*$', '', content_no_code, flags=re.MULTILINE)
+
+            h1_matches = re.findall(r'^# [^#]', content_no_code, re.MULTILINE)
+            if h1_matches:
+                result.add_error("H1 headings (# Title) are not allowed - title comes from YAML 'name' field")
+
+        # Check list markers
+        list_rules = rules.get("lists", {})
+        unordered_rule = list_rules.get("unordered", {})
+        if unordered_rule.get("marker") == "-":
+            # Check for asterisk list markers
+            asterisk_lists = re.findall(r'^\* ', content, re.MULTILINE)
+            if asterisk_lists:
+                result.add_warning(f"Found {len(asterisk_lists)} asterisk (*) list markers. Use dash (-) instead.")
+
+        # Check images format
+        image_rules = rules.get("images", {})
+        if image_rules.get("format") == "WebP only (.webp extension)":
+            non_webp = re.findall(r'!\[.*?\]\([^)]+\.(png|jpg|jpeg|gif)\)', content, re.IGNORECASE)
+            if non_webp:
+                result.add_error(f"Non-WebP images found. All images must be .webp format.")
+
+        # Check for alt text on images
+        alt_text_rule = image_rules.get("alt_text", {})
+        if alt_text_rule.get("required"):
+            empty_alt = re.findall(r'!\[\]\(', content)
+            if empty_alt:
+                result.add_warning(f"Found {len(empty_alt)} images without alt text")
+
+        # Check assets folder exists
+        assets_path = md_path.parent / "assets"
+        if cover_rule.get("required") and not assets_path.exists():
+            result.add_error("Assets folder is missing")
+
+        # Check cover.webp exists
+        if cover_rule.get("required") and assets_path.exists():
+            cover_path = assets_path / "cover.webp"
+            if not cover_path.exists():
+                result.add_error("Cover image 'assets/cover.webp' is missing")
+
+    def validate_yml_content(self, yml_path: Path, content_schema: dict) -> ValidationResult:
+        """Validate YML content files (used by books, bet, etc.)."""
+        result = ValidationResult(file_path=str(yml_path))
+
+        try:
+            data = self.load_yaml_file(yml_path)
+        except Exception as e:
+            result.add_error(f"Failed to parse YAML file: {e}")
+            return result
+
+        # Use JSON schema validation
+        schema_props = content_schema.get("properties", {})
+        required_fields = content_schema.get("required", [])
+
+        for field in required_fields:
+            if field not in data:
+                result.add_error(f"Missing required field: '{field}'")
+
+        for field, value in data.items():
+            if field in schema_props:
+                self._validate_field(result, field, value, schema_props[field])
+
+        return result
+
+    def validate_quiz_folder(self, quiz_folder: Path) -> list[ValidationResult]:
+        """Validate a single quiz folder (e.g., quizz/000/)."""
+        results = []
+
+        # Check for question.yml (required)
+        question_file = quiz_folder / "question.yml"
+        if not question_file.exists():
+            result = ValidationResult(file_path=str(question_file))
+            result.add_error("Missing required file: question.yml")
+            results.append(result)
+            return results
+
+        # Validate question.yml structure
+        result = ValidationResult(file_path=str(question_file))
+        try:
+            data = self.load_yaml_file(question_file)
+
+            # Required fields in question.yml
+            required_fields = ["id", "chapterId", "difficulty", "duration", "author"]
+            for field in required_fields:
+                if field not in data:
+                    result.add_error(f"Missing required field: '{field}'")
+
+            # Validate UUID format for id and chapterId
+            uuid_pattern = r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+            if "id" in data and not re.match(uuid_pattern, str(data.get("id", "")), re.IGNORECASE):
+                result.add_error(f"Field 'id' is not a valid UUID: {data.get('id')}")
+            if "chapterId" in data and not re.match(uuid_pattern, str(data.get("chapterId", "")), re.IGNORECASE):
+                result.add_error(f"Field 'chapterId' is not a valid UUID: {data.get('chapterId')}")
+
+            # Validate difficulty enum
+            valid_difficulties = ["easy", "intermediate", "hard"]
+            if "difficulty" in data and data["difficulty"] not in valid_difficulties:
+                result.add_error(f"Field 'difficulty' has invalid value '{data['difficulty']}'. Allowed: {valid_difficulties}")
+
+            # Validate duration is a positive number
+            if "duration" in data:
+                if not isinstance(data["duration"], (int, float)) or data["duration"] <= 0:
+                    result.add_error(f"Field 'duration' must be a positive number, got: {data['duration']}")
+
+        except Exception as e:
+            result.add_error(f"Failed to parse question.yml: {e}")
+
+        results.append(result)
+
+        # Check for at least one translation file
+        translation_files = [f for f in quiz_folder.glob("*.yml") if f.name != "question.yml"]
+        if not translation_files:
+            result = ValidationResult(file_path=str(quiz_folder))
+            result.add_error("No translation files found (e.g., en.yml, fr.yml)")
+            results.append(result)
+        else:
+            # Validate each translation file structure
+            for trans_file in translation_files:
+                trans_result = self._validate_quiz_translation(trans_file)
+                if trans_result.errors or trans_result.warnings:
+                    results.append(trans_result)
+
+        return results
+
+    def _validate_quiz_translation(self, trans_file: Path) -> ValidationResult:
+        """Validate a quiz translation file (e.g., en.yml, fr.yml)."""
+        result = ValidationResult(file_path=str(trans_file))
+
+        try:
+            data = self.load_yaml_file(trans_file)
+
+            # Required fields in translation files
+            required_fields = ["question", "answer", "wrong_answers"]
+            for field in required_fields:
+                if field not in data:
+                    result.add_error(f"Missing required field: '{field}'")
+
+            # Validate wrong_answers is a list with at least 1 item
+            if "wrong_answers" in data:
+                if not isinstance(data["wrong_answers"], list):
+                    result.add_error("Field 'wrong_answers' must be a list")
+                elif len(data["wrong_answers"]) < 1:
+                    result.add_error("Field 'wrong_answers' must have at least 1 item")
+
+        except Exception as e:
+            result.add_error(f"Failed to parse translation file: {e}")
+
+        return result
+
+    def validate_quizzes(self, folder: Path) -> list[ValidationResult]:
+        """Validate all quizzes in a content folder's quizz/ subdirectory."""
+        results = []
+        quizz_folder = folder / "quizz"
+
+        if not quizz_folder.exists():
+            # Quiz folder is optional - just return empty results
+            return results
+
+        if not quizz_folder.is_dir():
+            result = ValidationResult(file_path=str(quizz_folder))
+            result.add_error("'quizz' exists but is not a directory")
+            return [result]
+
+        # Get all quiz subfolders (numbered folders like 000, 001, etc.)
+        # Skip hidden folders (starting with '.')
+        quiz_subfolders = sorted([d for d in quizz_folder.iterdir() if d.is_dir() and not d.name.startswith('.')])
+
+        if not quiz_subfolders:
+            result = ValidationResult(file_path=str(quizz_folder))
+            result.add_warning("Quiz folder exists but contains no quiz subfolders")
+            return [result]
+
+        # Validate each quiz subfolder
+        for quiz_folder in quiz_subfolders:
+            quiz_results = self.validate_quiz_folder(quiz_folder)
+            results.extend(quiz_results)
+
+        # Create summary result for quiz validation
+        summary_result = ValidationResult(file_path=str(quizz_folder))
+        total_quizzes = len(quiz_subfolders)
+        quizzes_with_errors = sum(1 for r in results if r.errors)
+
+        if quizzes_with_errors == 0:
+            # All quizzes valid - don't add to results (will show in summary)
+            pass
+        else:
+            summary_result.add_warning(f"Validated {total_quizzes} quizzes, {quizzes_with_errors} with errors")
+            results.insert(0, summary_result)
+
+        return results
+
+    def validate_folder(self, folder_path: str) -> list[ValidationResult]:
+        """Validate a content folder."""
+        folder = Path(folder_path)
+
+        if not folder.is_absolute():
+            # Try resolving from current directory first
+            resolved_from_cwd = (Path.cwd() / folder).resolve()
+
+            if resolved_from_cwd.exists():
+                folder = resolved_from_cwd
+            else:
+                # Try resolving from repo root (for paths like "courses/btc101")
+                resolved_from_repo = (self.base_path / folder).resolve()
+                if resolved_from_repo.exists():
+                    folder = resolved_from_repo
+                else:
+                    # Last try: strip leading "../" and try from repo root
+                    # This handles cases like "../courses/btc101" when user is deep in the repo
+                    clean_path = str(folder)
+                    while clean_path.startswith("../") or clean_path.startswith("..\\"):
+                        clean_path = clean_path[3:]
+                    resolved_clean = (self.base_path / clean_path).resolve()
+                    if resolved_clean.exists():
+                        folder = resolved_clean
+                    else:
+                        folder = resolved_from_cwd  # Use original for error message
+        else:
+            folder = folder.resolve()
+
+        if not folder.exists():
+            result = ValidationResult(file_path=str(folder))
+            result.add_error(f"Folder does not exist. Try using absolute path or run from repo root.")
+            return [result]
+
+        if not folder.is_dir():
+            result = ValidationResult(file_path=str(folder))
+            result.add_error("Path is not a directory")
+            return [result]
+
+        # Detect content type
+        config = self.detect_content_type(folder)
+        if not config:
+            result = ValidationResult(file_path=str(folder))
+            result.add_error(f"Could not detect content type for folder. Supported types: {list(CONTENT_TYPES.keys())}")
+            return [result]
+
+        results = []
+
+        # Find and validate main YAML file
+        yaml_path = folder / config.yaml_file
+        if not yaml_path.exists():
+            result = ValidationResult(file_path=str(yaml_path))
+            result.add_warning(f"Missing metadata file: {config.yaml_file} (empty folder?)")
+            results.append(result)
+            return results
+        else:
+            schema_path = self.find_schema_file(config)
+            if schema_path:
+                schema = self.load_json_schema(schema_path)
+                yaml_data = self.load_yaml_file(yaml_path)
+                result = self.validate_yaml_against_schema(yaml_data, schema, str(yaml_path))
+                results.append(result)
+            else:
+                result = ValidationResult(file_path=str(yaml_path))
+                result.add_warning(f"Schema file '{config.schema_file}' not found - skipping validation")
+                results.append(result)
+
+        # Validate content files if applicable
+        if config.has_markdown_content:
+            content_schema_path = self.find_content_schema_file(config)
+            content_schema = self.load_json_schema(content_schema_path) if content_schema_path else None
+
+            if config.content_uses_yml:
+                # Validate .yml content files (books, bet, projects)
+                for yml_file in folder.glob("*.yml"):
+                    if yml_file.name != config.yaml_file:  # Skip main metadata file
+                        if content_schema:
+                            result = self.validate_yml_content(yml_file, content_schema)
+                        else:
+                            result = ValidationResult(file_path=str(yml_file))
+                            result.add_warning("Content schema not found - skipping validation")
+                        results.append(result)
+            else:
+                # Validate .md content files
+                # Skip presentation.md as it has no frontmatter requirements
+                for md_file in folder.glob("*.md"):
+                    if md_file.name == "presentation.md":
+                        continue  # Skip presentation files - they don't have frontmatter
+                    if content_schema:
+                        result = self.validate_markdown_content(md_file, content_schema)
+                    else:
+                        result = ValidationResult(file_path=str(md_file))
+                        result.add_warning("Content schema not found - skipping validation")
+                    results.append(result)
+
+        # Validate quizzes if applicable
+        if config.has_quizzes:
+            quiz_results = self.validate_quizzes(folder)
+            results.extend(quiz_results)
+
+        return results
+
+    def print_results(self, results: list[ValidationResult]):
+        """Print validation results in a formatted way."""
+        total_errors = sum(len(r.errors) for r in results)
+        total_warnings = sum(len(r.warnings) for r in results)
+
+        print(f"\n{Colors.BOLD}{'='*60}{Colors.END}")
+        print(f"{Colors.BOLD}Validation Results{Colors.END}")
+        print(f"{'='*60}\n")
+
+        for result in results:
+            rel_path = result.file_path
+            # Try to make path relative to repo root for cleaner output
+            file_path = Path(result.file_path)
+            repo_root = self._find_repo_root(file_path.parent if file_path.is_file() else file_path)
+            try:
+                rel_path = str(file_path.relative_to(repo_root))
+            except ValueError:
+                try:
+                    rel_path = str(file_path.relative_to(self.base_path))
+                except ValueError:
+                    pass
+
+            if result.errors or result.warnings:
+                status = f"{Colors.RED}FAILED{Colors.END}" if result.errors else f"{Colors.YELLOW}WARNINGS{Colors.END}"
+                print(f"{Colors.CYAN}{rel_path}{Colors.END} - {status}")
+
+                for error in result.errors:
+                    print(f"  {Colors.RED}ERROR:{Colors.END} {error}")
+
+                for warning in result.warnings:
+                    print(f"  {Colors.YELLOW}WARNING:{Colors.END} {warning}")
+
+                print()
+            else:
+                print(f"{Colors.CYAN}{rel_path}{Colors.END} - {Colors.GREEN}PASSED{Colors.END}")
+
+        print(f"\n{'='*60}")
+        if total_errors == 0:
+            print(f"{Colors.GREEN}{Colors.BOLD}All validations passed!{Colors.END}")
+        else:
+            print(f"{Colors.RED}{Colors.BOLD}Validation failed:{Colors.END} {total_errors} error(s), {total_warnings} warning(s)")
+        print(f"{'='*60}\n")
+
+        return total_errors == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate PlanB Network content against JSON schemas",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python validate.py tutorials/wallet/sparrow-wallet
+  python validate.py courses/btc101
+  python validate.py professors/pbn-author
+  python validate.py resources/bet/a-game-on-bitcoin
+  python validate.py events/awesome-workshop-YYYY
+
+Supported content types:
+  - tutorials/<category>/<tutorial-name>
+  - courses/<course-name>
+  - professors/<professor-name>
+  - events/<event-name>
+  - resources/bet/<bet-name>
+  - resources/books/<book-name>
+  - resources/channels/<channel-name>
+  - resources/conferences/<conference-name>
+  - resources/glossary/<word-name>
+  - resources/movies/<movie-name>
+  - resources/newsletters/<newsletter-name>
+  - resources/podcasts/<podcast-name>
+  - resources/projects/<project-name>
+        """
+    )
+
+    parser.add_argument(
+        "folder",
+        help="Path to the content folder to validate (relative to repo root or absolute)"
+    )
+
+    parser.add_argument(
+        "--base-path",
+        default=None,
+        help="Base path of the repository (auto-detected if not specified)"
+    )
+
+    parser.add_argument(
+        "--json", "-j",
+        action="store_true",
+        help="Output results as JSON"
+    )
+
+    args = parser.parse_args()
+
+    # Resolve the folder path first to help with repo root detection
+    folder_path = Path(args.folder)
+    if not folder_path.is_absolute():
+        folder_path = Path.cwd() / folder_path
+    folder_path = folder_path.resolve()
+
+    # Auto-detect repo root from folder path or base-path
+    def find_repo_root(start_path: Path) -> Path:
+        """Find repo root by looking for .git directory (primary) or known directories (fallback)."""
+        current = start_path
+        # First pass: look for .git (most reliable)
+        for _ in range(15):  # Max 15 levels up
+            if (current / ".git").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+
+        # Second pass: fallback to known directory structure (but require .git to not be deeper)
+        current = start_path
+        for _ in range(15):
+            # Check for known directories AND verify this isn't inside a docs/template folder
+            if all((current / d).exists() for d in ["courses", "tutorials", "professors"]):
+                # Make sure we're not in a template/docs subfolder
+                if "docs" not in current.parts[-3:] and "PBN-template-repo" not in current.parts:
+                    return current
+            if current.parent == current:
+                break
+            current = current.parent
+        return start_path
+
+    if args.base_path:
+        base_path = Path(args.base_path).resolve()
+    else:
+        base_path = find_repo_root(folder_path)
+
+    validator = SchemaValidator(str(base_path))
+    results = validator.validate_folder(args.folder)
+
+    if args.json:
+        output = {
+            "folder": args.folder,
+            "results": [
+                {
+                    "file": r.file_path,
+                    "valid": r.is_valid,
+                    "errors": r.errors,
+                    "warnings": r.warnings
+                }
+                for r in results
+            ],
+            "total_errors": sum(len(r.errors) for r in results),
+            "total_warnings": sum(len(r.warnings) for r in results),
+        }
+        print(json.dumps(output, indent=2))
+        total_errors = output["total_errors"]
+        total_warnings = output["total_warnings"]
+    else:
+        validator.print_results(results)
+        total_errors = sum(len(r.errors) for r in results)
+        total_warnings = sum(len(r.warnings) for r in results)
+
+    # Exit codes: 0 = passed, 1 = errors, 2 = warnings only
+    if total_errors > 0:
+        sys.exit(1)
+    elif total_warnings > 0:
+        sys.exit(2)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validation-format/validate_all.py
+++ b/scripts/validation-format/validate_all.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+PlanB Network Bulk Content Validator
+
+Validates all content folders in the repository against their respective schemas.
+Uses validate.py to validate each folder individually.
+
+Usage:
+    python validate_all.py                    # Validate all content
+    python validate_all.py --courses-only     # Validate only courses
+    python validate_all.py --tutorials-only   # Validate only tutorials
+    python validate_all.py --resources-only   # Validate only resources
+    python validate_all.py --json             # Output as JSON
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# ANSI color codes for terminal output
+class Colors:
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    BLUE = "\033[94m"
+    CYAN = "\033[96m"
+    MAGENTA = "\033[95m"
+    BOLD = "\033[1m"
+    END = "\033[0m"
+
+
+@dataclass
+class ContentFolderResult:
+    """Holds validation results for a single content folder."""
+    folder: str
+    content_type: str
+    total_errors: int = 0
+    total_warnings: int = 0
+    file_results: list = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return self.total_errors == 0
+
+
+# Content types and their root directories
+CONTENT_TYPE_ROOTS = {
+    "courses": "courses",
+    "tutorials": "tutorials",
+    "professors": "professors",
+    "events": "events",
+    "resources/bet": "resources/bet",
+    "resources/books": "resources/books",
+    "resources/channels": "resources/channels",
+    "resources/conferences": "resources/conferences",
+    "resources/glossary": "resources/glossary",
+    "resources/movies": "resources/movies",
+    "resources/newsletters": "resources/newsletters",
+    "resources/papers": "resources/papers",
+    "resources/podcasts": "resources/podcasts",
+    "resources/projects": "resources/projects",
+}
+
+
+def find_repo_root() -> Path:
+    """Find the repository root by looking for .git directory."""
+    current = Path(__file__).resolve().parent
+    for _ in range(10):
+        if (current / ".git").exists():
+            return current
+        if current.parent == current:
+            break
+        current = current.parent
+
+    # Fallback: assume we're in scripts/validation-format/
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def get_content_folders(repo_root: Path, content_type: str) -> list[Path]:
+    """Get all content folders for a given content type."""
+    root_path = repo_root / content_type
+
+    if not root_path.exists():
+        return []
+
+    folders = []
+
+    # Special handling for tutorials (has category subfolders)
+    if content_type == "tutorials":
+        for category in root_path.iterdir():
+            if category.is_dir() and not category.name.startswith('.'):
+                for tutorial in category.iterdir():
+                    if tutorial.is_dir() and not tutorial.name.startswith('.'):
+                        # Check if it has a tutorial.yml file
+                        if (tutorial / "tutorial.yml").exists():
+                            folders.append(tutorial)
+    else:
+        # Direct content folders (courses, professors, etc.)
+        for item in root_path.iterdir():
+            if item.is_dir() and not item.name.startswith('.'):
+                folders.append(item)
+
+    return sorted(folders)
+
+
+def validate_folder(repo_root: Path, folder: Path, json_output: bool = True) -> dict:
+    """Run validate.py on a single folder and return the result."""
+    validate_script = repo_root / "scripts" / "validation-format" / "validate.py"
+
+    # Calculate relative path from repo root
+    try:
+        rel_path = folder.relative_to(repo_root)
+    except ValueError:
+        rel_path = folder
+
+    cmd = [sys.executable, str(validate_script), str(rel_path), "--json"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        # Parse JSON output
+        if result.stdout:
+            try:
+                return json.loads(result.stdout)
+            except json.JSONDecodeError:
+                return {
+                    "folder": str(rel_path),
+                    "results": [],
+                    "total_errors": 1,
+                    "total_warnings": 0,
+                    "error": f"Failed to parse validator output: {result.stdout[:200]}"
+                }
+        else:
+            return {
+                "folder": str(rel_path),
+                "results": [],
+                "total_errors": 1,
+                "total_warnings": 0,
+                "error": f"No output from validator. stderr: {result.stderr[:200] if result.stderr else 'none'}"
+            }
+    except subprocess.TimeoutExpired:
+        return {
+            "folder": str(rel_path),
+            "results": [],
+            "total_errors": 1,
+            "total_warnings": 0,
+            "error": "Validation timed out"
+        }
+    except Exception as e:
+        return {
+            "folder": str(rel_path),
+            "results": [],
+            "total_errors": 1,
+            "total_warnings": 0,
+            "error": str(e)
+        }
+
+
+def print_progress(current: int, total: int, folder: str, result: dict, width: int = 50):
+    """Print progress bar and current folder status."""
+    percent = current / total
+    filled = int(width * percent)
+    bar = "█" * filled + "░" * (width - filled)
+
+    status = ""
+    if result["total_errors"] > 0:
+        status = f"{Colors.RED}✗{Colors.END}"
+    elif result["total_warnings"] > 0:
+        status = f"{Colors.YELLOW}!{Colors.END}"
+    else:
+        status = f"{Colors.GREEN}✓{Colors.END}"
+
+    # Clear line and print progress
+    print(f"\r{Colors.CYAN}[{bar}]{Colors.END} {current}/{total} {status} {folder[:60]:<60}", end="", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate all PlanB Network content against JSON schemas",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python validate_all.py                    # Validate everything
+  python validate_all.py --courses-only     # Validate only courses
+  python validate_all.py --tutorials-only   # Validate only tutorials
+  python validate_all.py --resources-only   # Validate all resource types
+  python validate_all.py --json             # Output as JSON
+  python validate_all.py --summary-only     # Show only summary, not individual errors
+        """
+    )
+
+    # Filter options
+    parser.add_argument(
+        "--courses-only",
+        action="store_true",
+        help="Validate only courses"
+    )
+    parser.add_argument(
+        "--tutorials-only",
+        action="store_true",
+        help="Validate only tutorials"
+    )
+    parser.add_argument(
+        "--professors-only",
+        action="store_true",
+        help="Validate only professors"
+    )
+    parser.add_argument(
+        "--events-only",
+        action="store_true",
+        help="Validate only events"
+    )
+    parser.add_argument(
+        "--resources-only",
+        action="store_true",
+        help="Validate only resources (all resource types)"
+    )
+    parser.add_argument(
+        "--type",
+        type=str,
+        help="Validate specific content type (e.g., 'resources/papers', 'tutorials')"
+    )
+
+    # Output options
+    parser.add_argument(
+        "--json", "-j",
+        action="store_true",
+        help="Output results as JSON"
+    )
+    parser.add_argument(
+        "--summary-only", "-s",
+        action="store_true",
+        help="Show only summary statistics, not individual errors"
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Show all results including passed validations"
+    )
+
+    args = parser.parse_args()
+
+    repo_root = find_repo_root()
+
+    # Determine which content types to validate
+    content_types_to_validate = []
+
+    if args.type:
+        if args.type in CONTENT_TYPE_ROOTS:
+            content_types_to_validate = [args.type]
+        else:
+            print(f"{Colors.RED}Error:{Colors.END} Unknown content type '{args.type}'")
+            print(f"Available types: {', '.join(CONTENT_TYPE_ROOTS.keys())}")
+            sys.exit(1)
+    elif args.courses_only:
+        content_types_to_validate = ["courses"]
+    elif args.tutorials_only:
+        content_types_to_validate = ["tutorials"]
+    elif args.professors_only:
+        content_types_to_validate = ["professors"]
+    elif args.events_only:
+        content_types_to_validate = ["events"]
+    elif args.resources_only:
+        content_types_to_validate = [t for t in CONTENT_TYPE_ROOTS if t.startswith("resources/")]
+    else:
+        content_types_to_validate = list(CONTENT_TYPE_ROOTS.keys())
+
+    # Collect all folders to validate
+    all_folders = []
+    for content_type in content_types_to_validate:
+        folders = get_content_folders(repo_root, content_type)
+        for folder in folders:
+            all_folders.append((content_type, folder))
+
+    if not all_folders:
+        if args.json:
+            print(json.dumps({"error": "No content folders found to validate", "results": []}))
+        else:
+            print(f"{Colors.YELLOW}No content folders found to validate.{Colors.END}")
+        sys.exit(0)
+
+    # Validate all folders
+    all_results = []
+    total_errors = 0
+    total_warnings = 0
+    passed_count = 0
+    failed_count = 0
+    warning_count = 0
+
+    if not args.json:
+        print(f"\n{Colors.BOLD}Validating {len(all_folders)} content folders...{Colors.END}\n")
+
+    for i, (content_type, folder) in enumerate(all_folders, 1):
+        result = validate_folder(repo_root, folder)
+        result["content_type"] = content_type
+        all_results.append(result)
+
+        total_errors += result.get("total_errors", 0)
+        total_warnings += result.get("total_warnings", 0)
+
+        if result.get("total_errors", 0) > 0:
+            failed_count += 1
+        elif result.get("total_warnings", 0) > 0:
+            warning_count += 1
+        else:
+            passed_count += 1
+
+        if not args.json:
+            print_progress(i, len(all_folders), result["folder"], result)
+
+    if not args.json:
+        print()  # New line after progress bar
+
+    # Output results
+    if args.json:
+        output = {
+            "summary": {
+                "total_folders": len(all_folders),
+                "passed": passed_count,
+                "failed": failed_count,
+                "warnings_only": warning_count,
+                "total_errors": total_errors,
+                "total_warnings": total_warnings,
+            },
+            "results": all_results
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        # Print detailed results (errors and warnings)
+        if not args.summary_only:
+            print(f"\n{Colors.BOLD}{'='*70}{Colors.END}")
+            print(f"{Colors.BOLD}Validation Details{Colors.END}")
+            print(f"{'='*70}\n")
+
+            # Group results by content type
+            by_type: dict[str, list] = {}
+            for result in all_results:
+                ct = result.get("content_type", "unknown")
+                if ct not in by_type:
+                    by_type[ct] = []
+                by_type[ct].append(result)
+
+            for content_type in sorted(by_type.keys()):
+                results = by_type[content_type]
+
+                # Check if there are any errors or warnings in this type
+                has_issues = any(
+                    r.get("total_errors", 0) > 0 or r.get("total_warnings", 0) > 0
+                    for r in results
+                )
+
+                if has_issues or args.verbose:
+                    print(f"\n{Colors.MAGENTA}{Colors.BOLD}[{content_type}]{Colors.END}")
+
+                    for result in results:
+                        errors = result.get("total_errors", 0)
+                        warnings = result.get("total_warnings", 0)
+
+                        if errors > 0:
+                            print(f"  {Colors.RED}✗{Colors.END} {result['folder']} - {errors} error(s), {warnings} warning(s)")
+                            if not args.summary_only:
+                                for file_result in result.get("results", []):
+                                    for error in file_result.get("errors", []):
+                                        print(f"      {Colors.RED}ERROR:{Colors.END} {error}")
+                                    for warning in file_result.get("warnings", []):
+                                        print(f"      {Colors.YELLOW}WARNING:{Colors.END} {warning}")
+                        elif warnings > 0:
+                            print(f"  {Colors.YELLOW}!{Colors.END} {result['folder']} - {warnings} warning(s)")
+                            if not args.summary_only:
+                                for file_result in result.get("results", []):
+                                    for warning in file_result.get("warnings", []):
+                                        print(f"      {Colors.YELLOW}WARNING:{Colors.END} {warning}")
+                        elif args.verbose:
+                            print(f"  {Colors.GREEN}✓{Colors.END} {result['folder']}")
+
+        # Print summary
+        print(f"\n{Colors.BOLD}{'='*70}{Colors.END}")
+        print(f"{Colors.BOLD}Summary{Colors.END}")
+        print(f"{'='*70}\n")
+
+        print(f"  Total folders validated: {len(all_folders)}")
+        print(f"  {Colors.GREEN}Passed:{Colors.END}         {passed_count}")
+        print(f"  {Colors.YELLOW}Warnings only:{Colors.END}  {warning_count}")
+        print(f"  {Colors.RED}Failed:{Colors.END}         {failed_count}")
+        print()
+        print(f"  Total errors:   {total_errors}")
+        print(f"  Total warnings: {total_warnings}")
+
+        print(f"\n{'='*70}")
+        if total_errors == 0:
+            if total_warnings == 0:
+                print(f"{Colors.GREEN}{Colors.BOLD}All validations passed!{Colors.END}")
+            else:
+                print(f"{Colors.YELLOW}{Colors.BOLD}Validation passed with {total_warnings} warning(s){Colors.END}")
+        else:
+            print(f"{Colors.RED}{Colors.BOLD}Validation failed: {total_errors} error(s) in {failed_count} folder(s){Colors.END}")
+        print(f"{'='*70}\n")
+
+    # Exit codes: 0 = passed, 1 = errors, 2 = warnings only
+    if total_errors > 0:
+        sys.exit(1)
+    elif total_warnings > 0:
+        sys.exit(2)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Extracted from #4202 which had accumulated **81 merge conflicts** due to 2 months of content drift on dev.

This PR contains **only the scripts and JSON schemas** — the valuable, conflict-free part of the original PR. Content format fixes (quizzes, tutorials, etc.) are intentionally excluded and should be regenerated by running the validators against current dev.

## What's included (29 files)

- `scripts/validation-format/` — Python validators + JSON schemas for all content types (courses, tutorials, quizzes, resources, professors, events)
- Updated `docs/PBN-template-repo/` tutorial scheme and example

## What's excluded

- ~850 auto-fixed content files (quiz YMLs, markdown frontmatter, etc.) — these should be regenerated fresh
- The `lnp206` UUID fix from the original PR (can be done separately)

## Supersedes

Closes #4202