### PR TITLE
[PROJECT] Add Bitcoin.diy

### DIFF
--- a/resources/projects/bitcoin-diy/en.yml
+++ b/resources/projects/bitcoin-diy/en.yml
@@ -1,0 +1,10 @@
+description: |
+  Bitcoin.diy is a Bitcoin-only education and review platform run by a solo founder with 20 years in IT and five years in Bitcoin. It covers self-custody setup, hardware wallet comparisons (Coldcard Mk4, Trezor Safe 5, Ledger Flex), exchange reviews, and beginner-to-intermediate guides. No altcoins. No noise. Written the way a knowledgeable friend explains it, not a finance blog dressing it up.
+# Proofreading metadata
+proofreading:
+  - language: en
+    last_contribution_date: 2026-04-17
+    urgency: 1
+    contributor_names:
+      - MrBitcoinDIY
+    reward: 0

--- a/resources/projects/bitcoin-diy/project.yml
+++ b/resources/projects/bitcoin-diy/project.yml
@@ -1,0 +1,12 @@
+id: 6cbf8cd0-d4d1-48f3-a7be-6edb505eabf3
+name: Bitcoin.diy
+links:
+  website: https://bitcoin.diy
+category: education
+contributor_names:
+  - MrBitcoinDIY
+tags:
+  - education
+  - self-custody
+  - hardware-wallet
+original_language: en


### PR DESCRIPTION
Bitcoin.diy is a Bitcoin-only education and review site focused on self-custody for beginners and intermediate users. The site covers hardware wallet reviews (Coldcard Mk4, Trezor Safe 5, Ledger), a self-custody setup guide, and exchange comparisons. Bitcoin-only by conviction — no altcoin content. Fits the education/projects category. Happy to adjust tags or description to match conventions.