### PR TITLE
chore: ignore translation report artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ scripts/auto-translate/translation_logic/argon-edge-450706-b7-d2831a252186.json
 # /teach generated lesson workspaces (ephemeral, never committed)
 .teach/
 .translation-lessons
+.translation-report.json
 scripts/agent-translate/knowledge


### PR DESCRIPTION
## Summary
- ignore the local `.translation-report.json` verification artifact

`knowledge/` and `.translation-lessons/` are already ignored in `dev`; `usage.py` is already current on `dev`.