### PR TITLE
fix: rename licence to license in project schema

### DIFF
--- a/scripts/validation-format/schemas/project-scheme.json
+++ b/scripts/validation-format/schemas/project-scheme.json
@@ -34,7 +34,7 @@
       ],
       "description": "Define project category. Only specific categories are allowed."
     },
-    "licence": {
+    "license": {
       "type": "string",
       "description": "License type for the project content (e.g., CC-BY-SA-V4)."
     },


### PR DESCRIPTION
## Summary
- Fixes typo in project-scheme.json: `licence` → `license` (standard English spelling)